### PR TITLE
🐛  Fix problem where AppcuesActivity would keep showing when its supposed to finish

### DIFF
--- a/appcues/src/main/java/com/appcues/monitor/ActivityExt.kt
+++ b/appcues/src/main/java/com/appcues/monitor/ActivityExt.kt
@@ -1,0 +1,23 @@
+package com.appcues.monitor
+
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+
+internal fun Activity.intentActionFinish(): String {
+    return componentName.className + ".ACTION.FINISH"
+}
+
+internal fun Activity.sendLocalBroadcast(intent: Intent) {
+    LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
+}
+
+internal fun Activity.registerLocalReceiver(broadcastReceiver: BroadcastReceiver, intentFilter: IntentFilter) {
+    LocalBroadcastManager.getInstance(this).registerReceiver(broadcastReceiver, intentFilter)
+}
+
+internal fun Activity.unregisterLocalReceiver(broadcastReceiver: BroadcastReceiver) {
+    LocalBroadcastManager.getInstance(this).unregisterReceiver(broadcastReceiver)
+}

--- a/appcues/src/main/java/com/appcues/monitor/CustomerActivityMonitor.kt
+++ b/appcues/src/main/java/com/appcues/monitor/CustomerActivityMonitor.kt
@@ -2,6 +2,7 @@ package com.appcues.monitor
 
 import android.app.Activity
 import android.app.Application
+import android.content.Intent
 import android.os.Bundle
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
@@ -75,6 +76,6 @@ internal class CustomerActivityMonitor(
     }
 
     override fun onActivityDestroyed(activity: Activity) {
-        // do nothing
+        activity.sendLocalBroadcast(Intent(activity.intentActionFinish()))
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -1,7 +1,10 @@
 package com.appcues.ui
 
+import android.app.Activity
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
@@ -13,6 +16,9 @@ import androidx.core.os.bundleOf
 import com.appcues.R
 import com.appcues.di.AppcuesKoinComponent
 import com.appcues.domain.entity.Experience
+import com.appcues.monitor.intentActionFinish
+import com.appcues.monitor.registerLocalReceiver
+import com.appcues.monitor.unregisterLocalReceiver
 import com.appcues.ui.extensions.Compose
 import com.appcues.ui.theme.AppcuesTheme
 import com.appcues.ui.trait.DialogTrait
@@ -25,13 +31,15 @@ internal class AppcuesActivity : AppCompatActivity(), AppcuesKoinComponent {
 
         private const val EXTRA_SCOPE_ID = "EXTRA_SCOPE_ID"
         private const val EXTRA_EXPERIENCE = "EXTRA_EXPERIENCE"
+        private const val EXTRA_PARENT_INTENT_ACTION_FINISH = "EXTRA_PARENT_INTENT_ACTION_FINISH"
 
-        fun getIntent(context: Context, scopeId: String, experience: Experience): Intent =
-            Intent(context, AppcuesActivity::class.java).apply {
+        fun getIntent(parent: Activity, scopeId: String, experience: Experience): Intent =
+            Intent(parent, AppcuesActivity::class.java).apply {
                 putExtras(
                     bundleOf(
                         EXTRA_SCOPE_ID to scopeId,
-                        EXTRA_EXPERIENCE to experience
+                        EXTRA_EXPERIENCE to experience,
+                        EXTRA_PARENT_INTENT_ACTION_FINISH to parent.intentActionFinish(),
                     )
                 )
             }
@@ -41,10 +49,15 @@ internal class AppcuesActivity : AppCompatActivity(), AppcuesKoinComponent {
 
     private val experience: Experience by lazy { intent.getParcelableExtra(EXTRA_EXPERIENCE)!! }
 
+    private val parentIntentActionFinish: String by lazy { intent.getStringExtra(EXTRA_PARENT_INTENT_ACTION_FINISH)!! }
+
     private val viewModel: AppcuesViewModel by viewModel { parametersOf(experience) }
+
+    private val broadcastReceiver = AppcuesBroadcastReceiver()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        registerLocalReceiver(broadcastReceiver, IntentFilter(parentIntentActionFinish))
         setContent {
             AppcuesTheme {
                 CompositionLocalProvider(LocalAppcuesActions provides AppcuesActions { finishAnimated() }) {
@@ -54,6 +67,18 @@ internal class AppcuesActivity : AppCompatActivity(), AppcuesKoinComponent {
                     }
                 }
             }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        unregisterLocalReceiver(broadcastReceiver)
+    }
+
+    inner class AppcuesBroadcastReceiver : BroadcastReceiver() {
+
+        override fun onReceive(context: Context?, intent: Intent?) {
+            finishAnimated()
         }
     }
 


### PR DESCRIPTION
This MR mitigates the problem we found where the AppcuesActivity would keep showing even after customer activity was set to finish.

Every activity will send a internal broadcast with Action like: Intent { package.com.ActivityName.ACTION.FINISH } when they invoke onDestroy step, our AppcuesActivity will listen for the specific parent's ActivityName Intent and finish accordingly.
 
The intent that we send to make this communication work is done via LocalBroadCastManager which means only our APP will see this, which is safer and better in general.

This solution is fine by me but if we feel like its not. Then I'm afraid we are out of options with activities and we should move to another solution (possibly adding a FrameLayout to attach a fragment and deal with other problems like configuration changes, etc).