### PR TITLE
Fix debugger font page background color and nav stack state restoration

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
@@ -37,7 +37,7 @@ internal fun DebuggerComposition(viewModel: DebuggerViewModel, onDismiss: () -> 
     val debuggerState by remember { mutableStateOf(MutableDebuggerState(density, viewModel.uiState.value == Creating)) }
 
     // listening for lifecycle changes to update isPaused properly
-    LocalLifecycleOwner.current.lifecycle.observeAsSate().let {
+    LocalLifecycleOwner.current.lifecycle.observeAsState().let {
         debuggerState.isPaused.value = it.value == Event.ON_PAUSE
     }
 
@@ -239,15 +239,15 @@ private fun CoroutineScope.animateFabToDismiss(
 }
 
 @Composable
-private fun Lifecycle.observeAsSate(): MutableState<Event> {
+private fun Lifecycle.observeAsState(): MutableState<Event> {
     val state = remember { mutableStateOf(ON_ANY) }
     DisposableEffect(this) {
         val observer = LifecycleEventObserver { _, event ->
             state.value = event
         }
-        this@observeAsSate.addObserver(observer)
+        this@observeAsState.addObserver(observer)
         onDispose {
-            this@observeAsSate.removeObserver(observer)
+            this@observeAsState.removeObserver(observer)
         }
     }
     return state

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerPanel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerPanel.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import com.appcues.R
 import com.appcues.debugger.DebuggerViewModel
 import com.appcues.debugger.model.DebuggerEventItem
@@ -52,7 +53,13 @@ private const val SLIDE_TRANSITION_MILLIS = 250
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 internal fun BoxScope.DebuggerPanel(debuggerState: MutableDebuggerState, debuggerViewModel: DebuggerViewModel) {
+    val navController = rememberAnimatedNavController()
+    val selectedEvent = remember { mutableStateOf<DebuggerEventItem?>(null) }
+
     // don't show if current debugger is paused
+    // IMPORTANT: any "remember" calls (like above) that affect the content of the expanded debugger pane, or subpages,
+    // need to happen before this short-circuit return is executed, otherwise state will not be properly retained
+    // on background/foreground
     if (debuggerState.isPaused.value) return
 
     // deeplink (if applicable) is used once, then reset
@@ -87,16 +94,19 @@ internal fun BoxScope.DebuggerPanel(debuggerState: MutableDebuggerState, debugge
                 .clickable(enabled = false, onClickLabel = null) {},
             contentAlignment = Alignment.TopCenter
         ) {
-            DebuggerPanelPages(debuggerViewModel, deeplinkPath)
+            DebuggerPanelPages(navController, selectedEvent, debuggerViewModel, deeplinkPath)
         }
     }
 }
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
-private fun BoxScope.DebuggerPanelPages(debuggerViewModel: DebuggerViewModel, deeplinkPath: String?) {
-    val navController = rememberAnimatedNavController()
-    val selectedEvent = remember { mutableStateOf<DebuggerEventItem?>(null) }
+private fun BoxScope.DebuggerPanelPages(
+    navController: NavHostController,
+    selectedEvent: MutableState<DebuggerEventItem?>,
+    debuggerViewModel: DebuggerViewModel,
+    deeplinkPath: String?
+) {
     val mainPage = "main"
     val eventDetailsPage = "event_details"
     val fontDetailsPage = "font_details"

--- a/appcues/src/main/java/com/appcues/debugger/ui/details/DebuggerEventDetails.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/details/DebuggerEventDetails.kt
@@ -51,6 +51,7 @@ internal fun DebuggerEventDetails(debuggerEventItem: DebuggerEventItem?, onBackP
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
+            .background(AppcuesColors.DebuggerBackground)
             .lazyColumnScrollIndicator(lazyListState),
         state = lazyListState
     ) {

--- a/appcues/src/main/java/com/appcues/debugger/ui/fonts/DebuggerFontDetails.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/fonts/DebuggerFontDetails.kt
@@ -54,6 +54,7 @@ internal fun DebuggerFontDetails(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
+            .background(AppcuesColors.DebuggerBackground)
             .lazyColumnScrollIndicator(lazyListState),
         state = lazyListState
     ) {

--- a/appcues/src/main/java/com/appcues/ui/theme/AppcuesColors.kt
+++ b/appcues/src/main/java/com/appcues/ui/theme/AppcuesColors.kt
@@ -11,6 +11,7 @@ internal object AppcuesColors {
     val PurpleLuna = Color(color = 0xFFEEEEFF)
     val OceanNight = Color(color = 0xFF627293)
     val Infinity = Color(color = 0xFF242A35)
+    val DebuggerBackground = Color.White
     val DebuggerBackdrop = Color(color = 0x54000000)
     val DebuggerDismissArea = Color(color = 0x20000000)
     val SharkbaitOhAh = Color(color = 0xFF627293)


### PR DESCRIPTION
fix a couple issues from testing

* The previous page was bleeding through during the navigation transition (fonts or events) since sub-pages did not have a background color set, transparent - so updated all to be consistent
* The nav stack state was not properly being remembered due to some short-circuit logic in the composition tree - reworked this to ensure a background/foreground will land you back on the page you were on - thanks @andretortolano for the tip on this one.