### PR TITLE
Support Paused state in the StateMachine and logic to render a new Experience if needed

### DIFF
--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
         <activity
             android:name=".ui.AppcuesActivity"
             android:exported="false"
-            android:noHistory="true"
             android:theme="@style/Appcues.AppcuesActivityTheme" />
     </application>
 

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -15,6 +15,7 @@ import com.appcues.statemachine.State.BeginningStep
 import com.appcues.statemachine.State.EndingExperience
 import com.appcues.statemachine.State.EndingStep
 import com.appcues.statemachine.State.Idling
+import com.appcues.statemachine.State.Paused
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.StateMachine
 import kotlinx.coroutines.Dispatchers
@@ -95,6 +96,7 @@ internal class ExperienceLifecycleTracker(
             is EndingStep -> experience.published
             is Idling -> false
             is RenderingStep -> experience.published
+            is Paused -> false
         }
 
     private fun Error.shouldTrack(): Boolean =

--- a/appcues/src/main/java/com/appcues/statemachine/Action.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Action.kt
@@ -9,4 +9,6 @@ internal sealed class Action {
     data class EndExperience(val destroyed: Boolean, val markComplete: Boolean = false) : Action()
     object Reset : Action()
     data class ReportError(val error: Error) : Action()
+    object Pause : Action()
+    object Resume : Action()
 }

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -25,4 +25,5 @@ internal sealed class State {
         val dismissAndContinue: (() -> Unit)?,
     ) : State()
     data class EndingExperience(val experience: Experience, val flatStepIndex: Int, val markComplete: Boolean) : State()
+    data class Paused(val state: State) : State()
 }

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -161,16 +161,19 @@ internal class StateMachine(
                 }
 
             // EndingExperience
-            state is EndingExperience && action is Reset -> state.fromEndingExperienceToIdling(action)
+            state is EndingExperience && action is Reset ->
+                state.fromEndingExperienceToIdling(action)
+
+            // Paused
+            state is Paused && action is Resume ->
+                Transition(state.state)
+
+            state is Paused && action is EndExperience ->
+                Transition(state.state, ContinuationEffect(action))
 
             // Pause
-            action is Pause -> Transition(Paused(state))
-
-            // Resume
-            state is Paused && action is Resume -> Transition(state.state)
-
-            // EndingExperience while paused
-            state is Paused && action is EndExperience -> Transition(state.state, ContinuationEffect(action))
+            action is Pause && state !is Paused ->
+                Transition(Paused(state))
 
             // No valid combination of state plus action
             else -> null

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -3,9 +3,11 @@ package com.appcues.statemachine
 import com.appcues.AppcuesConfig
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.statemachine.Action.EndExperience
+import com.appcues.statemachine.Action.Pause
 import com.appcues.statemachine.Action.RenderStep
 import com.appcues.statemachine.Action.ReportError
 import com.appcues.statemachine.Action.Reset
+import com.appcues.statemachine.Action.Resume
 import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.Action.StartStep
 import com.appcues.statemachine.Error.ExperienceAlreadyActive
@@ -18,6 +20,7 @@ import com.appcues.statemachine.State.BeginningStep
 import com.appcues.statemachine.State.EndingExperience
 import com.appcues.statemachine.State.EndingStep
 import com.appcues.statemachine.State.Idling
+import com.appcues.statemachine.State.Paused
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.Transition.EmptyTransition
 import com.appcues.statemachine.Transition.ErrorLoggingTransition
@@ -159,6 +162,15 @@ internal class StateMachine(
 
             // EndingExperience
             state is EndingExperience && action is Reset -> state.fromEndingExperienceToIdling(action)
+
+            // Pause
+            action is Pause -> Transition(Paused(state))
+
+            // Resume
+            state is Paused && action is Resume -> Transition(state.state)
+
+            // EndingExperience while paused
+            state is Paused && action is EndExperience -> Transition(state.state, ContinuationEffect(action))
 
             // No valid combination of state plus action
             else -> null

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -66,6 +66,16 @@ internal class AppcuesActivity : AppCompatActivity() {
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        viewModel.onPause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.onResume()
+    }
+
     @Composable
     private fun Composition() {
         CompositionLocalProvider(

--- a/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
@@ -7,6 +7,8 @@ import com.appcues.action.ActionProcessor
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.StepContainer
 import com.appcues.statemachine.Action.EndExperience
+import com.appcues.statemachine.Action.Pause
+import com.appcues.statemachine.Action.Resume
 import com.appcues.statemachine.Action.StartStep
 import com.appcues.statemachine.State.BeginningStep
 import com.appcues.statemachine.State.EndingStep
@@ -130,6 +132,18 @@ internal class AppcuesViewModel(
             if (state is Dismissing) {
                 state.continueAction()
             }
+        }
+    }
+
+    fun onPause() {
+        appcuesCoroutineScope.launch {
+            stateMachine.handleAction(Pause)
+        }
+    }
+
+    fun onResume() {
+        appcuesCoroutineScope.launch {
+            stateMachine.handleAction(Resume)
         }
     }
 }


### PR DESCRIPTION
This is a Draft PR to discuss a proposed idea for an issue recently uncovered.

**Issue**: since our AppcuesActivity was set to use `noHistory=true` in commit https://github.com/appcues/appcues-android-sdk/commit/5bedc0096b4779589150b3f1584f23eec4f11c5c (PR #141) - any ExperienceAction that might open up a new Activity would inadvertently kill off a running Experience when launched, even if there was no close action and the expectation was that you could return back to the running Experience.  Example: link to URL - which opens the Chrome Tabs Activity - not good.

**Idea**: revert the `noHistory=true` change and support more robust handling of pause/resume in AppcuesActivity.  The StateMachine can be told to go into a Paused state, remembering the actual state it was in before paused.  Then, if a new Experience render comes in while Paused - we can assume that a new Activity on top has triggered new screens/events to qualify this, and the old Paused Experience can be ended in the background before launching the new one.

This is similar to the override code we put in place to allow an event-triggered Experience to override a screen-triggered experience a little while back.  Due to the nature of how the Android Activity system works, and our single StateMachine architecture - this seems a viable approach to continue to allow a single current Experience, but give priority to whatever Activity is topmost/visible.

Simple way to test: use Charles to trigger a flow with mapLocal on the sample app sign-in screen on launch.  Then, run a deep link like 
```
 adb shell am start -W -a android.intent.action.VIEW -d "appcues-example://events"
```
which will trigger a new Activity to be placed on top, new screen view, and a new Experience to show.  

Prior to this change, if `noHistory=true` was removed the manifest - this second Experience would not show, since another Experience was actively running the state machine, hidden in the background.  However, having `noHistory=true` in the manifest is no good - for reasons already noted above.