### PR TITLE
Add "_osVersion" auto property with current Android API level

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -56,6 +56,7 @@ internal class AutoPropertyDecorator(
         "_appBuild" to context.getAppBuild().toString(),
         "_sdkVersion" to BuildConfig.SDK_VERSION,
         "_sdkName" to "appcues-android",
+        "_osVersion" to "${VERSION.SDK_INT}",
         "_deviceType" to context.resources.getString(R.string.device_type),
         "_deviceModel" to getDeviceName(),
     )


### PR DESCRIPTION
One-liner, something that might be useful to target against in some cases.  This is a string property, even though its really an Int on Android, since it's a shared user property and we thought it best to keep the type consistent across iOS (where it is a string) and Android.