### PR TITLE
Support option to mark flow as complete on close action

### DIFF
--- a/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
@@ -3,6 +3,7 @@ package com.appcues.action.appcues
 import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.getConfigOrDefault
 import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.StateMachine
 
@@ -15,7 +16,9 @@ internal class CloseAction(
         const val TYPE = "@appcues/close"
     }
 
+    private val markComplete = config.getConfigOrDefault("markComplete", false)
+
     override suspend fun execute(appcues: Appcues) {
-        stateMachine.handleAction(EndExperience(false))
+        stateMachine.handleAction(EndExperience(false, markComplete))
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -18,7 +18,6 @@ import com.appcues.statemachine.State.Idling
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.StateMachine
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinScopeComponent
@@ -57,11 +56,12 @@ internal class ExperienceLifecycleTracker(
                         trackLifecycleEvent(StepCompleted(it.experience, it.flatStepIndex))
                     }
                     is EndingExperience -> {
-                        if (it.flatStepIndex == it.experience.flatSteps.count() - 1) {
-                            // if ending on the last step - it was completed
+                        if (it.markComplete || it.flatStepIndex == it.experience.flatSteps.count() - 1) {
+                            // if ending on the last step OR an action requested it be considered complete explicitly,
+                            // track the experience_completed event
                             trackLifecycleEvent(ExperienceCompleted(it.experience))
                         } else {
-                            // otherwise its considered dismissed (not completed)
+                            // otherwise its considered experience_dismissed (not completed)
                             trackLifecycleEvent(ExperienceDismissed(it.experience, it.flatStepIndex))
                         }
                     }

--- a/appcues/src/main/java/com/appcues/statemachine/Action.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Action.kt
@@ -6,7 +6,7 @@ internal sealed class Action {
     data class StartExperience(val experience: Experience) : Action()
     data class StartStep(val stepReference: StepReference) : Action()
     object RenderStep : Action()
-    data class EndExperience(val destroyed: Boolean) : Action()
+    data class EndExperience(val destroyed: Boolean, val markComplete: Boolean = false) : Action()
     object Reset : Action()
     data class ReportError(val error: Error) : Action()
 }

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -16,5 +16,5 @@ internal sealed class State(open val experience: Experience?) {
         val dismissAndContinue: Action?
     ) : State(experience)
 
-    data class EndingExperience(override val experience: Experience, val flatStepIndex: Int) : State(experience)
+    data class EndingExperience(override val experience: Experience, val flatStepIndex: Int, val markComplete: Boolean) : State(experience)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
@@ -82,7 +82,7 @@ internal interface Transitions {
     }
 
     fun EndingStep.fromEndingStepToEndingExperience(action: EndExperience): Transition {
-        return Transition(EndingExperience(experience, flatStepIndex), ContinuationEffect(Reset))
+        return Transition(EndingExperience(experience, flatStepIndex, action.markComplete), ContinuationEffect(Reset))
     }
 
     fun EndingStep.fromEndingStepToBeginningStep(action: StartStep): Transition {


### PR DESCRIPTION
stacks on #94 

pending spec changes noted in https://github.com/appcues/appcues-mobile-experience-spec/pull/33

this adds the ability to override the dismiss/completed analytics logic via the `@appcues/close` action `markComplete` config value.