### PR TITLE
Update ExperienceLifecycleTracker to not track experience already active errors

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -71,6 +71,7 @@ internal class ExperienceLifecycleTracker(
                         when (this) {
                             is Error.ExperienceError -> trackLifecycleEvent(ExperienceError(this))
                             is Error.StepError -> trackLifecycleEvent(StepError(this))
+                            is Error.ExperienceAlreadyActive -> Unit
                         }
                     }
                 }
@@ -98,6 +99,7 @@ internal class ExperienceLifecycleTracker(
                 when (reason) {
                     is Error.ExperienceError -> reason.experience.published
                     is Error.StepError -> reason.experience.published
+                    is Error.ExperienceAlreadyActive -> false
                 }
             }
         }

--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 internal sealed class Error(open val message: String) {
     val id: UUID = UUID.randomUUID()
 
+    data class ExperienceAlreadyActive(val ignoredExperience: Experience, override val message: String) : Error(message)
     data class ExperienceError(val experience: Experience, override val message: String) : Error(message)
     data class StepError(val experience: Experience, val stepIndex: Int, override val message: String) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -8,7 +8,7 @@ import com.appcues.statemachine.Action.ReportError
 import com.appcues.statemachine.Action.Reset
 import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.Action.StartStep
-import com.appcues.statemachine.Error.ExperienceError
+import com.appcues.statemachine.Error.ExperienceAlreadyActive
 import com.appcues.statemachine.State.BeginningExperience
 import com.appcues.statemachine.State.BeginningStep
 import com.appcues.statemachine.State.EndingExperience
@@ -76,16 +76,14 @@ internal class StateMachine(
         }
     }
 
-    fun reportError(error: Error) {
-        appcuesCoroutineScope.launch {
-            _stateResultFlow.emit(Failure(error))
-        }
+    suspend fun reportError(error: Error) {
+        _stateResultFlow.emit(Failure(error))
     }
 
     private fun State.take(action: Action): Transition {
         return takeValidStateTransitions(this, action) ?: when (action) {
             // start experience action when experience is already active
-            is StartExperience -> ErrorLoggingTransition(ExperienceError(action.experience, "Experience already active"))
+            is StartExperience -> ErrorLoggingTransition(ExperienceAlreadyActive(action.experience, "Experience already active"))
             // report error action
             is ReportError -> ErrorLoggingTransition(action.error)
             // undefined transition - no-op

--- a/appcues/src/main/java/com/appcues/statemachine/Transition.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transition.kt
@@ -27,7 +27,7 @@ internal open class Transition(
         stateMachine.handleAction(action)
     }
 
-    private fun ReportErrorEffect.applyEffect(stateMachine: StateMachine) {
+    private suspend fun ReportErrorEffect.applyEffect(stateMachine: StateMachine) {
         stateMachine.reportError(error)
     }
 


### PR DESCRIPTION
enforcing the same policy on analytics that was implemented on iOS here https://github.com/appcues/appcues-ios-sdk/pull/146

Also, chased down a race condition where state result updates could get posted to the SharedFlow out of sequence.  This was due to error reporting (via side effect) launching a new coroutine while applying the side effect, rather than using the coroutine that was already active for the action.  This would cause issues, for example, like launching 2 flows simultaneously resulting the app being hung while the AppcuesViewModel waits on a state update that would never arrive - since it was already sent and replaced with another result that `collectLatest` was seeing in the VM.