### PR TITLE
Fix ci cache in Validation / Test Pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,18 +28,16 @@ jobs:
       JVM_OPTS: -Xmx3200m
     steps:
       - checkout
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      - android/restore-gradle-cache
+      - android/restore-build-cache
       - run:
          name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
          command: sudo chmod +x ./gradlew
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      - android/save-gradle-cache
+      - android/save-build-cache
       - run:
           name: Run Tests
           command: ./gradlew detekt test


### PR DESCRIPTION
using Android Orb Cache commands to Generate Keys, Restore and Save  Cache