### PR TITLE
Ensure that the debugger UI is always launched on the main thread

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
@@ -44,7 +44,7 @@ internal class AppcuesDebuggerManager(context: Context, private val koinScope: S
         }
     }
 
-    fun start(activity: Activity, deeplinkPath: String? = null) {
+    fun start(activity: Activity, deeplinkPath: String? = null) = activity.runOnUiThread {
         this.currentActivity = activity
         coroutineScope.coroutineContext.cancelChildren()
         // it is possible to re-enter start without a stop (deeplinks) - in which case we continue to


### PR DESCRIPTION
Discovered during some React Native testing, which can launch the debugger through the wrapper on non-main thread - which then crashes due to the UI code that runs inside the SDK.

I can move the wrapper call to the main thread for now, but this will fix the issue at the lower level for the future, so it does not crop up again elsewhere.