### PR TITLE
Add tests for new AnalyticsListener functionality

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -3,6 +3,7 @@ package com.appcues
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
 import com.appcues.action.ActionRegistry
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ActivityRequestBuilder
@@ -249,7 +250,8 @@ class Appcues internal constructor(koinScope: Scope) {
 
     // if a listener is attached, this will publish tracked analytics so that a host application would be able to
     // observe and re-broadcast tracking data as desired.
-    private fun publishTracking(data: TrackingData) {
+    @VisibleForTesting
+    internal fun publishTracking(data: TrackingData) {
 
         fun EventRequest.screenTitle(): String? =
             attributes[ActivityRequestBuilder.SCREEN_TITLE_ATTRIBUTE] as? String

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -4,8 +4,18 @@ import android.app.Activity
 import android.content.Intent
 import com.appcues.action.ActionRegistry
 import com.appcues.action.ExperienceAction
+import com.appcues.analytics.ActivityRequestBuilder
 import com.appcues.analytics.ActivityScreenTracking
+import com.appcues.analytics.AnalyticType.EVENT
+import com.appcues.analytics.AnalyticType.GROUP
+import com.appcues.analytics.AnalyticType.IDENTIFY
+import com.appcues.analytics.AnalyticType.SCREEN
+import com.appcues.analytics.AnalyticsEvent
+import com.appcues.analytics.AnalyticsListener
 import com.appcues.analytics.AnalyticsTracker
+import com.appcues.analytics.TrackingData
+import com.appcues.data.remote.request.ActivityRequest
+import com.appcues.data.remote.request.EventRequest
 import com.appcues.debugger.AppcuesDebuggerManager
 import com.appcues.rules.KoinScopeRule
 import com.appcues.rules.MainDispatcherRule
@@ -327,5 +337,110 @@ internal class AppcuesTest : AppcuesScopeTest {
 
         // THEN
         verify { tracker.track(name, null) }
+    }
+
+    @Test
+    fun `analyticsListener SHOULD track event WHEN event TrackingData is published`() {
+        // GIVEN
+        val attributes = hashMapOf<String, Any>("prop" to 42)
+        val activity = ActivityRequest(
+            accountId = "123",
+            userId = "userId",
+            events = listOf(EventRequest("event1", attributes = attributes))
+        )
+        val data = TrackingData(EVENT, false, activity)
+        val listener = mockk<AnalyticsListener>(relaxed = true)
+        appcues.analyticsListener = listener
+
+        // WHEN
+        appcues.publishTracking(data)
+
+        // THEN
+        verify { listener.trackedAnalytic(EVENT, "event1", attributes, false) }
+    }
+
+    @Test
+    fun `analyticsListener SHOULD track screen WHEN screen TrackingData is published`() {
+        // GIVEN
+        val attributes = hashMapOf<String, Any>(ActivityRequestBuilder.SCREEN_TITLE_ATTRIBUTE to "screen1")
+        val activity = ActivityRequest(
+            accountId = "123",
+            userId = "userId",
+            events = listOf(EventRequest(AnalyticsEvent.ScreenView.eventName, attributes = attributes))
+        )
+        val data = TrackingData(SCREEN, false, activity)
+        val listener = mockk<AnalyticsListener>(relaxed = true)
+        appcues.analyticsListener = listener
+
+        // WHEN
+        appcues.publishTracking(data)
+
+        // THEN
+        verify { listener.trackedAnalytic(SCREEN, "screen1", attributes, false) }
+    }
+
+    @Test
+    fun `analyticsListener SHOULD track identify WHEN identify TrackingData is published`() {
+        // GIVEN
+        val storage: Storage = get()
+        storage.userId = "userId"
+        val attributes = hashMapOf<String, Any>("prop" to 42)
+        val activity = ActivityRequest(
+            accountId = "123",
+            userId = storage.userId,
+            profileUpdate = attributes
+        )
+        val data = TrackingData(IDENTIFY, false, activity)
+        val listener = mockk<AnalyticsListener>(relaxed = true)
+        appcues.analyticsListener = listener
+
+        // WHEN
+        appcues.publishTracking(data)
+
+        // THEN
+        verify { listener.trackedAnalytic(IDENTIFY, "userId", attributes, false) }
+    }
+
+    @Test
+    fun `analyticsListener SHOULD track group WHEN group TrackingData is published`() {
+        // GIVEN
+        val storage: Storage = get()
+        storage.groupId = "groupId"
+        val attributes = hashMapOf<String, Any>("prop" to 42)
+        val activity = ActivityRequest(
+            accountId = "123",
+            userId = "userId",
+            groupId = storage.groupId,
+            groupUpdate = attributes
+        )
+        val data = TrackingData(GROUP, false, activity)
+        val listener = mockk<AnalyticsListener>(relaxed = true)
+        appcues.analyticsListener = listener
+
+        // WHEN
+        appcues.publishTracking(data)
+
+        // THEN
+        verify { listener.trackedAnalytic(GROUP, "groupId", attributes, false) }
+    }
+
+    @Test
+    fun `analyticsListener SHOULD track internal event WHEN event TrackingData is published AND isInternal equals true`() {
+        // GIVEN
+        val attributes = hashMapOf<String, Any>("prop" to 42)
+        val activity = ActivityRequest(
+            accountId = "123",
+            userId = "userId",
+            events = listOf(EventRequest("event1", attributes = attributes))
+        )
+        val data = TrackingData(EVENT, true, activity)
+        val listener = mockk<AnalyticsListener>(relaxed = true)
+        appcues.analyticsListener = listener
+
+        // WHEN
+        appcues.publishTracking(data)
+
+        // THEN
+        verify { listener.trackedAnalytic(EVENT, "event1", attributes, true) }
     }
 }


### PR DESCRIPTION
A few test updates to (A) ensure AnalyticsTracker is publishing the expected tracking data to the analyticsFlow SharedFlow and (B) ensure that Appcues is properly broadcasting that tracking data to any attached AnalyticsListener