### PR TITLE
Fix issue with Debugger deeplink to Font page

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
@@ -121,6 +121,8 @@ internal class DebuggerViewModel(
             Creating -> this.deeplinkPath = deeplinkPath
             // if currently idle and a new link comes in - expand to that link
             Idle -> _uiState.value = Expanded(deeplinkPath)
+            // currently open - reset to the new path
+            is Expanded -> _uiState.value = Expanded(deeplinkPath)
             // otherwise, no valid link action available
             else -> Unit
         }
@@ -191,5 +193,10 @@ internal class DebuggerViewModel(
 
     private fun List<DebuggerEventItem>.hideEventsForFab(): List<DebuggerEventItem> {
         return toMutableList().onEach { it.showOnFab = false }
+    }
+
+    fun onDetailDismiss() {
+        // reset the view state to remove any deeplink path
+        _uiState.value = Expanded()
     }
 }


### PR DESCRIPTION
Found two issues in recent testing

1. Something changed in the composition flow that broke the link to fonts page - this might have been in the compose beta02 update? basically: one composition pass would run and have the deeplink value and navigate to it but wipe out the value (DebuggerPanel) - then another pass would run and reset the state to the main page
2. Deeplink to font page, then back out, then deeplink to font page again - would not work - it was treating it as no actual change in UIState

overall, it feels like the way we are maintaining and passing this state around is a bit fragile? maybe we can improve more deeply. I took a small fix approach here since it's the Debugger and lower priority than core SDK code. comments on fixes within code...