### PR TITLE
Ensure that we fully await the dismiss of an experience before allowing the state machine to continue

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
@@ -1,9 +1,12 @@
 package com.appcues.statemachine
 
 import com.appcues.data.model.Experience
+import com.appcues.util.ResultOf
+import kotlinx.coroutines.CompletableDeferred
 
 internal sealed class SideEffect {
     data class ContinuationEffect(val action: Action) : SideEffect()
     data class PresentContainerEffect(val experience: Experience, val containerIndex: Int) : SideEffect()
     data class ReportErrorEffect(val error: Error) : SideEffect()
+    data class AwaitEffect(val completableDeferred: CompletableDeferred<ResultOf<State, Error>>) : SideEffect()
 }

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -13,8 +13,7 @@ internal sealed class State(open val experience: Experience?) {
         val flatStepIndex: Int,
         // this works as a ContinuationSideEffect that AppcuesViewModel will
         // send to the state machine once it's done dismissing the current container
-        val dismissAndContinue: Action?
+        val dismissAndContinue: (suspend () -> Unit)?
     ) : State(experience)
-
     data class EndingExperience(override val experience: Experience, val flatStepIndex: Int, val markComplete: Boolean) : State(experience)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -10,6 +10,7 @@ import com.appcues.statemachine.Action.Reset
 import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.Action.StartStep
 import com.appcues.statemachine.Error.ExperienceAlreadyActive
+import com.appcues.statemachine.SideEffect.AwaitEffect
 import com.appcues.statemachine.SideEffect.ContinuationEffect
 import com.appcues.statemachine.SideEffect.PresentContainerEffect
 import com.appcues.statemachine.SideEffect.ReportErrorEffect
@@ -104,6 +105,9 @@ internal class StateMachine(
                     // return the success for RenderingState - the resting state of machine
                     Success(updatedState)
                 }
+                is AwaitEffect -> {
+                    sideEffect.completableDeferred.await()
+                }
             }
         } else {
             // if no side effect, return success with current state
@@ -138,8 +142,8 @@ internal class StateMachine(
             // BeginningStep
             state is BeginningStep && action is RenderStep -> state.fromBeginningStepToRenderingStep(action)
             // RenderingStep
-            state is RenderingStep && action is StartStep -> state.fromRenderingStepToEndingStep(action)
-            state is RenderingStep && action is EndExperience -> state.fromRenderingStepToEndingExperience(action)
+            state is RenderingStep && action is StartStep -> state.fromRenderingStepToEndingStep(action, this@StateMachine)
+            state is RenderingStep && action is EndExperience -> state.fromRenderingStepToEndingExperience(action, this@StateMachine)
             // EndingStep
             state is EndingStep && action is EndExperience -> state.fromEndingStepToEndingExperience(action)
             state is EndingStep && action is StartStep -> state.fromEndingStepToBeginningStep(action)


### PR DESCRIPTION
This is a subtle one, but a bug I noticed on a device, then was able to reproduce in the emulator with some artificial delays - it's a race condition.

Essentially, when we execute the EndStep and then ask the AppcuesViewModel to process the dismissal and then notify the StateMachine with a continuation action to move to the next step - we were not awaiting the completion of that dismiss, and thus a subsequent action to launch an experience _could_ hit a race condition where it would not launch due to another experience currently rendering - even though that one was supposed to be closed.

The technique here is to use a [CompletableDeferred](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-completable-deferred/) to allow us to suspend in the StateMachine until that action is executed in the VM.  That way, we can be sure that a close action really is all the way closed before the next action will be allowed to execute.

I ran into this while starting to look into [sc-34082], but that one will build on top of this as it needs to be able to dismiss the current experience, wait on it properly, then show the new experience as part of the event-trigger priority behavior requested.