### PR TITLE
Implement automatic screen tracking for Activities

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -3,6 +3,7 @@ package com.appcues
 import android.content.Context
 import com.appcues.action.ActionRegistry
 import com.appcues.action.ExperienceAction
+import com.appcues.analytics.ActivityScreenTracking
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.builder.ApiHostBuilderValidator
 import com.appcues.di.AppcuesKoinContext
@@ -22,6 +23,7 @@ class Appcues internal constructor(koinScope: Scope) {
     private val analyticsTracker by koinScope.inject<AnalyticsTracker>()
     private val storage by koinScope.inject<Storage>()
     private val sessionMonitor by koinScope.inject<SessionMonitor>()
+    private val activityScreenTracking by koinScope.inject<ActivityScreenTracking>()
 
     /**
      * Set the listener to be notified about the display of Experience content.
@@ -148,10 +150,10 @@ class Appcues internal constructor(koinScope: Scope) {
     }
 
     /**
-     * Enables automatic screen tracking. (Works for Activities)
+     * Enables automatic screen tracking for Activities.
      */
-    fun trackScreen() {
-        logcues.info("trackScreen()")
+    fun trackScreens() {
+        activityScreenTracking.trackScreens()
     }
 
     /**

--- a/appcues/src/main/java/com/appcues/analytics/ActivityScreenTracking.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ActivityScreenTracking.kt
@@ -1,0 +1,38 @@
+package com.appcues.analytics
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Bundle
+import com.appcues.logging.Logcues
+
+internal class ActivityScreenTracking(
+    private val context: Context,
+    private val analyticsTracker: AnalyticsTracker,
+    private val logcues: Logcues,
+) : Application.ActivityLifecycleCallbacks {
+
+    fun trackScreens() {
+        val application = context.applicationContext as Application
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        val packageManager = activity.packageManager
+        try {
+            val info = packageManager.getActivityInfo(activity.componentName, PackageManager.GET_META_DATA)
+            val activityLabel = info.loadLabel(packageManager)
+            analyticsTracker.screen(activityLabel.toString())
+        } catch (ex: PackageManager.NameNotFoundException) {
+            logcues.error(ex)
+        }
+    }
+
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
+}

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsKoin.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsKoin.kt
@@ -13,6 +13,7 @@ internal object AnalyticsKoin : KoinScopePlugin {
         scoped { ActivityRequestBuilder(config = get(), storage = get(), decorator = get()) }
         scoped { ExperienceLifecycleTracker(scope = this) }
         scoped { AnalyticsPolicy(sessionMonitor = get(), appcuesCoroutineScope = get(), stateMachine = get(), logcues = get()) }
+        scoped { ActivityScreenTracking(context = get(), analyticsTracker = get(), logcues = get()) }
         scoped {
             AnalyticsTracker(
                 appcuesCoroutineScope = get(),

--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
             android:label="@string/title_activity_main" />
         <activity
             android:name=".signin.SignInActivity"
-            android:exported="true" >
+            android:exported="true"
+            android:label="@string/title_activity_signin" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/samples/kotlin-android-app/src/main/res/values/strings.xml
+++ b/samples/kotlin-android-app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="skip_menu">Skip</string>
     <string name="user_id_label">User ID</string>
     <string name="title_activity_signin">Sign In</string>
-    <string name="title_activity_main">Appcues</string>
+    <string name="title_activity_main">Home</string>
     <string name="tab_events">Events</string>
     <string name="tab_profile">Profile</string>
     <string name="tab_group">Group</string>


### PR DESCRIPTION
This adds an optional feature to automatically track Activities by their `label` property, as screen views.  Likely not extremely high value for more sophisticated apps, but a very simple entry point for those that might want something working immediately - matches how Segment handles screen tracking on Android.