### PR TITLE
🐛 Fixed Skippable trait icon for different backgrounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ output.json
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/deploymentTargetDropDown.xml
+/.idea/assetWizardSettings.xml
 
 # Keystore files
 *.jks

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -1,6 +1,6 @@
 package com.appcues.trait.appcues
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Spacer
@@ -8,13 +8,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -39,16 +37,14 @@ internal class SkippableTrait(
                     .align(Alignment.TopEnd)
                     .padding(8.dp)
                     .clip(CircleShape)
-                    .size(30.dp, 30.dp)
-                    .background(Color(color = 0x80000000)),
+                    .size(30.dp, 30.dp),
                 onClick = {
                     stateMachine.handleAction(EndExperience())
                 }
             ) {
-                Icon(
-                    painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),
+                Image(
+                    painter = painterResource(id = R.drawable.ic_dismiss),
                     contentDescription = stringResource(id = R.string.skippable_trait_dismiss),
-                    tint = Color(color = 0xFFE3E9F1)
                 )
             }
         }

--- a/appcues/src/main/res/drawable/ic_dismiss.xml
+++ b/appcues/src/main/res/drawable/ic_dismiss.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="18"
+    android:viewportHeight="18">
+    <path
+        android:fillColor="#88888888"
+        android:pathData="M0,0v18h18L18,0L0,0zM14,12.59L12.59,14L9,10.41L5.41,14L4,12.59L7.59,9L4,5.41L5.41,4L9,7.59L12.59,4L14,5.41L10.41,9L14,12.59z" />
+</vector>

--- a/appcues/src/main/res/values/themes.xml
+++ b/appcues/src/main/res/values/themes.xml
@@ -6,6 +6,8 @@
     <style name="Appcues.AppcuesActivityTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowIsFloating">false</item>


### PR DESCRIPTION
I tried some libraries out there to give us the same effect as we have on IOS (the blurred with vibrance background) but it didnt quite work for me, I spent too much time on the and I feel like I need to move on for now and maybe have this on the back of my mind and research on the side without much compromise to a solution.

<img width="390" alt="image" src="https://user-images.githubusercontent.com/5244805/159015079-c4e7343a-80cf-4dd7-9be1-239743a0ae4f.png">
<img width="382" alt="image" src="https://user-images.githubusercontent.com/5244805/159015179-6565f7a9-bb4c-461a-bc2d-de840b535e5f.png">


we could probably ask sam to help us defining a good setup for this dismissing icon.