### PR TITLE
Move ExpandedBottomSheetModal into correct package name

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -94,3 +94,42 @@ dependencies {
     // Needed for createComposeRule
     androidTestImplementation "androidx.compose.ui:ui-test-manifest:1.1.1"
 }
+
+android.libraryVariants.all { variant ->
+    task "copyDependencies${variant.name.capitalize()}"() {
+        outputs.upToDateWhen { false }
+        doLast {
+            println "Executing copyDependencies${variant.name.capitalize()}"
+            variant.getCompileClasspath().each { fileDependency ->
+                def sourcePath = fileDependency.absolutePath
+                def destinationPath = project.projectDir.path + "/build/dependencies/${variant.name}/"
+                println "Copying dependency:"
+                println sourcePath
+
+                //The monstrous regex that gets the name of the lib from it’s exploded .aar path
+                def dependencyName
+                if (sourcePath.contains("classes.jar")) {
+                    def dependencyNameRegexResult = (sourcePath =~ /.*\/(.*)\.aar\/.*\/jars\/classes\.jar/)
+                    if (dependencyNameRegexResult.size() > 0) {
+                        dependencyName = dependencyNameRegexResult[0][1]
+                        println "Exploded AAR found : ${dependencyName}"
+                    }
+                }
+
+                copy {
+                    from sourcePath
+                    into destinationPath
+
+                    rename {String filename ->
+                        if (filename.contains("classes.jar") && dependencyName != null) {
+                            dependencyName = "${dependencyName}.jar"
+                            println "Renaming dependency file to : ${dependencyName}"
+                            return dependencyName
+                        }
+                        return filename
+                    }
+                }
+            }
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -1,6 +1,5 @@
 package com.appcues.trait.appcues
 
-import ExpandedBottomSheetModal
 import androidx.compose.runtime.Composable
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfigOrDefault
@@ -8,6 +7,7 @@ import com.appcues.data.model.getConfigStyle
 import com.appcues.trait.ContentWrappingTrait
 import com.appcues.ui.modal.BottomSheetModal
 import com.appcues.ui.modal.DialogModal
+import com.appcues.ui.modal.ExpandedBottomSheetModal
 import com.appcues.ui.modal.FullScreenModal
 
 internal class ModalTrait(

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -1,3 +1,5 @@
+package com.appcues.ui.modal
+
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween


### PR DESCRIPTION
Minor thing that popped up during Xamarin binding experiments - this file had no package, should be `com.appcues.ui.modal`.

Also - added the `copyDependencies*` gradle task to the SDK, just a convenience item but can be used to export all the dpenedency .jars to a folder via gradle.  This is handy for Xamarin binding.