### PR TITLE
Add the AppcuesInterceptor

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -28,7 +28,9 @@ class Appcues internal constructor(koinScope: Scope) {
     }
 
     /**
-     * Returns the current version of Appcues SDK
+     * Returns the current version of Appcues SDK.
+     *
+     * @return Current version.
      */
     val version: String
         get() = "${BuildConfig.SDK_VERSION}-${BuildConfig.BUILD_TYPE}"
@@ -211,6 +213,7 @@ class Appcues internal constructor(koinScope: Scope) {
         /**
          *  Set the session timeout for the configuration. This timeout value is used to determine if a new session is started
          *  upon the application returning to the foreground. The default value is 1800 seconds (30 minutes).
+         *
          *  [sessionTimeout] The timeout length, in seconds.
          */
         fun sessionTimeout(timeout: Int) = apply {
@@ -223,6 +226,7 @@ class Appcues internal constructor(koinScope: Scope) {
          * Set the activity storage max size for the configuration.  This value determines how many analytics requests can be
          * stored on the local device and retried later, in the case of the device network connection being unavailable.
          * Only the most recent requests, up to this count, are retained.
+         *
          * [size] The number of items to store, maximum 25, minimum 0.
          */
         fun activityStorageMaxSize(size: Int) = apply {
@@ -235,10 +239,22 @@ class Appcues internal constructor(koinScope: Scope) {
          *  Sets the activity storage max age for the configuration.  This value determines how long an item can be stored
          *  on the local device and retried later, in the case of hte device network connection being unavailable.  Only
          *  requests that are more recent than the max age will be retried - or all, if not set.
-         *  [seconds] The max age, in seconds, since now.  The default is `nil`, meaning no max age.
+         *
+         *  [age] The max age, in seconds, since now.  The default is `nil`, meaning no max age.
          */
         fun activityStorageMaxAge(age: Int) = apply {
             _activityStorageMaxAge = age.coerceAtLeast(0)
+        }
+
+        private var _interceptor: AppcuesInterceptor? = null
+
+        /**
+         * Set the interceptor for additional control over SDK runtime behaviors.
+         *
+         * [interceptor] The interceptor to use.
+         */
+        fun interceptor(interceptor: AppcuesInterceptor) = apply {
+            _interceptor = interceptor
         }
 
         fun build(): Appcues {
@@ -254,6 +270,7 @@ class Appcues internal constructor(koinScope: Scope) {
                         sessionTimeout = _sessionTimeout,
                         activityStorageMaxSize = _activityStorageMaxSize,
                         activityStorageMaxAge = _activityStorageMaxAge,
+                        interceptor = _interceptor,
                     )
                 )
             }

--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -9,6 +9,7 @@ internal data class AppcuesConfig(
     val sessionTimeout: Int,
     val activityStorageMaxSize: Int,
     val activityStorageMaxAge: Int?,
+    val interceptor: AppcuesInterceptor?,
 ) {
     companion object {
         const val SESSION_TIMEOUT_DEFAULT = 1800 // 30 minutes by default

--- a/appcues/src/main/java/com/appcues/AppcuesInterceptor.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesInterceptor.kt
@@ -1,0 +1,20 @@
+package com.appcues
+
+import java.util.UUID
+
+/**
+ * The AppcuesInterceptor can optionally be applied during SDK initialization
+ * to allow for more customizable control over SDK behaviors at runtime.
+ */
+interface AppcuesInterceptor {
+
+    /**
+     * Determines if the given Appcues experience can display.  Can be used to handle
+     * additional processing needed to get the application into a valid state to display
+     * before returning a value.
+     *
+     * [experienceId] the ID of the experience that is being requested to display.
+     * @return true if the experience can be shown, false if not.
+     */
+    suspend fun canDisplayExperience(experienceId: UUID): Boolean
+}

--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -21,7 +21,8 @@ internal object AppcuesKoin : KoinScopePlugin {
                 appcuesCoroutineScope = get(),
                 repository = get(),
                 stateMachine = get(),
-                sessionMonitor = get()
+                sessionMonitor = get(),
+                config = get(),
             )
         }
         scoped {

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -1,5 +1,6 @@
 package com.appcues.ui
 
+import com.appcues.AppcuesConfig
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.SessionMonitor
 import com.appcues.data.AppcuesRepository
@@ -13,10 +14,14 @@ internal class ExperienceRenderer(
     private val repository: AppcuesRepository,
     private val stateMachine: StateMachine,
     private val sessionMonitor: SessionMonitor,
+    private val config: AppcuesConfig,
 ) {
 
-    fun show(experience: Experience) {
-        stateMachine.handleAction(StartExperience(experience))
+    suspend fun show(experience: Experience) {
+        val canShow = config.interceptor?.canDisplayExperience(experience.id) ?: true
+        if (canShow) {
+            stateMachine.handleAction(StartExperience(experience))
+        }
     }
 
     fun show(experienceId: String) {


### PR DESCRIPTION
To allow for custom control over if and when an experience will show.

I made this a Builder option that ends up in the config object - open to other ideas though if there is a better way.

to use, you would implement something like this, with an example 3 sec delay on experience rendering 
```
    override suspend fun canDisplayExperience(experienceId: UUID): Boolean {
        delay(3000)
        return true
    }
```

then add to your SDK init like
```
        Appcues.Builder(this, BuildConfig.APPCUES_ACCOUNT_ID, BuildConfig.APPCUES_APPLICATION_ID)
            .interceptor(this)
            .build().also { appcues = it }
```