### PR TITLE
🐛  Fix when we start appcues from an activity the first activity was no the currentActivity

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:1.4.1"
     implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation "androidx.startup:startup-runtime:1.1.0"
 
     implementation "androidx.compose.ui:ui:1.0.5"
     implementation "androidx.compose.ui:ui-tooling:1.0.5"

--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.appcues">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -9,6 +10,17 @@
             android:name=".ui.AppcuesActivity"
             android:exported="false"
             android:theme="@style/Appcues.AppcuesActivityTheme" />
+
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+
+            <meta-data
+                android:name="com.appcues.AppcuesInitializer"
+                android:value="androidx.startup" />
+        </provider>
     </application>
 
 </manifest>

--- a/appcues/src/main/java/com/appcues/AppcuesInitializer.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesInitializer.kt
@@ -1,0 +1,17 @@
+package com.appcues
+
+import android.app.Application
+import android.content.Context
+import androidx.startup.Initializer
+import com.appcues.monitor.AppcuesActivityMonitor
+
+@Suppress("unused")
+internal class AppcuesInitializer : Initializer<AppcuesActivityMonitor> {
+
+    override fun create(context: Context): AppcuesActivityMonitor {
+        AppcuesActivityMonitor.initialize(context.applicationContext as Application)
+        return AppcuesActivityMonitor
+    }
+
+    override fun dependencies() = emptyList<Class<out Initializer<*>>>()
+}

--- a/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt
+++ b/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt
@@ -1,0 +1,50 @@
+package com.appcues.monitor
+
+import android.app.Activity
+import android.app.Application
+import android.content.Intent
+import android.os.Bundle
+import com.appcues.ui.AppcuesActivity
+import java.lang.ref.WeakReference
+
+internal object AppcuesActivityMonitor : Application.ActivityLifecycleCallbacks {
+
+    private var activityWeakReference: WeakReference<Activity>? = null
+
+    val activity: Activity?
+        get() = activityWeakReference?.get()
+
+    fun initialize(application: Application) {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (activity !is AppcuesActivity) {
+            this.activityWeakReference = WeakReference(activity)
+        }
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        // do nothing
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        // do nothing
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        // do nothing
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        // do nothing
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+        // do nothing
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        activity.sendLocalBroadcast(Intent(activity.intentActionFinish()))
+    }
+}

--- a/appcues/src/main/java/com/appcues/monitor/CustomerActivityMonitor.kt
+++ b/appcues/src/main/java/com/appcues/monitor/CustomerActivityMonitor.kt
@@ -1,14 +1,9 @@
 package com.appcues.monitor
 
-import android.app.Activity
-import android.app.Application
-import android.content.Intent
-import android.os.Bundle
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.appcues.R
 import com.appcues.di.AppcuesKoinComponent
-import com.appcues.di.getApplicationContext
 import com.appcues.di.getOwnedViewModel
 import com.appcues.domain.entity.Experience
 import com.appcues.domain.gateway.CustomerViewGateway
@@ -19,17 +14,11 @@ import org.koin.androidx.viewmodel.ViewModelOwner
 
 internal class CustomerActivityMonitor(
     override val scopeId: String,
-) : CustomerViewGateway, ActivityMonitor, Application.ActivityLifecycleCallbacks, AppcuesKoinComponent {
-
-    init {
-        getApplicationContext().registerActivityLifecycleCallbacks(this)
-    }
-
-    private var customerActivity: Activity? = null
+) : CustomerViewGateway, ActivityMonitor, AppcuesKoinComponent {
 
     override suspend fun showExperience(experience: Experience) {
         withContext(Dispatchers.Main) {
-            customerActivity?.let {
+            AppcuesActivityMonitor.activity?.let {
                 it.startActivity(AppcuesActivity.getIntent(it, scopeId, experience))
                 it.overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
             }
@@ -37,7 +26,7 @@ internal class CustomerActivityMonitor(
     }
 
     override fun getCustomerViewModel(): CustomerViewModel? {
-        return customerActivity?.let {
+        return AppcuesActivityMonitor.activity?.let {
             getOwnedViewModel(
                 owner = {
                     ViewModelOwner.from(
@@ -47,35 +36,5 @@ internal class CustomerActivityMonitor(
                 }
             )
         }
-    }
-
-    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        if (activity !is AppcuesActivity) {
-            this.customerActivity = activity
-        }
-    }
-
-    override fun onActivityStarted(activity: Activity) {
-        // do nothing
-    }
-
-    override fun onActivityResumed(activity: Activity) {
-        // do nothing
-    }
-
-    override fun onActivityPaused(activity: Activity) {
-        // do nothing
-    }
-
-    override fun onActivityStopped(activity: Activity) {
-        // do nothing
-    }
-
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
-        // do nothing
-    }
-
-    override fun onActivityDestroyed(activity: Activity) {
-        activity.sendLocalBroadcast(Intent(activity.intentActionFinish()))
     }
 }


### PR DESCRIPTION
With this change we are not forcing customers to only initialize our SDK during Application.onCreate(), giving more flexibility even for lazy initializations using DI if they want to.

this also solves the problem that we found related to React Native integration where we had to initialize the SDK after application onCreate.

![Screen Shot 2022-02-04 at 09 29 06](https://user-images.githubusercontent.com/5244805/152530057-5544c11f-810b-44ca-98cd-617734fe2fb8.png)

