### PR TITLE
Implement sequential experience action handling

### DIFF
--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -13,12 +13,8 @@ import org.koin.dsl.ScopeDSL
 internal object ActionKoin : KoinScopePlugin {
 
     override fun ScopeDSL.install(config: AppcuesConfig) {
-        scoped {
-            ActionRegistry(
-                scope = get(),
-                logcues = get(),
-            )
-        }
+        scoped { ActionRegistry(scope = get(), logcues = get()) }
+        scoped { ActionProcessor(appcues = get(), appcuesCoroutineScope = get()) }
 
         factory { params ->
             CloseAction(

--- a/appcues/src/main/java/com/appcues/action/ActionProcessor.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionProcessor.kt
@@ -1,0 +1,30 @@
+package com.appcues.action
+
+import com.appcues.Appcues
+import com.appcues.AppcuesCoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+// Responsible for queueing up any ExperienceActions to run in sequential order,
+// to allow for things like closing current experience + launching a new experience, for example.
+internal class ActionProcessor(
+    private val appcues: Appcues,
+    private val appcuesCoroutineScope: AppcuesCoroutineScope,
+) {
+
+    private val actionQueue = Channel<ExperienceAction>(Channel.UNLIMITED)
+
+    init {
+        appcuesCoroutineScope.launch {
+            for (action in actionQueue) {
+                action.execute(appcues)
+            }
+        }
+    }
+
+    fun process(action: ExperienceAction) {
+        appcuesCoroutineScope.launch {
+            actionQueue.send(action)
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
@@ -2,8 +2,8 @@ package com.appcues.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.appcues.Appcues
 import com.appcues.AppcuesCoroutineScope
+import com.appcues.action.ActionProcessor
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.StepContainer
 import com.appcues.statemachine.Action
@@ -35,9 +35,8 @@ internal class AppcuesViewModel(
         data class Dismissing(val continueAction: Action) : UIState()
     }
 
-    val stateMachine by inject<StateMachine>()
-
-    private val appcues by inject<Appcues>()
+    private val stateMachine by inject<StateMachine>()
+    private val actionProcessor by inject<ActionProcessor>()
     private val appcuesCoroutineScope by inject<AppcuesCoroutineScope>()
 
     private val _uiState = MutableStateFlow<UIState>(Idle)
@@ -105,14 +104,7 @@ internal class AppcuesViewModel(
     }
 
     fun onAction(experienceAction: ExperienceAction) {
-        uiState.value.let { state ->
-            // if current state IS Rendering then we process the action
-            if (state is Rendering) {
-                viewModelScope.launch {
-                    experienceAction.execute(appcues)
-                }
-            }
-        }
+        actionProcessor.process(experienceAction)
     }
 
     fun onPageChanged(index: Int) {


### PR DESCRIPTION
Adds a new `ActionProcessor` class, which queues and processes, in sequence, `ExperienceAction` objects triggered by the `AppcuesViewModel` from user interaction.  A Kotlin [Channel](https://kotlinlang.org/docs/channels.html) is used to stream the actions into the handler and process sequentially inside the same coroutine using suspending action functions.

I made a separate class for this and did not lump into the `StateMachine` directly, since this was a sort of related but separate concept.  Often the `ExperienceAction` will end up executing `StateMachine` actions, but it is not required - and either way, the existing suspend function for `StateMachine` actions ensures that the next `ExperienceAction` will not start until the current one completes through the machine.

example here is a button with 4 actions:
* close experience
* deep link to profile tab
* launch another experience
* link to web url


https://user-images.githubusercontent.com/19266448/165341868-5add07c3-f5da-4ca9-a99f-ddef020c31d5.mp4

