### PR TITLE
Support init option to pass in the start Activity from the host application

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -1,5 +1,6 @@
 package com.appcues
 
+import android.app.Activity
 import android.content.Context
 import com.appcues.action.ExperienceAction
 import com.appcues.builder.ApiHostBuilderValidator
@@ -145,6 +146,12 @@ class Appcues internal constructor(
             }
         }
 
+        private var _activity: Activity? = null
+
+        fun activity(activity: Activity) = apply {
+            _activity = activity
+        }
+
         fun build(): Appcues {
             return with(AppcuesKoinContext) {
                 startKoinOnce(context)
@@ -154,7 +161,8 @@ class Appcues internal constructor(
                         accountId = accountId,
                         applicationId = applicationId,
                         loggingLevel = _loggingLevel,
-                        apiHostUrl = _apiHostUrl
+                        apiHostUrl = _apiHostUrl,
+                        activity = _activity
                     )
                 )
             }

--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -1,8 +1,11 @@
 package com.appcues
 
+import android.app.Activity
+
 internal data class AppcuesConfig(
     val accountId: String,
     val applicationId: String,
     val loggingLevel: Appcues.LoggingLevel,
     val apiHostUrl: String?,
+    val activity: Activity?,
 )

--- a/appcues/src/main/java/com/appcues/di/KoinExt.kt
+++ b/appcues/src/main/java/com/appcues/di/KoinExt.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import com.appcues.Appcues
 import com.appcues.AppcuesConfig
 import com.appcues.data.remote.di.AppcuesRemoteSourceModule
+import com.appcues.monitor.ActivityMonitor
 import org.koin.androidx.viewmodel.ViewModelOwnerDefinition
 import org.koin.androidx.viewmodel.scope.getViewModel
 import org.koin.core.component.get
@@ -36,8 +37,11 @@ internal fun AppcuesKoinContext.newAppcuesInstance(appcuesConfig: AppcuesConfig)
         )
     )
 
+    val activityMonitor: ActivityMonitor = getScope(scopeId).get()
+    activityMonitor.customerActivity = appcuesConfig.activity
+
     return Appcues(
         logcues = getScope(scopeId).get(),
-        activityMonitor = getScope(scopeId).get(),
+        activityMonitor = activityMonitor,
     )
 }

--- a/appcues/src/main/java/com/appcues/monitor/ActivityMonitor.kt
+++ b/appcues/src/main/java/com/appcues/monitor/ActivityMonitor.kt
@@ -1,6 +1,8 @@
 package com.appcues.monitor
 
-internal interface ActivityMonitor {
+import android.app.Activity
 
+internal interface ActivityMonitor {
+    var customerActivity: Activity?
     fun getCustomerViewModel(): CustomerViewModel?
 }

--- a/appcues/src/main/java/com/appcues/monitor/CustomerActivityMonitor.kt
+++ b/appcues/src/main/java/com/appcues/monitor/CustomerActivityMonitor.kt
@@ -25,7 +25,7 @@ internal class CustomerActivityMonitor(
         getApplicationContext().registerActivityLifecycleCallbacks(this)
     }
 
-    private var customerActivity: Activity? = null
+    override var customerActivity: Activity? = null
 
     override suspend fun showExperience(experience: Experience) {
         withContext(Dispatchers.Main) {


### PR DESCRIPTION
@andretortolano  this is one possible workaround to the issue that came up with React Native - if the customer activity is started _before_ our SDK is initialized, we won't be able to get that first activity reference and start content on it, etc.

this makes it an optional Builder param for special integration types that might need to do so, like our react sdk wrapper