### PR TITLE
♻️ Adjustments to PresentingTrait

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/DataMapperKoin.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/DataMapperKoin.kt
@@ -20,6 +20,8 @@ internal object DataMapperKoin : KoinScopePlugin {
             ExperienceMapper(
                 stepMapper = get(),
                 traitsMapper = get(),
+                scope = get(),
+                context = get(),
             )
         }
 

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -1,5 +1,6 @@
 package com.appcues.data.mapper.experience
 
+import android.content.Context
 import com.appcues.data.mapper.step.StepMapper
 import com.appcues.data.mapper.trait.TraitsMapper
 import com.appcues.data.model.Experience
@@ -12,14 +13,18 @@ import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.ContainerDecoratingTrait
 import com.appcues.trait.ContentHolderTrait
 import com.appcues.trait.ContentWrappingTrait
-import com.appcues.trait.ExperiencePresentingTrait
 import com.appcues.trait.ExperienceTrait
+import com.appcues.trait.PresentingTrait
 import com.appcues.trait.appcues.DefaultContentHolderTrait
+import com.appcues.trait.appcues.DefaultPresentingTrait
+import org.koin.core.scope.Scope
 import java.util.UUID
 
 internal class ExperienceMapper(
     private val stepMapper: StepMapper,
     private val traitsMapper: TraitsMapper,
+    private val scope: Scope,
+    private val context: Context,
 ) {
 
     fun map(from: ExperienceResponse): Experience {
@@ -45,8 +50,7 @@ internal class ExperienceMapper(
                     experienceActions,
                 )
             },
-            // what should we do if no presenting trait is found?
-            presentingTrait = traits.filterIsInstance<ExperiencePresentingTrait>().first(),
+            presentingTrait = traits.getExperiencePresentingTraitOrDefault(),
             contentHolderTrait = traits.getContainerCreatingTraitOrDefault(),
             // what should we do if no content wrapping trait is found?
             contentWrappingTrait = traits.filterIsInstance<ContentWrappingTrait>().first(),
@@ -57,6 +61,10 @@ internal class ExperienceMapper(
 
     private fun List<ExperienceTrait>.getContainerCreatingTraitOrDefault(): ContentHolderTrait {
         return filterIsInstance<ContentHolderTrait>().firstOrNull() ?: DefaultContentHolderTrait(null)
+    }
+
+    private fun List<ExperienceTrait>.getExperiencePresentingTraitOrDefault(): PresentingTrait {
+        return filterIsInstance<PresentingTrait>().firstOrNull() ?: DefaultPresentingTrait(null, scope, context)
     }
 
     private fun List<TraitResponse>.mergeWith(other: List<TraitResponse>): List<TraitResponse> {

--- a/appcues/src/main/java/com/appcues/data/model/StepContainer.kt
+++ b/appcues/src/main/java/com/appcues/data/model/StepContainer.kt
@@ -4,11 +4,11 @@ import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.ContainerDecoratingTrait
 import com.appcues.trait.ContentHolderTrait
 import com.appcues.trait.ContentWrappingTrait
-import com.appcues.trait.ExperiencePresentingTrait
+import com.appcues.trait.PresentingTrait
 
 internal data class StepContainer(
     val steps: List<Step>,
-    val presentingTrait: ExperiencePresentingTrait,
+    val presentingTrait: PresentingTrait,
     val contentHolderTrait: ContentHolderTrait,
     val contentWrappingTrait: ContentWrappingTrait,
     val backdropTraits: List<BackdropDecoratingTrait>,

--- a/appcues/src/main/java/com/appcues/statemachine/Transition.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transition.kt
@@ -32,7 +32,7 @@ internal open class Transition(
     }
 
     private fun PresentContainerEffect.applyEffect() {
-        experience.stepContainers[containerIndex].presentingTrait.presentExperience()
+        experience.stepContainers[containerIndex].presentingTrait.present()
     }
 
     class ErrorLoggingTransition(error: Error) : Transition(null, ReportErrorEffect(error))

--- a/appcues/src/main/java/com/appcues/trait/ExperiencePresentingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ExperiencePresentingTrait.kt
@@ -1,6 +1,0 @@
-package com.appcues.trait
-
-interface ExperiencePresentingTrait : ExperienceTrait {
-
-    fun presentExperience()
-}

--- a/appcues/src/main/java/com/appcues/trait/PresentingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/PresentingTrait.kt
@@ -1,0 +1,6 @@
+package com.appcues.trait
+
+interface PresentingTrait : ExperienceTrait {
+
+    fun present()
+}

--- a/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
@@ -28,8 +28,6 @@ internal object TraitKoin : KoinScopePlugin {
         factory { params ->
             ModalTrait(
                 config = params.getOrNull(),
-                scope = get(),
-                context = get(),
             )
         }
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/DefaultPresentingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/DefaultPresentingTrait.kt
@@ -1,0 +1,18 @@
+package com.appcues.trait.appcues
+
+import android.content.Context
+import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.trait.PresentingTrait
+import com.appcues.ui.AppcuesActivity
+import org.koin.core.scope.Scope
+
+class DefaultPresentingTrait(
+    override val config: AppcuesConfigMap,
+    private val scope: Scope,
+    private val context: Context,
+) : PresentingTrait {
+
+    override fun present() {
+        context.startActivity(AppcuesActivity.getIntent(context, scope.id))
+    }
+}

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -1,26 +1,21 @@
 package com.appcues.trait.appcues
 
 import ExpandedBottomSheetModal
-import android.content.Context
 import androidx.compose.runtime.Composable
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfigOrDefault
 import com.appcues.data.model.getConfigStyle
 import com.appcues.trait.ContentWrappingTrait
-import com.appcues.trait.ExperiencePresentingTrait
-import com.appcues.ui.AppcuesActivity
 import com.appcues.ui.modal.BottomSheetModal
 import com.appcues.ui.modal.DialogModal
 import com.appcues.ui.modal.FullScreenModal
-import org.koin.core.scope.Scope
 
 internal class ModalTrait(
     override val config: AppcuesConfigMap,
-    private val scope: Scope,
-    private val context: Context,
-) : ExperiencePresentingTrait, ContentWrappingTrait {
+) : ContentWrappingTrait {
 
     companion object {
+
         const val TYPE = "@appcues/modal"
     }
 
@@ -28,10 +23,6 @@ internal class ModalTrait(
     private val presentationStyle = config.getConfigOrDefault("presentationStyle", "full")
 
     private val style = config.getConfigStyle("style")
-
-    override fun presentExperience() {
-        context.startActivity(AppcuesActivity.getIntent(context, scope.id))
-    }
 
     @Composable
     override fun WrapContent(content: @Composable () -> Unit) {


### PR DESCRIPTION
Rename to PresentingTrait
decoupled it from @appcues/modal and created Default implementation when none of this trait type is found during the mapping.


this is for after "♻️ Adjustments to render multiple step groups properly" gets merged