### PR TITLE
Update Compose 1.2.0-beta01 and some other dependencies

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -45,7 +45,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.1.0-rc01"
+        kotlinCompilerExtensionVersion = "1.2.0-beta01"
     }
 
     packagingOptions {
@@ -63,14 +63,14 @@ android {
 dependencies {
     // Androidx
     implementation "androidx.core:core-ktx:1.7.0"
-    implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation 'androidx.activity:activity-compose:1.5.0-rc01'
     implementation "androidx.browser:browser:1.4.0"
-    implementation "androidx.compose.ui:ui:1.1.1"
-    implementation "androidx.compose.ui:ui-tooling:1.1.1"
-    implementation "androidx.compose.material:material:1.1.1"
-    implementation "androidx.navigation:navigation-compose:2.4.2"
-    implementation "com.google.android.material:material:1.5.0"
-    implementation 'android.arch.lifecycle:extensions:1.1.1'
+    implementation "androidx.compose.ui:ui:1.2.0-beta01"
+    implementation "androidx.compose.ui:ui-tooling:1.2.0-beta01"
+    implementation "androidx.compose.material:material:1.2.0-beta01"
+    implementation "androidx.navigation:navigation-compose:2.5.0-rc01"
+    implementation "com.google.android.material:material:1.6.0"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.room:room-runtime:2.4.2"
     implementation "androidx.room:room-ktx:2.4.2"
     kapt "androidx.room:room-compiler:2.4.2"
@@ -88,11 +88,11 @@ dependencies {
     implementation "io.insert-koin:koin-core:3.1.4"
     implementation "io.insert-koin:koin-android:3.1.4"
     // View Pager
-    implementation "com.google.accompanist:accompanist-pager:0.23.1"
+    implementation "com.google.accompanist:accompanist-pager:0.24.8-beta"
     // Webview
-    implementation "com.google.accompanist:accompanist-webview:0.24.5-alpha"
+    implementation "com.google.accompanist:accompanist-webview:0.24.8-beta"
     // Navigation Animated
-    implementation "com.google.accompanist:accompanist-navigation-animation:0.23.1"
+    implementation "com.google.accompanist:accompanist-navigation-animation:0.24.8-beta"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"

--- a/appcues/src/main/java/com/appcues/ui/AppcuesViewModelFactory.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesViewModelFactory.kt
@@ -9,7 +9,7 @@ internal class AppcuesViewModelFactory(
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return AppcuesViewModel(scope) as T
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0"
+        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
         classpath "com.karumi:shot:5.13.0"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Dec 28 10:03:27 BRT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updated to 1.2.0-beta01 that was just released around I/O, also used `gradle appcues:dependencies --scan` to examine other dependency resolution in the project, which led to a few other updates to make our dependencies explicit.

also
* update to kotlin 1.6.21
* gradle 7.2
* I'm now on Android Studio Chipmunk 2021.2.1 which _may_ be required for the Gradle update? I'm not positive.

There is a Coil 2.0 update out that we should look into separately I think. It likely requires some code changes https://coil-kt.github.io/coil/changelog/

These kinds of things can cause complications with the Xamarin bindings, but considering that a lower priority at this point.