### PR TITLE
♻️  Refactored back viewmodel to properly report state to RenderingStep

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -47,10 +47,10 @@ internal class ExperienceLifecycleTracker(
                                 trackLifecycleEvent(ExperienceStarted(experience))
                                 startedExperience = true
                             }
-                            trackLifecycleEvent(StepSeen(experience, step))
+                            trackLifecycleEvent(StepSeen(experience, flatStepIndex))
                         }
                         is EndingStep -> {
-                            trackLifecycleEvent(StepCompleted(experience, step))
+                            trackLifecycleEvent(StepCompleted(experience, flatStepIndex))
                             // todo - need a way to check if the step ended was the last step of the last step container
                             // and mark the `completedExperience = true` if so -- so that we can correctly fire
                             // the experience completed vs. dismissed events
@@ -59,7 +59,7 @@ internal class ExperienceLifecycleTracker(
                             if (completedExperience) {
                                 trackLifecycleEvent(ExperienceCompleted(experience))
                             } else {
-                                trackLifecycleEvent(ExperienceDismissed(experience, step))
+                                trackLifecycleEvent(ExperienceDismissed(experience, flatStepIndex))
                             }
                         }
                         is Idling -> {

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -19,4 +19,15 @@ internal data class Experience(
             }
         }
     }
+
+    val stepIndexLookup: HashMap<Int, Int> = hashMapOf<Int, Int>().apply {
+        flatSteps.forEachIndexed { stepIndex, step ->
+            stepContainers.forEach {
+                val index = it.steps.indexOf(step)
+                if (index >= 0) {
+                    put(stepIndex, index)
+                }
+            }
+        }
+    }
 }

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -21,10 +21,10 @@ internal sealed class State(open val experience: Experience?) {
 
     data class Idling(override val experience: Experience? = null) : State(experience)
     data class BeginningExperience(override val experience: Experience) : State(experience)
-    data class BeginningStep(override val experience: Experience, val step: Int) : State(experience)
-    data class RenderingStep(override val experience: Experience, val step: Int) : State(experience)
-    data class EndingStep(override val experience: Experience, val step: Int, val dismiss: Boolean) : State(experience)
-    data class EndingExperience(override val experience: Experience, val step: Int) : State(experience)
+    data class BeginningStep(override val experience: Experience, val flatStepIndex: Int) : State(experience)
+    data class RenderingStep(override val experience: Experience, val flatStepIndex: Int) : State(experience)
+    data class EndingStep(override val experience: Experience, val flatStepIndex: Int, val dismiss: Boolean) : State(experience)
+    data class EndingExperience(override val experience: Experience, val flatStepIndex: Int) : State(experience)
 
     fun transition(action: Action): Transition? = when {
         this is Idling && action is StartExperience ->
@@ -32,15 +32,15 @@ internal sealed class State(open val experience: Experience?) {
         this is BeginningExperience && action is StartStep ->
             Transition.fromBeginningExperienceToBeginningStep(experience)
         this is BeginningStep && action is RenderStep ->
-            Transition(RenderingStep(experience, step))
+            Transition(RenderingStep(experience, flatStepIndex))
         this is RenderingStep && action is StartStep ->
-            Transition.fromRenderingStepToEndingStep(experience, step, action.stepReference)
+            Transition.fromRenderingStepToEndingStep(experience, flatStepIndex, action.stepReference)
         this is RenderingStep && action is EndExperience ->
-            Transition(EndingStep(experience, step, true), Continuation(EndExperience))
+            Transition(EndingStep(experience, flatStepIndex, true), Continuation(EndExperience))
         this is EndingStep && action is EndExperience ->
-            Transition(EndingExperience(experience, step), Continuation(Reset))
+            Transition(EndingExperience(experience, flatStepIndex), Continuation(Reset))
         this is EndingStep && action is StartStep ->
-            Transition.fromEndingStepToBeginningStep(experience, step, action.stepReference)
+            Transition.fromEndingStepToBeginningStep(experience, flatStepIndex, action.stepReference)
         this is EndingExperience && action is Reset ->
             Transition(Idling())
 


### PR DESCRIPTION
I did some testing but it was more difficult then expected to create what I wanted around this idea of only changing to RenderingStep when we for sure have composed something on screen. So I think that the safest bet is to always go from BeginningStep to RenderingStep as soon as we process that state. (old way)

Also changed some stuff to support rendering different step containers which will be important for later