### PR TITLE
Unit tests for Actions package

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -7,6 +7,7 @@ import com.appcues.logging.Logcues
 import com.appcues.statemachine.StateMachine
 import com.appcues.ui.ExperienceRenderer
 import com.appcues.util.ContextResources
+import com.appcues.util.LinkOpener
 import org.koin.dsl.ScopeDSL
 
 internal object AppcuesKoin : KoinScopePlugin {
@@ -47,5 +48,6 @@ internal object AppcuesKoin : KoinScopePlugin {
                 logcues = get()
             )
         }
+        scoped { LinkOpener(get()) }
     }
 }

--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -25,7 +25,7 @@ internal object ActionKoin : KoinScopePlugin {
         factory { params ->
             LinkAction(
                 config = params.getOrNull(),
-                context = get(),
+                linkOpener = get(),
             )
         }
 

--- a/appcues/src/main/java/com/appcues/action/appcues/LinkAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/LinkAction.kt
@@ -1,18 +1,16 @@
 package com.appcues.action.appcues
 
-import android.content.Context
-import android.content.Intent
 import android.net.Uri
-import androidx.browser.customtabs.CustomTabsIntent
 import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfig
 import com.appcues.data.model.getConfigOrDefault
+import com.appcues.util.LinkOpener
 
 internal class LinkAction(
     override val config: AppcuesConfigMap,
-    private val context: Context,
+    private val linkOpener: LinkOpener,
 ) : ExperienceAction {
 
     companion object {
@@ -30,30 +28,13 @@ internal class LinkAction(
             if (scheme != null) {
                 // only HTTP or HTTPS URLs are eligible for Chrome Custom Tabs in-app browser
                 if (!openExternally && (scheme == "http" || scheme == "https")) {
-                    openCustomTabs(uri)
+                    linkOpener.openCustomTabs(uri)
                 } else {
                     // this will handle any in-app deep link scheme URLs OR any web urls that were
                     // requested to open into the external browser application
-                    startNewIntent(uri)
+                    linkOpener.startNewIntent(uri)
                 }
             }
-        }
-    }
-
-    private fun startNewIntent(uri: Uri) {
-        Intent(Intent.ACTION_VIEW).apply {
-            data = uri
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }.also {
-            context.startActivity(it)
-        }
-    }
-
-    private fun openCustomTabs(uri: Uri) {
-        CustomTabsIntent.Builder().build().apply {
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }.also {
-            it.launchUrl(context, uri)
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/data/model/ModelExtensions.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ModelExtensions.kt
@@ -32,7 +32,11 @@ internal fun AppcuesConfigMap.getConfigInt(key: String): Int? {
     if (this == null) return null
     // get value by key as Int?
     return get(key)?.let {
-        if (it is Double) it.toInt() else null
+        when (it) {
+            is Double -> it.toInt()
+            is Int -> it
+            else -> null
+        }
     }
 }
 

--- a/appcues/src/main/java/com/appcues/util/LinkOpener.kt
+++ b/appcues/src/main/java/com/appcues/util/LinkOpener.kt
@@ -1,0 +1,26 @@
+package com.appcues.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+
+internal class LinkOpener(private var context: Context) {
+
+    fun startNewIntent(uri: Uri) {
+        Intent(Intent.ACTION_VIEW).apply {
+            data = uri
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }.also {
+            context.startActivity(it)
+        }
+    }
+
+    fun openCustomTabs(uri: Uri) {
+        CustomTabsIntent.Builder().build().apply {
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }.also {
+            it.launchUrl(context, uri)
+        }
+    }
+}

--- a/appcues/src/test/java/com/appcues/AppcuesKoinTestRule.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesKoinTestRule.kt
@@ -6,8 +6,10 @@ import com.appcues.analytics.AnalyticsTracker
 import com.appcues.debugger.AppcuesDebuggerManager
 import com.appcues.logging.Logcues
 import com.appcues.mocks.storageMockk
+import com.appcues.statemachine.StateMachine
 import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
+import com.appcues.util.LinkOpener
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,6 +50,7 @@ class AppcuesKoinTestRule : TestWatcher() {
                     scope(named(scope.id)) {
                         scoped { AppcuesConfig("00000", "123") }
                         scoped { scope }
+                        scoped { AppcuesCoroutineScope(get()) }
                         scoped { mockk<AnalyticsTracker>(relaxed = true) }
                         scoped { mockk<SessionMonitor>(relaxed = true) }
                         scoped { mockk<Logcues>(relaxed = true) }
@@ -57,9 +60,10 @@ class AppcuesKoinTestRule : TestWatcher() {
                         scoped { mockk<TraitRegistry>(relaxed = true) }
                         scoped { mockk<ActionRegistry>(relaxed = true) }
                         scoped { mockk<DeeplinkHandler>(relaxed = true) }
-                        scoped { AppcuesCoroutineScope(get()) }
+                        scoped { mockk<StateMachine>(relaxed = true) }
+                        scoped { mockk<LinkOpener>(relaxed = true) }
                         scoped { storageMockk() }
-                        scoped { Appcues(scope) }
+                        scoped { mockk<Appcues>(relaxed = true) }
                     }
                 }
             )

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -34,7 +34,7 @@ internal class AppcuesTest : AppcuesScopeTest {
 
     @Before
     fun setUp() {
-        appcues = get()
+        appcues = Appcues(get())
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/action/ActionRegistryTest.kt
+++ b/appcues/src/test/java/com/appcues/action/ActionRegistryTest.kt
@@ -1,0 +1,54 @@
+package com.appcues.action
+
+import com.appcues.AppcuesKoinTestRule
+import com.appcues.AppcuesScopeTest
+import com.appcues.logging.Logcues
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.component.get
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ActionRegistryTest : AppcuesScopeTest {
+
+    @get:Rule
+    override val koinTestRule = AppcuesKoinTestRule()
+
+    @Test
+    fun `get SHOULD return registered ExperienceAction`() {
+        // GIVEN
+        val type = "myAction"
+        val action: ExperienceAction = mockk()
+        val registry = ActionRegistry(get(), get())
+        registry.register(type) { action }
+
+        // WHEN
+        val actionFromRegistry = registry[type]?.invoke(null)
+
+        // THEN
+        assertThat(action).isEqualTo(actionFromRegistry)
+    }
+
+    @Test
+    fun `duplicate registration SHOULD log an error and leave existing`() {
+        // GIVEN
+        val type = "myAction"
+        val action: ExperienceAction = mockk()
+        val actionDupe: ExperienceAction = mockk()
+        val registry = ActionRegistry(get(), get())
+        val logcues: Logcues = get()
+        registry.register(type) { action }
+        registry.register(type) { actionDupe }
+
+        // WHEN
+        val actionFromRegistry = registry[type]?.invoke(null)
+
+        // THEN
+        assertThat(action).isEqualTo(actionFromRegistry)
+        assertThat(action).isNotEqualTo(actionDupe)
+        verify { logcues.error(exception = any()) }
+    }
+}

--- a/appcues/src/test/java/com/appcues/action/appcues/CloseActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/CloseActionTest.kt
@@ -1,0 +1,51 @@
+package com.appcues.action.appcues
+
+import com.appcues.AppcuesKoinTestRule
+import com.appcues.AppcuesScopeTest
+import com.appcues.statemachine.Action.EndExperience
+import com.appcues.statemachine.StateMachine
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.component.get
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class CloseActionTest : AppcuesScopeTest {
+
+    @get:Rule
+    override val koinTestRule = AppcuesKoinTestRule()
+
+    @Test
+    fun `close SHOULD have expected type name`() {
+        assertThat(CloseAction.TYPE).isEqualTo("@appcues/close")
+    }
+
+    @Test
+    fun `close SHOULD trigger StateMachine EndExperience action`() = runTest {
+        // GIVEN
+        val stateMachine: StateMachine = get()
+        val action = CloseAction(mapOf(), stateMachine)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        coVerify { stateMachine.handleAction(EndExperience(destroyed = false, markComplete = false)) }
+    }
+
+    @Test
+    fun `close SHOULD trigger StateMachine EndExperience action with markComplete true WHEN config is true`() = runTest {
+        // GIVEN
+        val stateMachine: StateMachine = get()
+        val action = CloseAction(mapOf("markComplete" to true), stateMachine)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        coVerify { stateMachine.handleAction(EndExperience(destroyed = false, markComplete = true)) }
+    }
+}

--- a/appcues/src/test/java/com/appcues/action/appcues/ContinueActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/ContinueActionTest.kt
@@ -1,0 +1,82 @@
+package com.appcues.action.appcues
+
+import com.appcues.AppcuesKoinTestRule
+import com.appcues.AppcuesScopeTest
+import com.appcues.statemachine.Action.StartStep
+import com.appcues.statemachine.StateMachine
+import com.appcues.statemachine.StepReference.StepId
+import com.appcues.statemachine.StepReference.StepIndex
+import com.appcues.statemachine.StepReference.StepOffset
+import com.google.common.truth.Truth
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.component.get
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ContinueActionTest : AppcuesScopeTest {
+
+    @get:Rule
+    override val koinTestRule = AppcuesKoinTestRule()
+
+    @Test
+    fun `continue SHOULD have expected type name`() {
+        Truth.assertThat(ContinueAction.TYPE).isEqualTo("@appcues/continue")
+    }
+
+    @Test
+    fun `continue SHOULD trigger StateMachine StartStep with index WHEN config has index`() = runTest {
+        // GIVEN
+        val stateMachine: StateMachine = get()
+        val action = ContinueAction(mapOf("index" to 1), stateMachine)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        coVerify { stateMachine.handleAction(StartStep(StepIndex(1))) }
+    }
+
+    @Test
+    fun `continue SHOULD trigger StateMachine StartStep with offset WHEN config has offset`() = runTest {
+        // GIVEN
+        val stateMachine: StateMachine = get()
+        val action = ContinueAction(mapOf("offset" to -1), stateMachine)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        coVerify { stateMachine.handleAction(StartStep(StepOffset(-1))) }
+    }
+
+    @Test
+    fun `continue SHOULD trigger StateMachine StartStep with step id WHEN config has step id`() = runTest {
+        // GIVEN
+        val stepId = UUID.randomUUID()
+        val stateMachine: StateMachine = get()
+        val action = ContinueAction(mapOf("stepID" to stepId.toString()), stateMachine)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        coVerify { stateMachine.handleAction(StartStep(StepId(stepId))) }
+    }
+
+    @Test
+    fun `continue SHOULD trigger StateMachine StartStep with offset 1 by default`() = runTest {
+        // GIVEN
+        val stateMachine: StateMachine = get()
+        val action = ContinueAction(mapOf(), stateMachine)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        coVerify { stateMachine.handleAction(StartStep(StepOffset(1))) }
+    }
+}

--- a/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
@@ -1,0 +1,53 @@
+package com.appcues.action.appcues
+
+import com.appcues.Appcues
+import com.appcues.AppcuesKoinTestRule
+import com.appcues.AppcuesScopeTest
+import com.google.common.truth.Truth
+import io.mockk.Called
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.component.get
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class LaunchExperienceActionTest : AppcuesScopeTest {
+
+    @get:Rule
+    override val koinTestRule = AppcuesKoinTestRule()
+
+    @Test
+    fun `launch experience SHOULD have expected type name`() {
+        Truth.assertThat(LaunchExperienceAction.TYPE).isEqualTo("@appcues/launch-experience")
+    }
+
+    @Test
+    fun `launch experience SHOULD trigger Appcues show with experience ID`() = runTest {
+        // GIVEN
+        val experienceId: String = UUID.randomUUID().toString()
+        val appcues: Appcues = get()
+        val action = LaunchExperienceAction(mapOf("experienceID" to experienceId))
+
+        // WHEN
+        action.execute(appcues)
+
+        // THEN
+        coVerify { appcues.show(experienceId) }
+    }
+
+    @Test
+    fun `launch experience SHOULD NOT trigger Appcues show WHEN no experience ID is in config`() = runTest {
+        // GIVEN
+        val appcues: Appcues = get()
+        val action = LaunchExperienceAction(mapOf())
+
+        // WHEN
+        action.execute(appcues)
+
+        // THEN
+        coVerify { appcues wasNot Called }
+    }
+}

--- a/appcues/src/test/java/com/appcues/action/appcues/LinkActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/LinkActionTest.kt
@@ -1,0 +1,87 @@
+package com.appcues.action.appcues
+
+import android.net.Uri
+import com.appcues.AppcuesKoinTestRule
+import com.appcues.AppcuesScopeTest
+import com.appcues.util.LinkOpener
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.component.get
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class LinkActionTest : AppcuesScopeTest {
+
+    @get:Rule
+    override val koinTestRule = AppcuesKoinTestRule()
+
+    @Before
+    fun setUp() {
+        // mocking of android.net.Uri is required https://stackoverflow.com/a/63890812
+        val mockWebUri = mockk<Uri>(relaxed = true) {
+            every { this@mockk.toString() } returns "https://test/path"
+            every { this@mockk.scheme } returns "https"
+        }
+        val mockAppSchemeUri = mockk<Uri>(relaxed = true) {
+            every { this@mockk.toString() } returns "myapp://test/path"
+            every { this@mockk.scheme } returns "myapp"
+        }
+        mockkStatic(Uri::class)
+        every { Uri.parse("https://test/path") } returns mockWebUri
+        every { Uri.parse("myapp://test/path") } returns mockAppSchemeUri
+    }
+
+    @Test
+    fun `link SHOULD have expected type name`() {
+        assertThat(LinkAction.TYPE).isEqualTo("@appcues/link")
+    }
+
+    @Test
+    fun `link SHOULD call LinkOpener startNewIntent for external web link`() = runTest {
+        // GIVEN
+        val uri: Uri = Uri.parse("https://test/path")
+        val linkOpener: LinkOpener = get()
+        val action = LinkAction(mapOf("url" to uri.toString(), "openExternally" to true), linkOpener)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        verify { linkOpener.startNewIntent(uri) }
+    }
+
+    @Test
+    fun `link SHOULD call LinkOpener openCustomTabs by default for web link`() = runTest {
+        // GIVEN
+        val uri: Uri = Uri.parse("https://test/path")
+        val linkOpener: LinkOpener = get()
+        val action = LinkAction(mapOf("url" to uri.toString()), linkOpener)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        verify { linkOpener.openCustomTabs(uri) }
+    }
+
+    @Test
+    fun `link SHOULD call LinkOpener startNewIntent for app scheme link`() = runTest {
+        // GIVEN
+        val uri: Uri = Uri.parse("myapp://test/path")
+        val linkOpener: LinkOpener = get()
+        val action = LinkAction(mapOf("url" to uri.toString()), linkOpener)
+
+        // WHEN
+        action.execute(get())
+
+        // THEN
+        verify { linkOpener.startNewIntent(uri) }
+    }
+}

--- a/appcues/src/test/java/com/appcues/action/appcues/TrackEventActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/TrackEventActionTest.kt
@@ -1,0 +1,52 @@
+package com.appcues.action.appcues
+
+import com.appcues.Appcues
+import com.appcues.AppcuesKoinTestRule
+import com.appcues.AppcuesScopeTest
+import com.google.common.truth.Truth.assertThat
+import io.mockk.Called
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.component.get
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class TrackEventActionTest : AppcuesScopeTest {
+
+    @get:Rule
+    override val koinTestRule = AppcuesKoinTestRule()
+
+    @Test
+    fun `tracke event SHOULD have expected type name`() {
+        assertThat(TrackEventAction.TYPE).isEqualTo("@appcues/track")
+    }
+
+    @Test
+    fun `track event SHOULD trigger Appcues track with event`() = runTest {
+        // GIVEN
+        val event = "track_event"
+        val appcues: Appcues = get()
+        val action = TrackEventAction(mapOf("eventName" to event))
+
+        // WHEN
+        action.execute(appcues)
+
+        // THEN
+        coVerify { appcues.track(event) }
+    }
+
+    @Test
+    fun `track event SHOULD NOT trigger Appcues track WHEN no eventName is in config`() = runTest {
+        // GIVEN
+        val appcues: Appcues = get()
+        val action = TrackEventAction(mapOf())
+
+        // WHEN
+        action.execute(appcues)
+
+        // THEN
+        coVerify { appcues wasNot Called }
+    }
+}

--- a/appcues/src/test/java/com/appcues/action/appcues/UpdateProfileActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/UpdateProfileActionTest.kt
@@ -1,0 +1,56 @@
+package com.appcues.action.appcues
+
+import com.appcues.Appcues
+import com.appcues.AppcuesKoinTestRule
+import com.appcues.AppcuesScopeTest
+import com.appcues.Storage
+import com.google.common.truth.Truth.assertThat
+import io.mockk.Called
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.component.get
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class UpdateProfileActionTest : AppcuesScopeTest {
+
+    @get:Rule
+    override val koinTestRule = AppcuesKoinTestRule()
+
+    @Test
+    fun `update profile SHOULD have expected type name`() {
+        assertThat(UpdateProfileAction.TYPE).isEqualTo("@appcues/update-profile")
+    }
+
+    @Test
+    fun `update profile SHOULD trigger Appcues identify with properties`() = runTest {
+        // GIVEN
+        val appcues: Appcues = get()
+        val storage: Storage = get()
+        val userId = "test-user"
+        storage.userId = userId
+        val properties = mapOf("prop1" to 2, "prop2" to "ok")
+        val action = UpdateProfileAction(properties, storage)
+
+        // WHEN
+        action.execute(appcues)
+
+        // THEN
+        coVerify { appcues.identify(userId, properties) }
+    }
+
+    @Test
+    fun `update profile SHOULD NOT trigger Appcues identify WHEN no props are in config`() = runTest {
+        // GIVEN
+        val appcues: Appcues = get()
+        val action = UpdateProfileAction(null, get())
+
+        // WHEN
+        action.execute(appcues)
+
+        // THEN
+        coVerify { appcues wasNot Called }
+    }
+}


### PR DESCRIPTION
Mostly straightforward tests of our ActionRegistry and built in ExperienceAction types - no real issues found.  Couple notes

* similar to iOS, extracted a `LinkOpener` class to make the LinkAction more testable and decouple from the link handling implementation on Android platform code
* updated the code that gets Int values from config blocks to allow Double or Int as the raw type