### PR TITLE
🐛 Fix bug to properly display the debugger even when activity is fitsystemwindow false

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
@@ -15,6 +15,8 @@ import androidx.lifecycle.viewModelScope
 import com.appcues.R
 import com.appcues.debugger.DebuggerViewModel.UIState.Expanded
 import com.appcues.debugger.ui.DebuggerComposition
+import com.appcues.util.getNavigationBarHeight
+import com.appcues.util.getStatusBarHeight
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -100,7 +102,10 @@ internal class AppcuesDebuggerManager(context: Context, private val koinScope: S
 
                         id = R.id.appcues_debugger_view
 
-                        layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+                        layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT).apply {
+                            // adds margin top and bottom according to visible status and navigation bar
+                            setMargins(0, context.getStatusBarHeight(), 0, context.getNavigationBarHeight())
+                        }
 
                         setContent {
                             MaterialTheme {
@@ -126,9 +131,7 @@ internal class AppcuesDebuggerManager(context: Context, private val koinScope: S
 
     private fun getParentView(activity: Activity): ViewGroup {
         // if there is any difference in API levels we can handle it here
-        return activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
-            .let { it.parent as ViewGroup }
-            .let { it.parent as ViewGroup }
+        return activity.window.decorView.rootView as ViewGroup
     }
 
     private fun setDebuggerBackPressCallback(activity: Activity) {

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionEvents.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionEvents.kt
@@ -84,7 +84,8 @@ internal fun BoxScope.DebuggerFloatingActionEvents(
             LazyColumn(
                 modifier = Modifier.animateContentSize(),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
-                reverseLayout = eventsProperties.drawTop
+                reverseLayout = eventsProperties.drawTop,
+                userScrollEnabled = false,
             ) {
                 items(events, key = { it.id }) { event ->
                     Item(event, eventsProperties.anchorToStart) { debuggerViewModel.onDisplayedEventTimeout() }

--- a/appcues/src/main/java/com/appcues/debugger/ui/MutableDebuggerState.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/MutableDebuggerState.kt
@@ -30,8 +30,8 @@ internal class MutableDebuggerState(private val density: Density, private val is
     val isExpanded = MutableTransitionState(false)
     val isPaused = mutableStateOf(value = false)
 
-    val fabXOffset = mutableStateOf(value = 0f)
-    val fabYOffset = mutableStateOf(value = 0f)
+    val fabXOffset = mutableStateOf(value = -1f)
+    val fabYOffset = mutableStateOf(value = -1f)
     val isDraggingOverDismiss = mutableStateOf(value = false)
 
     val deeplinkPath = mutableStateOf<String?>(value = null)
@@ -60,7 +60,10 @@ internal class MutableDebuggerState(private val density: Density, private val is
         }
     }
 
-    fun getFabPositionAsIntOffset(): IntOffset {
+    fun getFabPositionAsIntOffset(): IntOffset? {
+        // in case the value is initial value we return null
+        if (fabXOffset.value < 0f || fabYOffset.value < 0f) return null
+
         return IntOffset(fabXOffset.value.roundToInt(), fabYOffset.value.roundToInt())
     }
 

--- a/appcues/src/main/java/com/appcues/util/ContextExt.kt
+++ b/appcues/src/main/java/com/appcues/util/ContextExt.kt
@@ -1,0 +1,17 @@
+package com.appcues.util
+
+import android.content.Context
+
+internal fun Context.getStatusBarHeight(): Int {
+    val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
+    return if (resourceId > 0) {
+        resources.getDimensionPixelSize(resourceId)
+    } else 0
+}
+
+internal fun Context.getNavigationBarHeight(): Int {
+    val resourceId: Int = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+    return if (resourceId > 0) {
+        resources.getDimensionPixelSize(resourceId)
+    } else 0
+}


### PR DESCRIPTION
Initially I tried to research a way to check if the activity was fitting system window or not, but it seems like a impossible task so I moved away from it and went on a different approach.

 Now we are drawing on the decorView.root which has similar effect as we had before but in addition to this I had to manually add top/bottom margins to the ComposeView used by the debugger or else the debugger could go under status/navigation bar icons.