### PR TITLE
Add support for deeplinking to preview or published content

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -1,6 +1,7 @@
 package com.appcues
 
 import android.content.Context
+import android.content.Intent
 import com.appcues.action.ActionRegistry
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ActivityScreenTracking
@@ -24,6 +25,7 @@ class Appcues internal constructor(koinScope: Scope) {
     private val storage by koinScope.inject<Storage>()
     private val sessionMonitor by koinScope.inject<SessionMonitor>()
     private val activityScreenTracking by koinScope.inject<ActivityScreenTracking>()
+    private val deeplinkHandler by koinScope.inject<DeeplinkHandler>()
 
     /**
      * Set the listener to be notified about the display of Experience content.
@@ -161,6 +163,16 @@ class Appcues internal constructor(koinScope: Scope) {
      */
     fun debug() {
         logcues.info("debug()")
+    }
+
+    /**
+     * Notify Appcues of a new Intent to check for deep link content.  This should be used to pass along Intents
+     * that may be using the custom Appcues scheme, for things like previewing experiences.
+     *
+     * [intent] the Intent that the Appcues SDK should check for deep link content.
+     */
+    fun onNewIntent(intent: Intent?) {
+        deeplinkHandler.handle(intent)
     }
 
     private fun identify(isAnonymous: Boolean, userId: String, properties: HashMap<String, Any>?) {

--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -16,6 +16,7 @@ internal object AppcuesKoin : KoinScopePlugin {
         scoped { Logcues(config.loggingLevel) }
         scoped { StateMachine(appcuesCoroutineScope = get(), config = get()) }
         scoped { Storage(context = get(), config = get()) }
+        scoped { DeeplinkHandler(config = get(), appcues = get(), experienceRenderer = get()) }
         scoped {
             ExperienceRenderer(
                 appcuesCoroutineScope = get(),

--- a/appcues/src/main/java/com/appcues/DeeplinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/DeeplinkHandler.kt
@@ -1,0 +1,29 @@
+package com.appcues
+
+import android.content.Intent
+import android.net.Uri
+import com.appcues.ui.ExperienceRenderer
+
+internal class DeeplinkHandler(
+    private val config: AppcuesConfig,
+    private val appcues: Appcues,
+    private val experienceRenderer: ExperienceRenderer,
+) {
+
+    fun handle(intent: Intent?) {
+        val linkAction: String? = intent?.action
+        val linkData: Uri? = intent?.data
+
+        if (linkAction == Intent.ACTION_VIEW &&
+            linkData?.scheme == "appcues-${config.applicationId}" &&
+            linkData.host == "sdk"
+        ) {
+            val segments = linkData.pathSegments
+            when {
+                segments.count() == 2 && segments[0] == "experience_preview" -> experienceRenderer.preview(segments[1])
+                segments.count() == 2 && segments[0] == "experience_content" -> experienceRenderer.show(segments[1])
+                segments.count() == 1 && segments[0] == "debugger" -> appcues.debug()
+            }
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/SessionMonitor.kt
+++ b/appcues/src/main/java/com/appcues/SessionMonitor.kt
@@ -28,7 +28,7 @@ internal class SessionMonitor(
     val sessionId: UUID?
         get() = _sessionId
 
-    private val isActive: Boolean
+    val isActive: Boolean
         get() = _sessionId != null
 
     private var applicationBackgrounded: Date? = null

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -9,10 +9,15 @@ import com.appcues.analytics.ExperienceLifecycleEvent.StepCompleted
 import com.appcues.analytics.ExperienceLifecycleEvent.StepError
 import com.appcues.analytics.ExperienceLifecycleEvent.StepSeen
 import com.appcues.statemachine.Error
+import com.appcues.statemachine.State
+import com.appcues.statemachine.State.BeginningExperience
+import com.appcues.statemachine.State.BeginningStep
 import com.appcues.statemachine.State.EndingExperience
 import com.appcues.statemachine.State.EndingStep
+import com.appcues.statemachine.State.Idling
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.StateMachine
+import com.appcues.util.ResultOf
 import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
 import kotlinx.coroutines.Dispatchers
@@ -35,36 +40,38 @@ internal class ExperienceLifecycleTracker(
 
     suspend fun start() = withContext(Dispatchers.IO) {
         stateMachine.stateResultFlow.collect { result ->
-            when (result) {
-                is Success -> with(result.value) {
-                    when (this) {
-                        is RenderingStep -> {
-                            if (isFirst) {
-                                // update this value for auto-properties
-                                storage.lastContentShownAt = Date()
-                                trackLifecycleEvent(ExperienceStarted(experience))
+            if (result.shouldTrack()) { // will not track for unpublished (preview) experiences
+                when (result) {
+                    is Success -> with(result.value) {
+                        when (this) {
+                            is RenderingStep -> {
+                                if (isFirst) {
+                                    // update this value for auto-properties
+                                    storage.lastContentShownAt = Date()
+                                    trackLifecycleEvent(ExperienceStarted(experience))
+                                }
+                                trackLifecycleEvent(StepSeen(experience, flatStepIndex))
                             }
-                            trackLifecycleEvent(StepSeen(experience, flatStepIndex))
-                        }
-                        is EndingStep -> {
-                            trackLifecycleEvent(StepCompleted(experience, flatStepIndex))
-                        }
-                        is EndingExperience -> {
-                            if (flatStepIndex == experience.flatSteps.count() - 1) {
-                                // if ending on the last step - it was completed
-                                trackLifecycleEvent(ExperienceCompleted(experience))
-                            } else {
-                                // otherwise its considered dismissed (not completed)
-                                trackLifecycleEvent(ExperienceDismissed(experience, flatStepIndex))
+                            is EndingStep -> {
+                                trackLifecycleEvent(StepCompleted(experience, flatStepIndex))
                             }
+                            is EndingExperience -> {
+                                if (flatStepIndex == experience.flatSteps.count() - 1) {
+                                    // if ending on the last step - it was completed
+                                    trackLifecycleEvent(ExperienceCompleted(experience))
+                                } else {
+                                    // otherwise its considered dismissed (not completed)
+                                    trackLifecycleEvent(ExperienceDismissed(experience, flatStepIndex))
+                                }
+                            }
+                            else -> Unit
                         }
-                        else -> Unit
                     }
-                }
-                is Failure -> with(result.reason) {
-                    when (this) {
-                        is Error.ExperienceError -> trackLifecycleEvent(ExperienceError(this))
-                        is Error.StepError -> trackLifecycleEvent(StepError(this))
+                    is Failure -> with(result.reason) {
+                        when (this) {
+                            is Error.ExperienceError -> trackLifecycleEvent(ExperienceError(this))
+                            is Error.StepError -> trackLifecycleEvent(StepError(this))
+                        }
                     }
                 }
             }
@@ -74,4 +81,24 @@ internal class ExperienceLifecycleTracker(
     private fun trackLifecycleEvent(event: ExperienceLifecycleEvent) {
         analyticsTracker.track(event.name, event.properties, false)
     }
+
+    private fun ResultOf<State, Error>.shouldTrack(): Boolean =
+        when (this) {
+            is Success -> {
+                when (this.value) {
+                    is BeginningExperience -> value.experience.published
+                    is BeginningStep -> value.experience.published
+                    is EndingExperience -> value.experience.published
+                    is EndingStep -> value.experience.published
+                    is Idling -> false
+                    is RenderingStep -> value.experience.published
+                }
+            }
+            is Failure -> {
+                when (reason) {
+                    is Error.ExperienceError -> reason.experience.published
+                    is Error.StepError -> reason.experience.published
+                }
+            }
+        }
 }

--- a/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
+++ b/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
@@ -45,6 +45,18 @@ internal class AppcuesRepository(
         }
     }
 
+    suspend fun getExperiencePreview(experienceId: String): Experience? = withContext(Dispatchers.IO) {
+        appcuesRemoteSource.getExperiencePreview(experienceId).let {
+            when (it) {
+                is Success -> experienceMapper.map(it.value)
+                is Failure -> {
+                    logcues.info("Experience preview request failed, reason: ${it.reason}")
+                    null
+                }
+            }
+        }
+    }
+
     suspend fun trackActivity(activity: ActivityRequest): List<Experience> = withContext(Dispatchers.IO) {
 
         val activityStorage = ActivityStorage(activity.requestId, activity.accountId, activity.userId, gson.toJson(activity))

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -33,7 +33,8 @@ internal class ExperienceMapper(
         return Experience(
             id = from.id,
             name = from.name,
-            stepContainers = from.steps.mapToStepContainer(from.traits, from.actions)
+            stepContainers = from.steps.mapToStepContainer(from.traits, from.actions),
+            published = from.state != "DRAFT" // "DRAFT" is used for experience preview in builder
         )
     }
 

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -5,7 +5,8 @@ import java.util.UUID
 internal data class Experience(
     val id: UUID,
     val name: String,
-    val stepContainers: List<StepContainer>
+    val stepContainers: List<StepContainer>,
+    val published: Boolean,
 ) {
 
     // will run once when creating the experience

--- a/appcues/src/main/java/com/appcues/data/remote/AppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/AppcuesRemoteSource.kt
@@ -7,6 +7,7 @@ import com.appcues.util.ResultOf
 
 internal interface AppcuesRemoteSource {
     suspend fun getExperienceContent(experienceId: String): ResultOf<ExperienceResponse, RemoteError>
+    suspend fun getExperiencePreview(experienceId: String): ResultOf<ExperienceResponse, RemoteError>
     suspend fun postActivity(userId: String, activityJson: String): ResultOf<ActivityResponse, RemoteError>
     suspend fun qualify(userId: String, activityJson: String): ResultOf<QualifyResponse, RemoteError>
 }

--- a/appcues/src/main/java/com/appcues/data/remote/DataRemoteKoin.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/DataRemoteKoin.kt
@@ -21,7 +21,8 @@ internal object DataRemoteKoin : KoinScopePlugin {
                 appcuesService = getAppcuesService(gson = get(), config.apiHostUrl ?: BASE_URL),
                 accountId = config.accountId,
                 storage = get(),
-                gson = get()
+                gson = get(),
+                sessionMonitor = get(),
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/data/remote/response/experience/ExperienceResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/experience/ExperienceResponse.kt
@@ -11,5 +11,6 @@ internal data class ExperienceResponse(
     val theme: String?,
     val actions: HashMap<UUID, List<ActionResponse>>?,
     val traits: List<TraitResponse>,
-    val steps: List<StepContainerResponse>
+    val steps: List<StepContainerResponse>,
+    val state: String?,
 )

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/AppcuesService.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/AppcuesService.kt
@@ -31,4 +31,17 @@ internal interface AppcuesService {
         @Path("user") user: String,
         @Path("experienceId") experienceId: String,
     ): ExperienceResponse
+
+    @GET("v1/accounts/{account}/users/{user}/experience_preview/{experienceId}")
+    suspend fun experiencePreview(
+        @Path("account") account: String,
+        @Path("user") user: String,
+        @Path("experienceId") experienceId: String,
+    ): ExperienceResponse
+
+    @GET("v1/accounts/{account}/experience_preview/{experienceId}")
+    suspend fun experiencePreview(
+        @Path("account") account: String,
+        @Path("experienceId") experienceId: String,
+    ): ExperienceResponse
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -3,10 +3,9 @@ package com.appcues.statemachine
 import com.appcues.data.model.Experience
 import java.util.UUID
 
-internal abstract class Error {
+internal sealed class Error(open val message: String) {
     val id: UUID = UUID.randomUUID()
-    abstract val message: String
 
-    data class ExperienceError(val experience: Experience, override val message: String) : Error()
-    data class StepError(val experience: Experience, val stepIndex: Int, override val message: String) : Error()
+    data class ExperienceError(val experience: Experience, override val message: String) : Error(message)
+    data class StepError(val experience: Experience, val stepIndex: Int, override val message: String) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -35,4 +35,14 @@ internal class ExperienceRenderer(
             }
         }
     }
+
+    fun preview(experienceId: String) {
+        appcuesCoroutineScope.launch {
+            // should this check if the state is Idling before even trying to fetch
+            // the experience? since it cannot show anyway, if already in another state?
+            repository.getExperiencePreview(experienceId)?.let {
+                show(it)
+            }
+        }
+    }
 }

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 
 internal val contentModalOneStubs = ExperienceResponse(
     id = UUID.fromString("9f4baa80-8f6a-41b1-a7b9-979da5c175e2"),
+    state = "PUBLISHED",
     name = "POC Modal One",
     theme = null,
     actions = null,


### PR DESCRIPTION
approach - customer can add an intent-filter like this to one of their activities, using the `appcues-{app_id}` custom scheme.
```
<intent-filter>
    <data android:scheme="appcues-4b6b796f-1313-440a-b356-ee4b7abe931c" />
    <action android:name="android.intent.action.VIEW" />
    <category android:name="android.intent.category.DEFAULT" />
    <category android:name="android.intent.category.BROWSABLE" />
</intent-filter>
```

then, custom scheme links below can be used to trigger showing content in the app.
```
appcues-{app_id}://sdk/experience_preview/{experience_id}
appcues-{app_id}://sdk/experience_content/{experience_id}
appcues-{app_id}://sdk/debugger (TBD)
```

the customer application is then responsible for calling `Appcues.onNewIntent(intent)` and passing the link info along to the SDK.  This is similar to [Localytics test mode](https://help.uplandsoftware.com/localytics/dev/android.html#setup-test-mode-android).

The difference between `experience_preview` and `experience_content` is that the preview mode is used for unpublished ("draft") content during build/design time.  A key note - when showing a preview, experience analytics are not captured.

Most of this work is for the preview feature, but it also covers the highly related deeplink to published content in [sc-31749]