### PR TITLE
Add jacoco coverage report generation and CI integration with codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ orbs:
   android: circleci/android@2.0.3
   aws-s3: circleci/aws-s3@3.0
   jq: circleci/jq@2.2.0
+  codecov: codecov/codecov@3.1.1
 
 # -------------------------
 #        REFERENCES
@@ -185,6 +186,11 @@ jobs:
       - run:
           name: Deploy SDK to GitHub Package Registry
           command: bundle exec fastlane deploy_github_package
+      - run:
+          name: Generate code coverage report
+          command: bundle exec fastlane code_coverage
+      - codecov/upload:
+          file: "./appcues/build/reports/jacoco/debugUnitTestCoverage/debugUnitTestCoverage.xml"
       - run:
           # some ideas from https://discuss.circleci.com/t/leveraging-circleci-api-to-include-build-logs-in-slack-notifications/39111
           name: Get changelog

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 apply from: 'publish-maven.gradle'
 apply from: 'copy-dependencies.gradle'
+apply from: 'codecov.gradle'
 
 android {
     compileSdk 31
@@ -24,9 +25,15 @@ android {
     resourcePrefix 'appcues_'
 
     buildTypes {
+        debug {
+            debuggable true
+            minifyEnabled false
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            testCoverageEnabled true
         }
     }
 

--- a/appcues/codecov.gradle
+++ b/appcues/codecov.gradle
@@ -1,0 +1,54 @@
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+// https://medium.com/jamf-engineering/android-kotlin-code-coverage-with-jacoco-sonar-and-gradle-plugin-6-x-3933ed503a6e
+
+project.afterEvaluate {
+
+    android.libraryVariants.all { variant ->
+
+        def variantName = variant.name
+        def unitTestTask = "test${variantName.capitalize()}UnitTest"
+
+        // add this task in "dependsOn" below to also include UI tests
+        //def androidTestCoverageTask = "create${variantName.capitalize()}CoverageReport"
+
+        tasks.create(name: "${variantName}UnitTestCoverage", type: JacocoReport, dependsOn: ["$unitTestTask"]) {
+
+            group = "Reporting"
+            description = "Generate Jacoco coverage reports for the ${variantName.capitalize()} build"
+
+            reports {
+                html.enabled  true
+                xml.enabled  true
+                csv.enabled  true
+            }
+
+            def excludes = [
+                    '**/R.class',
+                    '**/R$*.class',
+                    '**/BuildConfig.*',
+                    '**/Manifest*.*',
+                    '**/*Test*.*',
+                    'android/**/*.*',
+                    '**/*Koin*.*',
+                    '**/appcues/ui/**/*.*',
+                    '**/appcues/debugger/ui/**/*.*',
+            ]
+
+            def javaClasses = fileTree(dir: variant.javaCompileProvider.get().destinationDir, excludes: excludes)
+            def kotlinClasses = fileTree(dir: "${buildDir}/tmp/kotlin-classes/${variantName}", excludes: excludes)
+            classDirectories.setFrom(files([javaClasses, kotlinClasses]))
+
+            def variantSourceSets = variant.sourceSets.java.srcDirs.collect { it.path }.flatten()
+            sourceDirectories.setFrom(project.files(variantSourceSets))
+
+            // can use below to get UI output as well in future, if desired
+            // def androidTestsData = fileTree(dir: "${buildDir}/outputs/code_coverage/${variantName}AndroidTest/connected/", includes: ["**/*.ec"])
+            executionData(files(["$project.buildDir/jacoco/${unitTestTask}.exec"]))
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:7.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
         classpath "com.karumi:shot:5.13.0"
+        classpath "org.jacoco:org.jacoco.core:0.8.7"
     }
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,11 @@ platform :android do
     gradle(task: ':samples:kotlin-android-app:bundleRelease')
   end
 
+  desc "Generate unit test code coverage report"
+  lane :code_coverage do
+    gradle(task: ':appcues:debugUnitTestCoverage')
+  end
+
   desc "Deploy SDK release to GitHub Package Registry"
   lane :deploy_github_package do
     gradle(task: ':appcues:versionTxt')


### PR DESCRIPTION
Attempt here is to run the debugUnitTest task then the code coverage task, generate xml report with jacoco, then upload that to codecov.io via CircleCI - on merges to main.

codecov is free to open source projects, and once we are happy with it, we could also include a badge and link in our readme.

reporting and history will eventually show up here https://app.codecov.io/gh/appcues/appcues-android-sdk