### PR TITLE
Implement additional requested experience and step analytics properties

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -55,24 +55,28 @@ internal sealed class ExperienceLifecycleEvent(
         get() = event.eventName
 
     val properties: Map<String, Any>
-        get() = hashMapOf<String, Any>(
+        get() = hashMapOf<String, Any?>(
             "experienceId" to experience.id.toString().lowercase(),
             "experienceName" to experience.name,
+            "experienceType" to experience.type,
+            "version" to experience.publishedAt,
             // items in the spec that we are not ready for yet:
             // "version" to experience.version -- not included in response?
             // "localeName" to "", -- add locale values to analytics for localized experiences
             // "localeId" to "", -- add locale values to analytics for localized experiences
         ).apply {
             flatStepIndex?.let {
-                this["stepId"] = experience.flatSteps[it].id.toString()
+                val step = experience.flatSteps[it]
+                this["stepId"] = step.id.toString()
                 // this is required by SDK debugger to know which step and group is currently showing
                 this["stepIndex"] = "${experience.groupLookup[it] ?: 0},${experience.stepIndexLookup[it] ?: 0}"
+                this["stepType"] = step.type
             }
             error?.let {
                 this["message"] = it.message
                 this["errorId"] = it.id.toString()
             }
-        }
+        }.filterValues { it != null }.mapValues { it.value as Any }
 
     private val flatStepIndex: Int?
         get() = when (this) {

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -38,6 +38,8 @@ internal class ExperienceMapper(
             stepContainers = from.steps.mapToStepContainer(from.traits, from.actions),
             published = from.state != "DRAFT", // "DRAFT" is used for experience preview in builder
             priority = priority,
+            type = from.type,
+            publishedAt = from.publishedAt,
         )
     }
 

--- a/appcues/src/main/java/com/appcues/data/mapper/step/StepMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/StepMapper.kt
@@ -29,7 +29,8 @@ internal class StepMapper(
             id = from.id,
             content = stepContentMapper.map(from.content),
             traits = traitsMapper.map(mergedTraits).filterIsInstance(StepDecoratingTrait::class.java),
-            actions = actionsMapper.map(mergedActions)
+            actions = actionsMapper.map(mergedActions),
+            type = from.type,
         )
     }
 }

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -8,6 +8,8 @@ internal data class Experience(
     val stepContainers: List<StepContainer>,
     val published: Boolean,
     val priority: ExperiencePriority,
+    val type: String?,
+    val publishedAt: Long?,
 ) {
 
     // a unique identifier for this instance of the Experience, for comparison purposes, in the

--- a/appcues/src/main/java/com/appcues/data/model/Step.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Step.kt
@@ -7,5 +7,6 @@ internal data class Step(
     val id: UUID,
     val content: ExperiencePrimitive,
     val traits: List<StepDecoratingTrait>,
-    val actions: Map<UUID, List<Action>>
+    val actions: Map<UUID, List<Action>>,
+    val type: String?,
 )

--- a/appcues/src/main/java/com/appcues/data/remote/adapters/StepContainerAdapter.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/adapters/StepContainerAdapter.kt
@@ -17,7 +17,8 @@ internal data class StepOrContainerResponse(
     val children: List<StepResponse>?,
     val content: StepContentResponse?,
     val traits: List<TraitResponse>,
-    val actions: Map<UUID, List<ActionResponse>>
+    val actions: Map<UUID, List<ActionResponse>>,
+    val type: String?,
 )
 
 internal class StepContainerAdapter {
@@ -28,7 +29,15 @@ internal class StepContainerAdapter {
             stepOrContainer.content != null ->
                 StepContainerResponse(
                     id = UUID.randomUUID(),
-                    children = arrayListOf(StepResponse(stepOrContainer.id, stepOrContainer.content, listOf(), hashMapOf())),
+                    children = arrayListOf(
+                        StepResponse(
+                            id = stepOrContainer.id,
+                            content = stepOrContainer.content,
+                            traits = listOf(),
+                            actions = hashMapOf(),
+                            type = stepOrContainer.type,
+                        )
+                    ),
                     traits = stepOrContainer.traits,
                     actions = stepOrContainer.actions,
                 )

--- a/appcues/src/main/java/com/appcues/data/remote/response/experience/ExperienceResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/experience/ExperienceResponse.kt
@@ -15,4 +15,6 @@ internal data class ExperienceResponse(
     val traits: List<TraitResponse>,
     val steps: List<StepContainerResponse>,
     val state: String?,
+    val type: String?,
+    val publishedAt: Long?,
 )

--- a/appcues/src/main/java/com/appcues/data/remote/response/step/StepResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/step/StepResponse.kt
@@ -10,5 +10,6 @@ internal data class StepResponse(
     val id: UUID,
     val content: StepContentResponse,
     val traits: List<TraitResponse>,
-    val actions: Map<UUID, List<ActionResponse>>
+    val actions: Map<UUID, List<ActionResponse>>,
+    val type: String?,
 )

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
@@ -18,6 +18,8 @@ import java.util.UUID
 internal val contentModalOneStubs = ExperienceResponse(
     id = UUID.fromString("9f4baa80-8f6a-41b1-a7b9-979da5c175e2"),
     state = "PUBLISHED",
+    type = "mobile",
+    publishedAt = 1643221968554,
     name = "POC Modal One",
     theme = null,
     actions = null,
@@ -28,6 +30,7 @@ internal val contentModalOneStubs = ExperienceResponse(
             children = arrayListOf(
                 StepResponse(
                     id = UUID.fromString("68c0d4b4-4909-4d4a-9ce4-7af8b04efab2"),
+                    type = "modal",
                     content = StepContentResponse(
                         id = UUID.fromString("2cf7dbf7-c6be-4130-b642-85861f9c6b6a"),
                         type = "stack",

--- a/appcues/src/test/resources/content/content_modal_one.json
+++ b/appcues/src/test/resources/content/content_modal_one.json
@@ -49,6 +49,7 @@
         {
           "id": "68c0d4b4-4909-4d4a-9ce4-7af8b04efab2",
           "parentId": "6c2b7488-309c-432f-b62e-9f8539b46c9d",
+          "type": "modal",
           "contentType": "application/json",
           "content": {
             "type": "stack",
@@ -222,7 +223,7 @@
     }
   ],
   "traits": [],
-  "type": "experience",
+  "type": "mobile",
   "updatedAt": 1643221968568,
   "updatedBy": "dae301f0-bd74-4f75-8db2-8ab12f9930ac"
 }


### PR DESCRIPTION
* adds `experienceType` from experience `type` in response on all experience and step events
* adds `stepType` from step `type` in response (child step not group) for all step events
* adds `version` from experience `publishedAt` in response on all experience and step events

Matt has graciously offered to update the spec / examples as part of iOS side of this.