### PR TITLE
Added TrackEventAction to allow tracking custom analytic events from an Experience

### DIFF
--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -1,10 +1,10 @@
 package com.appcues.action
 
 import com.appcues.AppcuesConfig
-import com.appcues.action.appcues.AppcuesCloseAction
-import com.appcues.action.appcues.AppcuesLinkAction
+import com.appcues.action.appcues.CloseAction
+import com.appcues.action.appcues.LinkAction
+import com.appcues.action.appcues.TrackEventAction
 import com.appcues.di.KoinScopePlugin
-import com.appcues.trait.appcues.AppcuesSkippableTrait
 import org.koin.dsl.ScopeDSL
 
 internal object ActionKoin : KoinScopePlugin {
@@ -18,23 +18,22 @@ internal object ActionKoin : KoinScopePlugin {
         }
 
         factory { params ->
-            AppcuesCloseAction(
+            CloseAction(
                 config = params.getOrNull(),
                 stateMachine = get(),
             )
         }
 
         factory { params ->
-            AppcuesLinkAction(
+            LinkAction(
                 config = params.getOrNull(),
                 context = get(),
             )
         }
 
         factory { params ->
-            AppcuesSkippableTrait(
-                config = params.getOrNull(),
-                stateMachine = get(),
+            TrackEventAction(
+                config = params.getOrNull()
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
@@ -1,7 +1,8 @@
 package com.appcues.action
 
-import com.appcues.action.appcues.AppcuesCloseAction
-import com.appcues.action.appcues.AppcuesLinkAction
+import com.appcues.action.appcues.CloseAction
+import com.appcues.action.appcues.LinkAction
+import com.appcues.action.appcues.TrackEventAction
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.logging.Logcues
 import org.koin.core.component.KoinScopeComponent
@@ -20,8 +21,9 @@ internal class ActionRegistry(
     private val actions: HashMap<String, ActionFactoryBlock> = hashMapOf()
 
     init {
-        register("@appcues/close") { get<AppcuesCloseAction> { parametersOf(it) } }
-        register("@appcues/link") { get<AppcuesLinkAction> { parametersOf(it) } }
+        register("@appcues/close") { get<CloseAction> { parametersOf(it) } }
+        register("@appcues/link") { get<LinkAction> { parametersOf(it) } }
+        register("@appcues/track") { get<TrackEventAction> { parametersOf(it) } }
     }
 
     operator fun get(key: String): ActionFactoryBlock? {

--- a/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
@@ -6,7 +6,7 @@ import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.StateMachine
 
-internal class AppcuesCloseAction(
+internal class CloseAction(
     override val config: AppcuesConfigMap,
     private val stateMachine: StateMachine
 ) : ExperienceAction {

--- a/appcues/src/main/java/com/appcues/action/appcues/LinkAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/LinkAction.kt
@@ -9,7 +9,7 @@ import com.appcues.action.ExperienceAction
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfigOrDefault
 
-internal class AppcuesLinkAction(
+internal class LinkAction(
     override val config: AppcuesConfigMap,
     private val context: Context,
 ) : ExperienceAction {

--- a/appcues/src/main/java/com/appcues/action/appcues/TrackEventAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/TrackEventAction.kt
@@ -1,0 +1,19 @@
+package com.appcues.action.appcues
+
+import com.appcues.Appcues
+import com.appcues.action.ExperienceAction
+import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.getConfigOrDefault
+
+internal class TrackEventAction(
+    override val config: AppcuesConfigMap,
+) : ExperienceAction {
+
+    private val eventName = config.getConfigOrDefault<String?>("eventName", null)
+
+    override suspend fun execute(appcues: Appcues) {
+        if (!eventName.isNullOrEmpty()) {
+            appcues.track(eventName)
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
@@ -2,8 +2,9 @@ package com.appcues.trait
 
 import com.appcues.AppcuesConfig
 import com.appcues.di.KoinScopePlugin
-import com.appcues.trait.appcues.AppcuesBackdropTrait
-import com.appcues.trait.appcues.AppcuesModalTrait
+import com.appcues.trait.appcues.BackdropTrait
+import com.appcues.trait.appcues.ModalTrait
+import com.appcues.trait.appcues.SkippableTrait
 import org.koin.dsl.ScopeDSL
 
 internal object TraitKoin : KoinScopePlugin {
@@ -17,17 +18,24 @@ internal object TraitKoin : KoinScopePlugin {
         }
 
         factory { params ->
-            AppcuesBackdropTrait(
+            BackdropTrait(
                 config = params.getOrNull(),
                 stateMachine = get(),
             )
         }
 
         factory { params ->
-            AppcuesModalTrait(
+            ModalTrait(
                 config = params.getOrNull(),
                 scope = get(),
                 context = get(),
+            )
+        }
+
+        factory { params ->
+            SkippableTrait(
+                config = params.getOrNull(),
+                stateMachine = get(),
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/trait/TraitRegistry.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitRegistry.kt
@@ -2,9 +2,9 @@ package com.appcues.trait
 
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.logging.Logcues
-import com.appcues.trait.appcues.AppcuesBackdropTrait
-import com.appcues.trait.appcues.AppcuesModalTrait
-import com.appcues.trait.appcues.AppcuesSkippableTrait
+import com.appcues.trait.appcues.BackdropTrait
+import com.appcues.trait.appcues.ModalTrait
+import com.appcues.trait.appcues.SkippableTrait
 import org.koin.core.component.KoinScopeComponent
 import org.koin.core.component.get
 import org.koin.core.parameter.parametersOf
@@ -21,9 +21,9 @@ internal class TraitRegistry(
     private val actions: HashMap<String, TraitFactoryBlock> = hashMapOf()
 
     init {
-        register("@appcues/backdrop") { get<AppcuesBackdropTrait> { parametersOf(it) } }
-        register("@appcues/modal") { get<AppcuesModalTrait> { parametersOf(it) } }
-        register("@appcues/skippable") { get<AppcuesSkippableTrait> { parametersOf(it) } }
+        register("@appcues/backdrop") { get<BackdropTrait> { parametersOf(it) } }
+        register("@appcues/modal") { get<ModalTrait> { parametersOf(it) } }
+        register("@appcues/skippable") { get<SkippableTrait> { parametersOf(it) } }
     }
 
     operator fun get(key: String): TraitFactoryBlock? {

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropTrait.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-internal class AppcuesBackdropTrait(
+internal class BackdropTrait(
     override val config: AppcuesConfigMap,
     private val stateMachine: StateMachine
 ) : BackdropDecoratingTrait {

--- a/appcues/src/main/java/com/appcues/trait/appcues/GroupTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/GroupTrait.kt
@@ -6,7 +6,7 @@ import com.appcues.data.model.Step
 import com.appcues.data.model.getConfig
 import com.appcues.trait.StepGroupingTrait
 
-internal class AppcuesGroupTrait(override val config: AppcuesConfigMap) : StepGroupingTrait {
+internal class GroupTrait(override val config: AppcuesConfigMap) : StepGroupingTrait {
 
     override val groupId: String? = config.getConfig("groupId")
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -15,7 +15,7 @@ import com.appcues.ui.modal.DialogModal
 import com.appcues.ui.modal.FullScreenModal
 import org.koin.core.scope.Scope
 
-internal class AppcuesModalTrait(
+internal class ModalTrait(
     override val config: AppcuesConfigMap,
     private val scope: Scope,
     private val context: Context,

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -21,7 +21,7 @@ import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.StateMachine
 import com.appcues.trait.ContainerDecoratingTrait
 
-internal class AppcuesSkippableTrait(
+internal class SkippableTrait(
     override val config: AppcuesConfigMap,
     private val stateMachine: StateMachine
 ) : ContainerDecoratingTrait {


### PR DESCRIPTION
This was an iteration goal and an easy add-on to recent work, so knocked it out.

allows for actions in JSON like 
```
{
    "on": "tap",
    "type": "@appcues/track",
    "config": {
        "eventName": "custom_event"
    }
}
```

also renamed other Traits and Actions to remove `Appcues*` prefix