### PR TITLE
Add ExperienceListener capability

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -23,6 +23,16 @@ class Appcues internal constructor(koinScope: Scope) {
     private val storage by koinScope.inject<Storage>()
     private val sessionMonitor by koinScope.inject<SessionMonitor>()
 
+    /**
+     * Set the listener to be notified about the display of Experience content.
+     */
+    var experienceListener: ExperienceListener? by appcuesConfig::experienceListener
+
+    /**
+     * Set the interceptor for additional control over SDK runtime behaviors.
+     */
+    var interceptor: AppcuesInterceptor? by appcuesConfig::interceptor
+
     init {
         sessionMonitor.start()
     }
@@ -257,6 +267,17 @@ class Appcues internal constructor(koinScope: Scope) {
             _interceptor = interceptor
         }
 
+        private var _experienceListener: ExperienceListener? = null
+
+        /**
+         * Set the listener to be notified about the display of Experience content.
+         *
+         * [listener] The listener to use.
+         */
+        fun experienceListener(listener: ExperienceListener) = apply {
+            _experienceListener = listener
+        }
+
         fun build(): Appcues {
             return with(AppcuesKoinContext) {
                 createAppcues(
@@ -271,6 +292,7 @@ class Appcues internal constructor(koinScope: Scope) {
                         activityStorageMaxSize = _activityStorageMaxSize,
                         activityStorageMaxAge = _activityStorageMaxAge,
                         interceptor = _interceptor,
+                        experienceListener = _experienceListener,
                     )
                 )
             }

--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -9,7 +9,8 @@ internal data class AppcuesConfig(
     val sessionTimeout: Int,
     val activityStorageMaxSize: Int,
     val activityStorageMaxAge: Int?,
-    val interceptor: AppcuesInterceptor?,
+    var interceptor: AppcuesInterceptor?,
+    var experienceListener: ExperienceListener?,
 ) {
     companion object {
         const val SESSION_TIMEOUT_DEFAULT = 1800 // 30 minutes by default

--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -14,7 +14,7 @@ internal object AppcuesKoin : KoinScopePlugin {
         scoped { Appcues(koinScope = this) }
         scoped { AppcuesCoroutineScope(logcues = get()) }
         scoped { Logcues(config.loggingLevel) }
-        scoped { StateMachine(appcuesCoroutineScope = get()) }
+        scoped { StateMachine(appcuesCoroutineScope = get(), config = get()) }
         scoped { Storage(context = get(), config = get()) }
         scoped {
             ExperienceRenderer(

--- a/appcues/src/main/java/com/appcues/ExperienceListener.kt
+++ b/appcues/src/main/java/com/appcues/ExperienceListener.kt
@@ -1,0 +1,23 @@
+package com.appcues
+
+import java.util.UUID
+
+/**
+ * Provides a set of listener methods that can be used to be informed about when Experience
+ * content is being rendered inside of the application.
+ */
+interface ExperienceListener {
+    /**
+     * Notifies the listener when an Experience is starting.
+     *
+     * [experienceId] The ID of the Experience that is starting.
+     */
+    fun experienceStarted(experienceId: UUID)
+
+    /**
+     * Notifies the listener when an Experience has finished.
+     *
+     * [experienceId] The ID of the Experience that has finished.
+     */
+    fun experienceFinished(experienceId: UUID)
+}


### PR DESCRIPTION
This adds an `ExperienceListener` interface that can be implemented/subscribed to get notified about basic things like an experience starting and finishing.  This provides a way for the host application to at least know if other content is being rendered on top of their app.

This is a separate but related piece to the previous `AppcuesInterceptor` update (controlling if content can render)

Also, both the listener and interceptor can be applied during the Builder init time - since content may show immediately upon SDK init / session start. But, to allow for unsubscribe and ensuring we don't force the retain of customer objects, you can also set new values (or null out) using the properties on the Appcues instance.

This combination allows for doing something like this, for example:

init
```
appcues = Appcues.Builder(this, BuildConfig.APPCUES_ACCOUNT_ID, BuildConfig.APPCUES_APPLICATION_ID)
    .logging(loggingLevel)
    .interceptor(this)
    .experienceListener(this)
    .build()
```

use the interceptor to control the display behavior
```
override suspend fun canDisplayExperience(experienceId: UUID): Boolean {
    delay(5000)
    return true
}
```

use the listener to track the state of experience content - and then in the example for experienceFinished - remove the listener and interceptor that were added during init.
```
override fun experienceStarted(experienceId: UUID) {
    Log.i("Appcues Example", "Experience started $experienceId")
}

override fun experienceFinished(experienceId: UUID) {
    Log.i("Appcues Example", "Experience ended $experienceId")
    appcues.experienceListener = null
    appcues.interceptor = null
}
```
