### PR TITLE
♻️  Replace Glide for Coil as ImageLoader for ImageComponent

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.4.0'
     implementation "com.google.android.material:material:1.4.0"
 
-    implementation "com.github.skydoves:landscapist-glide:1.4.5"
+    implementation "io.coil-kt:coil-compose:1.4.0"
 
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-gson:2.9.0"

--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/ImageMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/ImageMapper.kt
@@ -23,7 +23,7 @@ internal class ImageMapper(
             ImageComponent(
                 id = id,
                 url = imageUrl,
-                size = sizeMapper.map(intrinsicSize),
+                intrinsicSize = sizeMapper.map(intrinsicSize),
                 backgroundColor = style.getBackgroundColor(),
                 style = styleMapper.map(style)
             )

--- a/appcues/src/main/java/com/appcues/data/remote/ExperienceModalOne.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/ExperienceModalOne.kt
@@ -46,8 +46,9 @@ internal fun experienceModalOneContent() = VerticalStackComponent(
                 ImageComponent(
                     id = UUID.randomUUID(),
                     url = "https://res.cloudinary.com/dnjrorsut/image/upload/v1635971825/98227/oh5drlvojb1spaetc1ol.jpg",
-                    size = ComponentSize(width = 1920, height = 1280),
-                    backgroundColor = ComponentColor(light = 0xFF8F8F8F, dark = 0xFF8F8F8F)
+                    intrinsicSize = ComponentSize(width = 1920, height = 1280),
+                    backgroundColor = ComponentColor(light = 0xFF8F8F8F, dark = 0xFF8F8F8F),
+                    style = ComponentStyle()
                 )
             )
         ),

--- a/appcues/src/main/java/com/appcues/domain/entity/ExperienceComponent.kt
+++ b/appcues/src/main/java/com/appcues/domain/entity/ExperienceComponent.kt
@@ -39,9 +39,9 @@ internal sealed class ExperienceComponent(open val id: UUID) : Parcelable {
     data class ImageComponent(
         override val id: UUID,
         val url: String,
-        val size: ComponentSize,
+        val style: ComponentStyle,
+        val intrinsicSize: ComponentSize?,
         val backgroundColor: ComponentColor?,
-        val style: ComponentStyle = ComponentStyle(),
     ) : ExperienceComponent(id)
 
     @Parcelize

--- a/appcues/src/main/java/com/appcues/ui/ExperienceModalOne.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceModalOne.kt
@@ -28,8 +28,9 @@ internal val experienceModalOne = VerticalStackComponent(
                 ImageComponent(
                     id = UUID.randomUUID(),
                     url = "https://res.cloudinary.com/dnjrorsut/image/upload/v1635971825/98227/oh5drlvojb1spaetc1ol.jpg",
-                    size = ComponentSize(width = 1920, height = 1280),
-                    backgroundColor = ComponentColor(light = 0xFF8F8F8F, dark = 0xFF8F8F8F)
+                    intrinsicSize = ComponentSize(width = 1920, height = 1280),
+                    backgroundColor = ComponentColor(light = 0xFF8F8F8F, dark = 0xFF8F8F8F),
+                    style = ComponentStyle()
                 )
             )
         ),

--- a/appcues/src/test/java/com/appcues/data/mapper/step/StepContentMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/StepContentMapperTest.kt
@@ -220,8 +220,8 @@ class StepContentMapperTest {
         with(result as ImageComponent) {
             assertThat(id).isEqualTo(randomId)
             assertThat(url).isEqualTo(imageUrl)
-            assertThat(size.width).isEqualTo(1920)
-            assertThat(size.height).isEqualTo(1280)
+            assertThat(intrinsicSize?.width).isEqualTo(1920)
+            assertThat(intrinsicSize?.height).isEqualTo(1280)
             assertThat(backgroundColor).isNotNull()
             assertThat(backgroundColor?.light).isEqualTo(0xFF000000)
         }


### PR DESCRIPTION
Per conversation with Scott, it would be recommended to replace Glide for Coil, this MR is all about that.

There is the replacing of the library, the implementation takes into account the possibility of ImageComponent Intrinsic Size being null, which will fall back to a default aspect ratio of 1.5 until the image is loaded from the web. (we need to talk about default values not only for this but for many other properties that are not required on our data schema)