### PR TITLE
Clarify deployment slack messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "🚀 Android Sample Deployment Successful!",
+                    "text": "🚀 Android Sample App Deployed to Google Play",
                     "emoji": true
                   }
                 }
@@ -198,7 +198,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "🚀 Android SDK Deployment Successful!",
+                    "text": "🚀 Android SDK Deployed to GitHub Package Registry",
                     "emoji": true
                   }
                 }


### PR DESCRIPTION
I'd like to make the messages for sample app deploy or SDK deploy to Github Package Registry a little more clear.