### PR TITLE
Add a persistent storage class for core SDK state

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -5,5 +5,5 @@ internal data class AppcuesConfig(
     val applicationId: String,
     val loggingLevel: Appcues.LoggingLevel,
     val apiHostUrl: String?,
-    val anonymousIdFactory: () -> String
+    val anonymousIdFactory: (() -> String)?
 )

--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -19,15 +19,21 @@ internal object AppcuesKoin : KoinScopePlugin {
             )
         }
 
-        scoped { AppcuesSession() }
         scoped { Logcues(config.loggingLevel) }
         scoped { StateMachine() }
+
+        scoped {
+            Storage(
+                context = get(),
+                config = get()
+            )
+        }
 
         scoped {
             AnalyticsTracker(
                 config = config,
                 repository = get(),
-                session = get(),
+                storage = get(),
                 experienceRenderer = get()
             )
         }

--- a/appcues/src/main/java/com/appcues/AppcuesSession.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesSession.kt
@@ -1,9 +1,0 @@
-package com.appcues
-
-import java.util.UUID
-
-internal data class AppcuesSession(
-    var userId: String = UUID.randomUUID().toString(),
-    var groupId: String? = null,
-    var isAnonymous: Boolean = false,
-)

--- a/appcues/src/main/java/com/appcues/Storage.kt
+++ b/appcues/src/main/java/com/appcues/Storage.kt
@@ -1,0 +1,51 @@
+package com.appcues
+
+import android.content.Context
+import android.content.SharedPreferences
+import java.util.Date
+import java.util.UUID
+
+internal class Storage(
+    context: Context,
+    config: AppcuesConfig
+) {
+    private enum class Constants(val rawVal: String) {
+        DeviceId("appcues.deviceId"),
+        UserId("appcues.userId"),
+        GroupId("appcues.groupId"),
+        IsAnonymous("appcues.isAnonymous"),
+        LastContentShownAt("appcues.lastContentShownAt")
+    }
+
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences("com.appcues.storage.${config.applicationId}", Context.MODE_PRIVATE)
+
+    var deviceId: String
+        get() = sharedPreferences.getString(Constants.DeviceId.rawVal, null) ?: ""
+        set(value) = sharedPreferences.edit().putString(Constants.DeviceId.rawVal, value).apply()
+
+    var userId: String
+        get() = sharedPreferences.getString(Constants.UserId.rawVal, null) ?: ""
+        set(value) = sharedPreferences.edit().putString(Constants.UserId.rawVal, value).apply()
+
+    var groupId: String?
+        get() = sharedPreferences.getString(Constants.GroupId.rawVal, null)
+        set(value) = sharedPreferences.edit().putString(Constants.GroupId.rawVal, value).apply()
+
+    var isAnonymous: Boolean
+        get() = sharedPreferences.getBoolean(Constants.IsAnonymous.rawVal, true)
+        set(value) = sharedPreferences.edit().putBoolean(Constants.IsAnonymous.rawVal, value).apply()
+
+    var lastContentShownAt: Date?
+        get() = sharedPreferences.getLong(Constants.LastContentShownAt.rawVal, 0).run { if (this > 0) Date(this) else null }
+        set(value) = when (value) {
+            null -> sharedPreferences.edit().remove(Constants.LastContentShownAt.rawVal).apply()
+            else -> sharedPreferences.edit().putLong(Constants.LastContentShownAt.rawVal, value.time).apply()
+        }
+
+    init {
+        if (deviceId.isEmpty()) {
+            deviceId = UUID.randomUUID().toString()
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
@@ -1,7 +1,7 @@
 package com.appcues.analytics
 
 import com.appcues.AppcuesConfig
-import com.appcues.AppcuesSession
+import com.appcues.Storage
 import com.appcues.data.AppcuesRepository
 import com.appcues.data.remote.request.ActivityRequest
 import com.appcues.data.remote.request.EventRequest
@@ -10,13 +10,13 @@ import com.appcues.ui.ExperienceRenderer
 internal class AnalyticsTracker(
     private val config: AppcuesConfig,
     private val repository: AppcuesRepository,
-    private val session: AppcuesSession,
+    private val storage: Storage,
     private val experienceRenderer: ExperienceRenderer
 ) {
     suspend fun identify(properties: HashMap<String, Any>? = null) {
         val activity = ActivityRequest(
-            userId = session.userId,
-            groupId = session.groupId,
+            userId = storage.userId,
+            groupId = storage.groupId,
             accountId = config.accountId,
             profileUpdate = properties
         )
@@ -26,8 +26,8 @@ internal class AnalyticsTracker(
     suspend fun track(name: String, properties: HashMap<String, Any>? = null, sync: Boolean = true) {
         val activity = ActivityRequest(
             events = listOf(EventRequest(name = name, attributes = properties)),
-            userId = session.userId,
-            groupId = session.groupId,
+            userId = storage.userId,
+            groupId = storage.groupId,
             accountId = config.accountId
         )
         trackActivity(activity, sync)
@@ -44,8 +44,8 @@ internal class AnalyticsTracker(
 
     suspend fun group(properties: HashMap<String, Any>? = null) {
         val activity = ActivityRequest(
-            userId = session.userId,
-            groupId = session.groupId,
+            userId = storage.userId,
+            groupId = storage.groupId,
             accountId = config.accountId,
             groupUpdate = properties
         )
@@ -53,6 +53,10 @@ internal class AnalyticsTracker(
     }
 
     private suspend fun trackActivity(activity: ActivityRequest, sync: Boolean) {
+
+        // todo - will need to revisit with proper session handling, but this means no user identified
+        if (storage.userId.isEmpty()) return
+
         // this will respond with qualified experiences, if applicable
         val experiences = repository.trackActivity(activity, sync)
 

--- a/appcues/src/main/java/com/appcues/data/remote/DataRemoteKoin.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/DataRemoteKoin.kt
@@ -17,7 +17,7 @@ internal object DataRemoteKoin : KoinScopePlugin {
             RetrofitAppcuesRemoteSource(
                 appcuesService = getAppcuesService(config.apiHostUrl ?: BASE_URL),
                 accountId = config.accountId,
-                session = get(),
+                storage = get(),
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSource.kt
@@ -1,6 +1,6 @@
 package com.appcues.data.remote.retrofit
 
-import com.appcues.AppcuesSession
+import com.appcues.Storage
 import com.appcues.data.remote.AppcuesRemoteSource
 import com.appcues.data.remote.request.ActivityRequest
 import com.appcues.data.remote.response.ActivityResponse
@@ -9,14 +9,14 @@ import com.appcues.data.remote.response.experience.ExperienceResponse
 internal class RetrofitAppcuesRemoteSource(
     private val appcuesService: AppcuesService,
     private val accountId: String,
-    private val session: AppcuesSession,
+    private val storage: Storage
 ) : AppcuesRemoteSource {
 
     override suspend fun getContent(contentId: String): ExperienceResponse {
-        return appcuesService.content(accountId, session.userId, contentId)
+        return appcuesService.content(accountId, storage.userId, contentId)
     }
 
     override suspend fun postActivity(activity: ActivityRequest, sync: Boolean): ActivityResponse {
-        return appcuesService.activity(accountId, session.userId, if (sync) 1 else null, activity)
+        return appcuesService.activity(accountId, storage.userId, if (sync) 1 else null, activity)
     }
 }


### PR DESCRIPTION
Fairly simple shared prefs backed storage for user ID, group ID, anonymous state, device ID, last content date (will be used later in autoprops) -- allows this data to be persisted through app sessions and not require a new user identify on each cold launch.