### PR TITLE
🐛 Fixed bug with content height in HorizontalPager

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
@@ -1,9 +1,19 @@
 package com.appcues.trait
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 
 interface ContentWrappingTrait : ExperienceTrait {
 
+    /**
+     * Create a wrap of the content, the default wrap used by appcues is the modal with different types.
+     *
+     * When creating a custom WrapContent is important to pass [hasFixedHeight] as true if you are defining the height constraint yourself.
+     * or else the SDK will consider the container with the same height as the content we will inflate within
+     *
+     * [contentPadding] is passed from the WrapContent without applying it yourself so we can modify the correct
+     * container in order to keep the vertical scroll nicely at the edge or the container.
+     */
     @Composable
-    fun WrapContent(content: @Composable () -> Unit)
+    fun WrapContent(content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit)
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/CarouselTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/CarouselTrait.kt
@@ -2,18 +2,15 @@ package com.appcues.trait.appcues
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import com.appcues.trait.ContentHolderTrait
 import com.appcues.trait.ContentHolderTrait.ContainerPages
 import com.appcues.ui.AppcuesPaginationData
@@ -22,6 +19,7 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
+import kotlinx.coroutines.flow.drop
 
 internal class CarouselTrait(
     override val config: Map<String, Any>?,
@@ -58,18 +56,32 @@ internal class CarouselTrait(
                 .collect { localPagination.onPageChanged(it) }
         }
 
-        val horizontalPagerSize = remember { HorizontalPagerSize(pagerState) }
+        // this is a workaround a problem that was found with this HorizontalPager
+        // where sometimes the currentPageOffset number is bigger or smaller than the expected range of {-1.0f, 1.0f}
+        LaunchedEffect(pagerState.currentPageOffset) {
+            snapshotFlow { pagerState.currentPageOffset }
+                .drop(1)
+                .collect {
+                    when {
+                        it < -1.0f -> pagerState.scrollToPage(pagerState.currentPage - 1)
+                        it > 1.0f -> pagerState.scrollToPage(pagerState.currentPage + 1)
+                    }
+                }
+        }
 
-        Spacer(
-            modifier = Modifier
-                .matchParentSize()
-                .onSizeChanged { horizontalPagerSize.onContainerFirstSized(it.height) }
-        )
+        val horizontalPagerSize = remember { HorizontalPagerSize(pagerState) }
 
         HorizontalPager(
             modifier = Modifier
-                // changes the size based on HorizontalPagerSize logic
-                .size(with(LocalDensity.current) { horizontalPagerSize.pagerContainerSize.toDp() }),
+                // basically we are measuring the pager layout and if we do have a valid containerHeight we use onGloballyPositioned
+                // else we will go with the measured height from the HorizontalPager until we can calculate the container properly
+                .layout { measurable, constraints ->
+                    val placeable = measurable.measure(constraints)
+                    val containerHeight = horizontalPagerSize.getContainerHeight()
+                    val calculatedHeight = if (containerHeight.isNaN()) placeable.height else containerHeight.toInt()
+
+                    layout(constraints.maxWidth, calculatedHeight) { placeable.place(0, 0) }
+                },
             count = containerPages.pageCount,
             state = pagerState,
             verticalAlignment = Alignment.Top
@@ -88,45 +100,29 @@ internal class CarouselTrait(
 
         val heightMap = mutableStateMapOf<Int, Int>()
 
-        val containerSize = mutableStateOf(0f)
-
-        val pagerContainerSize
-            get() = run {
-                val currentPageSize = heightMap[pagerState.currentPage] ?: 0
-                val nextPageSize = when {
-                    pagerState.currentPageOffset > 0 -> heightMap[pagerState.currentPage + 1] ?: 0
-                    pagerState.currentPageOffset < 0 -> heightMap[pagerState.currentPage - 1] ?: 0
-                    else -> currentPageSize
-                }
-
-                val offsetNormalized = if (pagerState.currentPageOffset < 0)
-                    pagerState.currentPageOffset * -1
-                else
-                    pagerState.currentPageOffset
-
-                val pageSize = (nextPageSize - currentPageSize) * offsetNormalized + currentPageSize
-
-                // if pageSize is nan or zero we return it so does not restrict
-                // the size to whatever value is in containerSize
-                if (pageSize.isNaN() || pageSize == 0f) pageSize
-                // when we do know whats the size of the page and the container size then we
-                // use whatever is bigger value
-                else maxOf(pageSize, containerSize.value)
+        fun getContainerHeight(): Float {
+            val currentPageSize = heightMap[pagerState.currentPage] ?: 0
+            val nextPageSize = when {
+                pagerState.currentPageOffset > 0 -> heightMap[pagerState.currentPage + 1] ?: 0
+                pagerState.currentPageOffset < 0 -> heightMap[pagerState.currentPage - 1] ?: 0
+                else -> currentPageSize
             }
 
-        fun onHeightChanged(index: Int, height: Int) {
-            if (height != 0 && heightMap[index] ?: 0 == 0) {
-                heightMap[index] = height
-            }
+            val offsetNormalized = if (pagerState.currentPageOffset < 0)
+                pagerState.currentPageOffset * -1 else pagerState.currentPageOffset
+
+            val pageSize = (nextPageSize - currentPageSize) * offsetNormalized + currentPageSize
+
+            // if pageSize is nan or zero we return it so does not restrict
+            // the size to whatever value is in containerSize
+            return if (pageSize.isNaN() || pageSize == 0f) Float.NaN
+            // when we do know whats the size of the page and the container size then we
+            // use whatever is bigger value
+            else pageSize
         }
 
-        fun onContainerFirstSized(height: Int) {
-            // set the content Size only once to get whatever size is coming
-            // from parent Box. this is good because if no specific size is
-            // specified we will probably get a very low height.
-            if (containerSize.value == 0f) {
-                containerSize.value = height.toFloat()
-            }
+        fun onHeightChanged(index: Int, height: Int) {
+            heightMap[index] = height
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -1,5 +1,6 @@
 package com.appcues.trait.appcues
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfigOrDefault
@@ -25,7 +26,7 @@ internal class ModalTrait(
     private val style = config.getConfigStyle("style")
 
     @Composable
-    override fun WrapContent(content: @Composable () -> Unit) {
+    override fun WrapContent(content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit) {
         when (presentationStyle) {
             "dialog" -> DialogModal(style, content)
             "full" -> FullScreenModal(style, content)

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -121,7 +122,7 @@ internal class AppcuesActivity : AppCompatActivity() {
                 }
             }
             // create wrapper
-            contentWrappingTrait.WrapContent {
+            contentWrappingTrait.WrapContent { hasFixedHeight, contentPadding ->
                 Box(
                     contentAlignment = Alignment.TopCenter
                 ) {
@@ -135,19 +136,25 @@ internal class AppcuesActivity : AppCompatActivity() {
                                 with(steps[index]) {
                                     CompositionLocalProvider(LocalAppcuesActions provides actions) {
                                         // used to get the padding values from step decorating trait and apply to the Column
-                                        val rememberPadding = rememberStepDecoratingPadding(LocalDensity.current)
+                                        val density = LocalDensity.current
+                                        val stepDecoratingPadding = remember(this) { StepDecoratingPadding(density) }
                                         // Our page content
                                         Column(
                                             horizontalAlignment = Alignment.CenterHorizontally,
                                             modifier = Modifier
+                                                // if WrappingContent has a fixed height we fill height
+                                                // else we will scale according to content
+                                                .then(if (hasFixedHeight) Modifier.fillMaxHeight() else Modifier)
                                                 .verticalScroll(rememberScrollState())
-                                                .padding(paddingValues = rememberPadding.value.toPaddingValues())
+                                                // if we have contentPadding to apply from the WrapContent trait then we apply here
+                                                .then(if (contentPadding != null) Modifier.padding(contentPadding) else Modifier)
+                                                .padding(paddingValues = stepDecoratingPadding.paddingValues.value)
                                         ) {
                                             content.Compose()
                                         }
 
                                         // apply step decorating traits
-                                        traits.forEach { with(it) { Overlay(rememberPadding.value) } }
+                                        traits.forEach { with(it) { Overlay(stepDecoratingPadding) } }
                                     }
                                 }
                             }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesCompositions.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesCompositions.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -100,9 +101,6 @@ fun AppcuesTraitAnimatedVisibility(
     )
 }
 
-@Composable
-internal fun rememberStepDecoratingPadding(density: Density) = remember { mutableStateOf(StepDecoratingPadding(density)) }
-
 class StepDecoratingPadding(private val density: Density) {
 
     private val topPaddingPx = mutableStateOf(0)
@@ -134,8 +132,8 @@ class StepDecoratingPadding(private val density: Density) {
         }
     }
 
-    internal fun toPaddingValues(): PaddingValues {
-        return with(density) {
+    val paddingValues = derivedStateOf {
+        with(density) {
             PaddingValues(
                 start = startPaddingPx.value.toDp(),
                 top = topPaddingPx.value.toDp(),

--- a/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
@@ -68,7 +68,6 @@ internal fun Modifier.modalStyle(
         .then(modifier)
         .styleBorder(style, isDark)
         .styleBackground(style, isDark)
-        .padding(style.getPaddings())
     else Modifier
 )
 

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,10 +21,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.AppcuesTraitAnimatedVisibility
+import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
 
 @Composable
-internal fun BottomSheetModal(style: ComponentStyle?, content: @Composable () -> Unit) {
+internal fun BottomSheetModal(
+    style: ComponentStyle?,
+    content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit
+) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.BottomCenter,
@@ -48,7 +53,7 @@ internal fun BottomSheetModal(style: ComponentStyle?, content: @Composable () ->
                             isDark = isSystemInDarkTheme(),
                             modifier = Modifier.bottomSheetCorner(style),
                         ),
-                    content = content,
+                    content = { content(true, style?.getPaddings()) },
                 )
             }
         }

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -8,7 +8,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Surface
@@ -19,13 +20,17 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.AppcuesTraitAnimatedVisibility
+import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
 import com.appcues.ui.extensions.styleShadow
 
 private const val SCREEN_PADDING = 0.05
 
 @Composable
-internal fun DialogModal(style: ComponentStyle?, content: @Composable () -> Unit) {
+internal fun DialogModal(
+    style: ComponentStyle?,
+    content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit
+) {
     val configuration = LocalConfiguration.current
     val dialogHorizontalMargin = (configuration.screenWidthDp * SCREEN_PADDING).dp
     val dialogVerticalMargin = (configuration.screenHeightDp * SCREEN_PADDING).dp
@@ -37,8 +42,7 @@ internal fun DialogModal(style: ComponentStyle?, content: @Composable () -> Unit
     ) {
         Surface(
             modifier = Modifier
-                // min width and height so it doesn't look weird
-                .defaultMinSize(minWidth = 200.dp, minHeight = 100.dp)
+                .fillMaxWidth()
                 // container padding based on screen size
                 .padding(horizontal = dialogHorizontalMargin, vertical = dialogVerticalMargin)
                 // default modal style modifiers
@@ -49,7 +53,7 @@ internal fun DialogModal(style: ComponentStyle?, content: @Composable () -> Unit
                         .styleShadow(style, isDark)
                         .dialogCorner(style),
                 ),
-            content = content,
+            content = { content(false, style?.getPaddings()) },
         )
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,10 +21,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.AppcuesTraitAnimatedVisibility
+import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
 
 @Composable
-internal fun ExpandedBottomSheetModal(style: ComponentStyle?, content: @Composable () -> Unit) {
+internal fun ExpandedBottomSheetModal(
+    style: ComponentStyle?,
+    content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit
+) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.BottomCenter
@@ -44,7 +49,7 @@ internal fun ExpandedBottomSheetModal(style: ComponentStyle?, content: @Composab
                         isDark = isSystemInDarkTheme(),
                         modifier = Modifier.bottomSheetCorner(style),
                     ),
-                content = content,
+                content = { content(true, style?.getPaddings()) },
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -11,16 +11,21 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.AppcuesTraitAnimatedVisibility
+import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
 
 @Composable
-internal fun FullScreenModal(style: ComponentStyle?, content: @Composable () -> Unit) {
+internal fun FullScreenModal(
+    style: ComponentStyle?,
+    content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit
+) {
     AppcuesTraitAnimatedVisibility(
         enter = enterTransition(),
         exit = exitTransition(),
@@ -34,7 +39,7 @@ internal fun FullScreenModal(style: ComponentStyle?, content: @Composable () -> 
                     style = style,
                     isDark = isSystemInDarkTheme()
                 ),
-            content = content,
+            content = { content(true, style?.getPaddings()) },
         )
     }
 }


### PR DESCRIPTION
This was a fun one.

I was doing some research to fix bug #35084 and I found out that depending on the ordering and different sizes of each page when drawing the HorizontalPager (accompanist library) I was getting inconsistent results and my sizing wasn't working as I intended. 

so after spending some hours working on this I found that there was a problem where if I set the height of the HorizontalPager, the next pages in the scroll would be constraint by that same height, and to fix this I changed the approach and used the Modifier.layout to measure the content and determine which is the better height to use during the layout step.

https://developer.android.com/jetpack/compose/layouts/basics

+plus I actually fixed the bug by adding hasFixedSize and contentPadding to the WrapContent interface.