### PR TITLE
Add support for Democues special case deeplinking logic

### DIFF
--- a/appcues/src/main/java/com/appcues/DeeplinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/DeeplinkHandler.kt
@@ -20,10 +20,12 @@ internal class DeeplinkHandler(
         val linkData: Uri? = intent?.data
         var handled = false
 
-        if (linkAction == Intent.ACTION_VIEW &&
-            linkData?.scheme == "appcues-${config.applicationId}" &&
-            linkData.host == "sdk"
-        ) {
+        if (linkData == null) return handled
+
+        val validScheme = linkData.scheme == "appcues-${config.applicationId}" || linkData.scheme == "appcues-democues"
+        val validHost = linkData.host == "sdk"
+
+        if (linkAction == Intent.ACTION_VIEW && validScheme && validHost) {
             val segments = linkData.pathSegments
             when {
                 segments.count() == 2 && segments[0] == "experience_preview" -> {


### PR DESCRIPTION
in addition to the `appcues-{application_id}` scheme, which matches the current app ID - we'll also support a special case of `appcues-democues` for deeplinks that are agnostic of app ID in the Democues usage where you can change the account/app at runtime.