### PR TITLE
Support fallback to other qualified experiences if first fails to load

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
@@ -111,12 +111,7 @@ internal class AnalyticsTracker(
         appcuesCoroutineScope.launch {
             // this will respond with qualified experiences, if applicable
             val experiences = repository.trackActivity(activity)
-
-            if (experiences.isNotEmpty()) {
-                // note: by default we just show the first experience, but will need to revisit and allow
-                // for showing secondary qualified experience if the first fails to load for some reason
-                experienceRenderer.show(experiences.first())
-            }
+            experienceRenderer.show(experiences)
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -29,6 +29,24 @@ internal class ExperienceRenderer(
         }
     }
 
+    suspend fun show(qualifiedExperiences: List<Experience>): Boolean {
+        if (qualifiedExperiences.isEmpty()) {
+            // If given an empty list of qualified experiences, complete with a success because this function has completed without error.
+            // This function only recurses on a non-empty case, so this block only applies to the initial external call.
+            return true
+        }
+
+        val success = show(qualifiedExperiences.first())
+        if (!success) {
+            val remainingExperiences = qualifiedExperiences.drop(1)
+            if (remainingExperiences.isNotEmpty()) {
+                // fallback logic - try the next remaining experience, if available
+                return show(remainingExperiences)
+            }
+        }
+        return success
+    }
+
     suspend fun show(experienceId: String): Boolean {
         if (!sessionMonitor.checkSession("cannot show Experience $experienceId")) return false
 


### PR DESCRIPTION
This one demonstrates why I believe the other changes in the state machine will be useful - being able to detect if an experience fails to load and then try second, third, etc qualified experiences as fallback options if needed.

A simple test, for example - a response qualification with a first item with zero steps, then a second item with a valid experience - the second item will now show, after the first one gives an error internally in the state machine for having zero steps.