### PR TITLE
Update to Compose 1.2.0-rc03

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -46,7 +46,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.2.0-rc02"
+        kotlinCompilerExtensionVersion = "1.2.0"
     }
 
     packagingOptions {
@@ -66,15 +66,15 @@ dependencies {
     implementation "androidx.core:core-ktx:1.8.0"
     implementation 'androidx.activity:activity-compose:1.5.0-rc01'
     implementation "androidx.browser:browser:1.4.0"
-    implementation "androidx.compose.ui:ui:1.2.0-rc02"
-    implementation "androidx.compose.ui:ui-tooling:1.2.0-rc02"
-    implementation "androidx.compose.material:material:1.2.0-rc02"
-    implementation "androidx.navigation:navigation-compose:2.5.0-rc02"
+    implementation "androidx.compose.ui:ui:1.2.0-rc03"
+    implementation "androidx.compose.ui:ui-tooling:1.2.0-rc03"
+    implementation "androidx.compose.material:material:1.2.0-rc03"
+    implementation "androidx.navigation:navigation-compose:2.5.0-rc03"
     implementation "com.google.android.material:material:1.6.1"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation "androidx.room:room-runtime:2.4.2"
-    implementation "androidx.room:room-ktx:2.4.2"
-    kapt "androidx.room:room-compiler:2.4.2"
+    implementation "androidx.room:room-runtime:2.5.0-alpha02"
+    implementation "androidx.room:room-ktx:2.5.0-alpha02"
+    kapt "androidx.room:room-compiler:2.5.0-alpha02"
     // Image Loader
     implementation "io.coil-kt:coil-compose:2.1.0"
     implementation "io.coil-kt:coil-gif:2.1.0"

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -9,6 +9,10 @@ apply from: 'publish-maven.gradle'
 apply from: 'copy-dependencies.gradle'
 apply from: 'codecov.gradle'
 
+ext.room_version = '2.4.2'
+ext.compose_version = '1.2.0-rc03'
+ext.compose_compiler_version = '1.2.0'
+
 android {
     compileSdk 32
 
@@ -46,7 +50,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.2.0"
+        kotlinCompilerExtensionVersion = "$compose_compiler_version"
     }
 
     packagingOptions {
@@ -64,17 +68,21 @@ android {
 dependencies {
     // Androidx
     implementation "androidx.core:core-ktx:1.8.0"
-    implementation 'androidx.activity:activity-compose:1.5.0-rc01'
+    implementation 'androidx.activity:activity-compose:1.5.0'
     implementation "androidx.browser:browser:1.4.0"
-    implementation "androidx.compose.ui:ui:1.2.0-rc03"
-    implementation "androidx.compose.ui:ui-tooling:1.2.0-rc03"
-    implementation "androidx.compose.material:material:1.2.0-rc03"
-    implementation "androidx.navigation:navigation-compose:2.5.0-rc03"
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.navigation:navigation-compose:$compose_version"
     implementation "com.google.android.material:material:1.6.1"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation "androidx.room:room-runtime:2.5.0-alpha02"
-    implementation "androidx.room:room-ktx:2.5.0-alpha02"
-    kapt "androidx.room:room-compiler:2.5.0-alpha02"
+    implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
+    // Line below is a temporary workaround for an issue that will be fixed in Room 2.5.0 - since
+    // Room 2.4.2 has a compatibility issue with Kotlin 1.7.0
+    // https://issuetracker.google.com/issues/236612358
+    kapt "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0"
     // Image Loader
     implementation "io.coil-kt:coil-compose:2.1.0"
     implementation "io.coil-kt:coil-gif:2.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
+        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0"
         classpath "com.karumi:shot:5.13.0"
         classpath "org.jacoco:org.jacoco.core:0.8.7"
     }


### PR DESCRIPTION
Update:  the workaround in comment 11 here https://issuetracker.google.com/issues/236612358#comment seems to work for us - so I think we can move forward with this until Room 2.4.3 is released for standard Kotlin 1.7.0 compat.

--------------

Marking this one as a draft, as it unfortunately hits a snag.  I was trying to stay current on Compose updates moving toward stable.

Compose 1.2.0-rc03 appears to require the, now stable, compose compiler 1.2.0.  Related - [Compose is now versioning libraries independently](https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html)

The 1.2.0 compiler requires Kotlin 1.7.0

Updating to Kotlin 1.7.0 breaks the Room code generation though, unfortunately.  Room 2.5.0-alpha02 appears to resolve the issue, but I was hoping to move towards Compose stable, not go backward to another alpha version of another lib 😞 

Looks like this is starting to pop up as a bug though with both [Kotlin](https://youtrack.jetbrains.com/issue/KT-52996/After-updating-kotlin-plugin-in-android-studio-facing-problem-with-Room-Database) and [Google Room](https://issuetracker.google.com/issues/236612358) teams. So we'll see how that plays out.