### PR TITLE
Show Screen name on debugger floating info

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionEvents.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionEvents.kt
@@ -125,7 +125,7 @@ private fun LazyItemScope.Item(event: DebuggerEventItem, isAnchoredStart: Boolea
                 contentDescription = LocalContext.current.getString(event.type.getTitleString())
             )
 
-            Text(fontSize = 12.sp, text = event.title, color = AppcuesColors.SharkbaitOhAh)
+            Text(fontSize = 12.sp, text = event.name, color = AppcuesColors.SharkbaitOhAh)
         }
     }
 


### PR DESCRIPTION
one line tweak to show the Screen title like "Update Profile" on the floating info, rather than the event name "Screen View" always - match iOS.