### PR TITLE
Add support for GitHub Package Registry publishing

### DIFF
--- a/appcues/publish-maven.gradle
+++ b/appcues/publish-maven.gradle
@@ -65,6 +65,40 @@ afterEvaluate {
                 artifactId = appcuesProperties.getProperty("ARTIFACT_ID") + "-debug"
                 version = appcuesProperties.getProperty("VERSION")
             }
+            gpr(MavenPublication) {
+                from components.release
+
+                // You can then customize attributes of the publication as shown below.
+                groupId = appcuesProperties.getProperty("GROUP_ID")
+                artifactId = appcuesProperties.getProperty("ARTIFACT_ID")
+                version = appcuesProperties.getProperty("VERSION")
+
+                pom {
+                    name = appcuesProperties.getProperty("NAME")
+                    description = appcuesProperties.getProperty("DESCRIPTION")
+                    url = appcuesProperties.getProperty("ORG_URL")
+                    licenses {
+                        license {
+                            name = appcuesProperties.getProperty("LICENSE")
+                            url = appcuesProperties.getProperty("LICENSE_URL")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = appcuesProperties.getProperty("ORG_ID")
+                            name = appcuesProperties.getProperty("ORG_NAME")
+                            organization = appcuesProperties.getProperty("ORG_NAME")
+                            organizationUrl = appcuesProperties.getProperty("ORG_URL")
+                            email = appcuesProperties.getProperty("ORG_EMAIL")
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:git://github.com/' + appcuesProperties.getProperty("GITHUB_PATH") + '.git'
+                        developerConnection = 'scm:git:ssh://github.com:' + appcuesProperties.getProperty("GITHUB_PATH") + '.git'
+                        url = 'https://github.com/' + appcuesProperties.getProperty("GITHUB_PATH")
+                    }
+                }
+            }
         }
         repositories {
             maven {
@@ -73,6 +107,14 @@ afterEvaluate {
                 credentials {
                     username = ossrhUsername
                     password = ossrhPassword
+                }
+            }
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/appcues/appcues-android-sdk")
+                credentials {
+                    username = System.getenv("GPR_USERNAME")
+                    password = System.getenv("GPR_TOKEN")
                 }
             }
         }


### PR DESCRIPTION
This creates a new Gradle task that can be run to push packages to this repo for private hosting, prior to releasing on Maven Central.  We can use this for early beta access I believe.
```
gradle publishReleasePublicationToGitHubPackagesRepository
```

"GPR" is the common acronym for GitHub Package Registry.  You must set env vars for "GPR_USERNAME" - your GitHub user name and "GPR_TOKEN" - a PAT with package access (write to publish, read to use).

initial version published here: https://github.com/appcues/appcues-android-sdk/packages/1386739

to use it, you would add a new `maven` item in the `repositories` Gradle settings like 
```kotlin
dependencyResolutionManagement {
    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
    repositories {
        google()
        mavenCentral()
        maven {
            url = uri("https://maven.pkg.github.com/appcues/appcues-android-sdk")
            credentials {
                username = System.getenv("GPR_USERNAME")
                password = System.getenv("GPR_TOKEN")
            }
        }
    }
}
```

References
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry
https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries