### PR TITLE
Improve how we track experience started/completed analytics

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -6,8 +6,8 @@ internal sealed class State(open val experience: Experience?) {
 
     data class Idling(override val experience: Experience? = null) : State(experience)
     data class BeginningExperience(override val experience: Experience) : State(experience)
-    data class BeginningStep(override val experience: Experience, val flatStepIndex: Int) : State(experience)
-    data class RenderingStep(override val experience: Experience, val flatStepIndex: Int) : State(experience)
+    data class BeginningStep(override val experience: Experience, val flatStepIndex: Int, val isFirst: Boolean) : State(experience)
+    data class RenderingStep(override val experience: Experience, val flatStepIndex: Int, val isFirst: Boolean) : State(experience)
     data class EndingStep(
         override val experience: Experience,
         val flatStepIndex: Int,

--- a/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
@@ -36,11 +36,11 @@ internal interface Transitions {
 
     fun BeginningExperience.fromBeginningExperienceToBeginningStep(action: StartStep): Transition {
         // not sure yet if we'll eventually do any trait composition here
-        return Transition(BeginningStep(experience, 0), PresentContainerEffect(experience, 0))
+        return Transition(BeginningStep(experience, 0, true), PresentContainerEffect(experience, 0))
     }
 
     fun BeginningStep.fromBeginningStepToRenderingStep(action: RenderStep): Transition {
-        return Transition(RenderingStep(experience, flatStepIndex))
+        return Transition(RenderingStep(experience, flatStepIndex, isFirst))
     }
 
     fun RenderingStep.fromRenderingStepToEndingStep(action: StartStep): Transition {
@@ -114,14 +114,14 @@ private fun transitionsToBeginningStep(
 ) = if (experience.areStepsFromDifferentGroup(currentStepIndex, nextStepIndex)) {
     // given that steps are from different container, we now get step container index to present
     experience.groupLookup[nextStepIndex]?.let { stepContainerIndex ->
-        Transition(BeginningStep(experience, nextStepIndex), PresentContainerEffect(experience, stepContainerIndex))
+        Transition(BeginningStep(experience, nextStepIndex, false), PresentContainerEffect(experience, stepContainerIndex))
     } ?: run {
         // this should never happen at this point. but better to safe guard anyways
         errorTransition(experience, currentStepIndex, "StepContainer for nextStepIndex $nextStepIndex not found")
     }
 } else {
     // else we just move to rendering step
-    Transition(BeginningStep(experience, nextStepIndex), ContinuationEffect(StartStep(nextStepReference)))
+    Transition(BeginningStep(experience, nextStepIndex, false), ContinuationEffect(StartStep(nextStepReference)))
 }
 
 private fun Experience.areStepsFromDifferentGroup(stepIndexOne: Int, stepIndexTwo: Int): Boolean {


### PR DESCRIPTION
Minor update - tracks whether a step being rendered `isFirst` (first step shown) as part of the State object, so we can accurately report `experience_started` when the first step is seen without having to track state in the listener - which would not work if we had multiple experiences running.

Also, fix up the determination of experience dismissed vs. completed - its "complete" if it ends on the final step, for modals at least.