### PR TITLE
Add action for requesting review

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -94,6 +94,9 @@ dependencies {
     implementation "com.google.accompanist:accompanist-webview:0.24.9-beta"
     // Navigation Animated
     implementation "com.google.accompanist:accompanist-navigation-animation:0.24.9-beta"
+    // Play In-App Review
+    implementation 'com.google.android.play:review:2.0.0'
+    implementation 'com.google.android.play:review-ktx:2.0.0'
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"

--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
             android:name=".ui.AppcuesActivity"
             android:exported="false"
             android:theme="@style/Appcues.AppcuesActivityTheme" />
+        <activity
+            android:name=".ui.InAppReviewActivity"
+            android:exported="false"
+            android:theme="@style/Appcues.AppcuesActivityTheme" />
     </application>
 
 </manifest>

--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -4,6 +4,7 @@ import com.appcues.action.appcues.CloseAction
 import com.appcues.action.appcues.ContinueAction
 import com.appcues.action.appcues.LaunchExperienceAction
 import com.appcues.action.appcues.LinkAction
+import com.appcues.action.appcues.RequestReviewAction
 import com.appcues.action.appcues.TrackEventAction
 import com.appcues.action.appcues.UpdateProfileAction
 import com.appcues.di.KoinScopePlugin
@@ -52,6 +53,14 @@ internal object ActionKoin : KoinScopePlugin {
             UpdateProfileAction(
                 config = params.getOrNull(),
                 storage = get(),
+            )
+        }
+
+        factory { params ->
+            RequestReviewAction(
+                config = params.getOrNull(),
+                context = get(),
+                koinScope = get(),
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
@@ -4,6 +4,7 @@ import com.appcues.action.appcues.CloseAction
 import com.appcues.action.appcues.ContinueAction
 import com.appcues.action.appcues.LaunchExperienceAction
 import com.appcues.action.appcues.LinkAction
+import com.appcues.action.appcues.RequestReviewAction
 import com.appcues.action.appcues.TrackEventAction
 import com.appcues.action.appcues.UpdateProfileAction
 import com.appcues.data.model.AppcuesConfigMap
@@ -30,6 +31,7 @@ internal class ActionRegistry(
         register(ContinueAction.TYPE) { get<ContinueAction> { parametersOf(it) } }
         register(UpdateProfileAction.TYPE) { get<UpdateProfileAction> { parametersOf(it) } }
         register(LaunchExperienceAction.TYPE) { get<LaunchExperienceAction> { parametersOf(it) } }
+        register(RequestReviewAction.TYPE) { get<RequestReviewAction> { parametersOf(it) } }
     }
 
     operator fun get(key: String): ActionFactoryBlock? {

--- a/appcues/src/main/java/com/appcues/action/appcues/RequestReviewAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/RequestReviewAction.kt
@@ -1,0 +1,30 @@
+package com.appcues.action.appcues
+
+import android.content.Context
+import com.appcues.Appcues
+import com.appcues.action.ExperienceAction
+import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.ui.InAppReviewActivity
+import kotlinx.coroutines.CompletableDeferred
+import org.koin.core.scope.Scope
+
+internal class RequestReviewAction(
+    override val config: AppcuesConfigMap,
+    private val context: Context,
+    private val koinScope: Scope,
+) : ExperienceAction {
+
+    companion object {
+        const val TYPE = "@appcues/request-review"
+    }
+
+    override suspend fun execute(appcues: Appcues) {
+
+        val completion = CompletableDeferred<Boolean>()
+        InAppReviewActivity.completion = completion
+
+        context.startActivity(InAppReviewActivity.getIntent(context, koinScope.id))
+
+        completion.await()
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/InAppReviewActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/InAppReviewActivity.kt
@@ -1,0 +1,99 @@
+package com.appcues.ui
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
+import androidx.lifecycle.lifecycleScope
+import com.appcues.di.AppcuesKoinContext
+import com.appcues.logging.Logcues
+import com.google.android.play.core.review.ReviewManagerFactory
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+internal class InAppReviewActivity : AppCompatActivity() {
+
+    companion object {
+        private const val REQUEST_TIMEOUT_MILLISECONDS = 3000L
+
+        private const val EXTRA_SCOPE_ID = "EXTRA_SCOPE_ID"
+
+        // since there can only be one review activity running at a time, this companion level
+        // deferred can be used to await completion
+        var completion: CompletableDeferred<Boolean>? = null
+
+        fun getIntent(context: Context, scopeId: String): Intent =
+            Intent(context, InAppReviewActivity::class.java).apply {
+                putExtras(
+                    bundleOf(
+                        EXTRA_SCOPE_ID to scopeId
+                    )
+                )
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+    }
+
+    private var success = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        // remove enter animation from this activity
+        overridePendingTransition(0, 0)
+        super.onCreate(savedInstanceState)
+
+        val requestCompletion = CompletableDeferred<Boolean>()
+
+        val manager = ReviewManagerFactory.create(this)
+        val request = manager.requestReviewFlow()
+        request.addOnCompleteListener { task ->
+
+            // will never get here on non-play store builds - need a timeout fallback, which is handled
+            // below.  This completion handler will short-circuit that timeout and run the normal review flow,
+            // when available.
+            requestCompletion.complete(true)
+
+            if (task.isSuccessful) {
+                val reviewInfo = task.result
+
+                // We got the ReviewInfo object
+                if (reviewInfo != null) {
+                    val flow = manager.launchReviewFlow(this, reviewInfo)
+                    flow.addOnCompleteListener {
+                        // The flow has finished. The API does not indicate whether the user
+                        // reviewed or not, or even whether the review dialog was shown. Thus, no
+                        // matter the result, we continue our app flow.
+                        success = true
+                        finish()
+                    }
+                } else {
+                    finish()
+                }
+            } else {
+                finish()
+            }
+        }
+
+        lifecycleScope.launch {
+            try {
+                withTimeout(REQUEST_TIMEOUT_MILLISECONDS) {
+                    requestCompletion.await()
+                }
+            } catch (e: TimeoutCancellationException) {
+                val scope = AppcuesKoinContext.koin.getScope(intent.getStringExtra(EXTRA_SCOPE_ID)!!)
+                val logcues = scope.get<Logcues>()
+                logcues.info("In-App Review not available for this application")
+                finish()
+            }
+        }
+    }
+
+    override fun finish() {
+        super.finish()
+        // remove exit animation from this activity
+        overridePendingTransition(0, 0)
+
+        completion?.complete(true)
+    }
+}

--- a/gradle/tools/detekt/detekt-config.yml
+++ b/gradle/tools/detekt/detekt-config.yml
@@ -237,6 +237,7 @@ exceptions:
       - 'NumberFormatException'
       - 'ParseException'
       - 'JsonDataException'
+      - 'TimeoutCancellationException'
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:
     active: true


### PR DESCRIPTION
This stacks on top of #160 , since it requires the capability to launch an Activity on top of a running experience.

Using the [Google Play in-app review lib](https://developer.android.com/guide/playcore/in-app-review/kotlin-java) to allow an experience action that can request a review.  Similar to iOS, it's not really guaranteed to show the review, that is up to the internal Play implementation - but we can request.

A new Activity, the InAppReviewActivity is used to launch this review on top of the current experience, with a callback to return when done and allow the Experience action sequence to continue in natural order.

There is a 3 sec timeout in place to return from the review Activity if the Play library never returns a result when asked for the review task.  The Play library only works on a build distributed from the store, like our internal test app builds. It will not work on a build installed directly from APK or emulator - it would just hang without this timeout, as no callback is invoked in those cases, just silent failure, unfortunately. 