### PR TITLE
Remove the Activity label for the Sign In Activity in the sample app

### DIFF
--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -19,8 +19,7 @@
             android:label="@string/title_activity_main" />
         <activity
             android:name=".signin.SignInActivity"
-            android:exported="true"
-            android:label="@string/title_activity_signin" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Restores the proper app name title in the launcher view