### PR TITLE
✨ Added Expanded State for Debugger view

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/debugger/DebuggerFloatingActionButton.kt
+++ b/appcues/src/main/java/com/appcues/ui/debugger/DebuggerFloatingActionButton.kt
@@ -2,6 +2,7 @@ package com.appcues.ui.debugger
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
@@ -34,6 +35,8 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.appcues.R.drawable
 
+private const val FAB_DRAGGING_SIZE_MULTIPLIER = 1.1f
+
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 internal fun BoxScope.DebuggerFloatingActionButton(
@@ -51,10 +54,17 @@ internal fun BoxScope.DebuggerFloatingActionButton(
             .align(Alignment.TopStart)
             .offset { debuggerState.getFabPositionAsIntOffset() }
     ) {
+        val elevation = animateDpAsState(targetValue = if (debuggerState.isDragging.targetState) 8.dp else 4.dp)
+        val size = animateDpAsState(
+            targetValue = if (debuggerState.isDragging.targetState)
+                debuggerState.fabSize.times(FAB_DRAGGING_SIZE_MULTIPLIER)
+            else
+                debuggerState.fabSize
+        )
         Box(
             modifier = Modifier
                 .shadow(
-                    elevation = 8.dp,
+                    elevation = elevation.value,
                     shape = RoundedCornerShape(percent = 100),
                     ambientColor = Color(color = 0xFF5C5CFF),
                     spotColor = Color(color = 0xFF000000)
@@ -77,7 +87,7 @@ internal fun BoxScope.DebuggerFloatingActionButton(
                         }
                     )
                 }
-                .size(size = debuggerState.fabSize)
+                .size(size = size.value)
                 .clip(RoundedCornerShape(percent = 100))
                 .background(
                     brush = Brush.horizontalGradient(

--- a/appcues/src/main/java/com/appcues/ui/debugger/DebuggerOnDrag.kt
+++ b/appcues/src/main/java/com/appcues/ui/debugger/DebuggerOnDrag.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.appcues.R.drawable
 
 @Composable
-internal fun BoxScope.DebuggerOnDragOverlay(
+internal fun BoxScope.DebuggerOnDrag(
     debuggerState: MutableDebuggerState,
     onDismiss: () -> Unit,
 ) {

--- a/appcues/src/main/java/com/appcues/ui/debugger/DebuggerPanel.kt
+++ b/appcues/src/main/java/com/appcues/ui/debugger/DebuggerPanel.kt
@@ -1,0 +1,73 @@
+package com.appcues.ui.debugger
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun BoxScope.DebuggerPanel(debuggerState: MutableDebuggerState) {
+    AnimatedVisibility(
+        visibleState = debuggerState.isExpanded,
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+        Spacer(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(color = 0x30000000))
+        )
+    }
+
+    AnimatedVisibility(
+        visibleState = debuggerState.isExpanded,
+        enter = enterTransition(),
+        exit = exitTransition(),
+        modifier = Modifier.align(Alignment.BottomCenter)
+    ) {
+        Box(
+            modifier = Modifier
+                .shadow(
+                    elevation = 8.dp,
+                    shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+                    ambientColor = Color(color = 0xFF5C5CFF),
+                    spotColor = Color(color = 0xFF000000)
+                )
+                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+                .height(debuggerState.getExpandedContainerHeight())
+                .fillMaxWidth()
+                .background(Color(color = 0xFFFFFFFF)),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            // content of the debugger view will be placed here
+        }
+    }
+}
+
+private fun enterTransition(): EnterTransition {
+    return slideInVertically(tween(durationMillis = 250)) { it }
+}
+
+private fun exitTransition(): ExitTransition {
+    return slideOutVertically(tween(durationMillis = 200)) { it } +
+        fadeOut(tween(durationMillis = 150))
+}

--- a/appcues/src/main/java/com/appcues/ui/debugger/DebuggerViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/debugger/DebuggerViewModel.kt
@@ -56,7 +56,11 @@ internal class DebuggerViewModel(
         _uiState.value = Dismissing
     }
 
-    fun onExpand() {
-        _uiState.value = Expanded
+    fun onFabClick() {
+        if (_uiState.value == Idle) {
+            _uiState.value = Expanded
+        } else if (_uiState.value == Expanded) {
+            _uiState.value = Idle
+        }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/debugger/MutableDebuggerState.kt
+++ b/appcues/src/main/java/com/appcues/ui/debugger/MutableDebuggerState.kt
@@ -20,10 +20,13 @@ internal class MutableDebuggerState(private val density: Density, val fabSize: D
 
         private const val GRID_SCREEN_COUNT = 5
         private const val GRID_FAB_POSITION = 4
+        private val EXPANDED_CONTAINER_TOP_PADDING = 8.dp
     }
 
     val isVisible = MutableTransitionState(false)
     val isDragging = MutableTransitionState(false)
+    val isExpanded = MutableTransitionState(false)
+
     val fabXOffset = mutableStateOf(value = 0f)
     val fabYOffset = mutableStateOf(value = 0f)
 
@@ -88,5 +91,27 @@ internal class MutableDebuggerState(private val density: Density, val fabSize: D
 
     fun getDismissAreaTargetYOffset(): Float {
         return dismissRect.center.y - fabRect.size.height / 2
+    }
+
+    fun getExpandedContainerHeight(): Dp {
+        return with(density) {
+            boxSize.height.toDp() - (fabSize / 2) - EXPANDED_CONTAINER_TOP_PADDING
+        }
+    }
+
+    fun getExpandedFabAnchor(): Offset {
+        return with(density) {
+            Offset((boxSize.width - fabSize.toPx()) / 2, EXPANDED_CONTAINER_TOP_PADDING.toPx())
+        }
+    }
+
+    fun getLastIdleFabAnchor(): Offset {
+        return fabRect.topLeft
+    }
+
+    fun shouldAnimateToIdle(): Boolean {
+        return fabRect.topLeft.let {
+            it.x != fabXOffset.value && it.y != fabYOffset.value
+        }
     }
 }


### PR DESCRIPTION
Added the Expanded state for our debugger.

There is a couple of things missing we need to address.

1. Add Generic properties (API level, time stamp, etc)
2. Add Experience Analytics. tracking through analytics
3. Add a counter on the FAB that notifies whenever a new event was sent that we did not see in the Expanded state
4. Add event floating info on FAB (top or bottom based on Y coordinates of FAB
5. Figure out a way to handle the native back button from android to move the debugger view from Expanded to Idle (we may need to explore other options for inflating the view)
6. Settle on the subject of content, right now if the customers app uses old Toolbar impl we cant draw over that because the way we are inflating our DebuggerView, to fix that (if we wanted to) we need to research a way of doing the inflation of the view in a way its drawing over all screen content (decorView) 