### PR TITLE
🐛 DebuggerManager stop does nothing in case activity reference is not initialized

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
@@ -62,7 +62,7 @@ internal class AppcuesDebuggerManager(context: Context, private val koinScope: S
 
     fun stop() {
         coroutineScope.coroutineContext.cancelChildren()
-        removeDebuggerView(this.currentActivity)
+        removeDebuggerView()
         debuggerViewModel?.viewModelScope?.cancel() // stop the VM from listening to app activity
         application.unregisterActivityLifecycleCallbacks(this)
         onBackPressCallback.remove()
@@ -121,8 +121,11 @@ internal class AppcuesDebuggerManager(context: Context, private val koinScope: S
         }
     }
 
-    private fun removeDebuggerView(activity: Activity) {
-        getParentView(activity).also {
+    private fun removeDebuggerView() {
+        // does nothing if currentActivity is not initialized
+        if (this::currentActivity.isInitialized.not()) return
+
+        getParentView(currentActivity).also {
             it.findViewById<ComposeView?>(R.id.appcues_debugger_view)?.run {
                 it.removeView(this)
             }


### PR DESCRIPTION
mistake com my part I forgot to include this in last the last PR, very important detail because when debugger manager has not started the debugger yet it will crash saying that currentActivity has not being initialized. 