### PR TITLE
Remove the deploy to GitHub package registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
             }
           channel: team-mobile-bots  
 
-  deploy_github_package:
+  update_code_coverage:
     working_directory: ~/code
     executor:
       name: android/android-machine
@@ -184,79 +184,15 @@ jobs:
     steps:
       - install_with_cache      
       - run:
-          name: Deploy SDK to GitHub Package Registry
-          command: bundle exec fastlane deploy_github_package
-      - run:
           name: Generate code coverage report
           command: bundle exec fastlane code_coverage
       - codecov/upload:
           file: "./appcues/build/reports/jacoco/debugUnitTestCoverage/debugUnitTestCoverage.xml"
-      - run:
-          # some ideas from https://discuss.circleci.com/t/leveraging-circleci-api-to-include-build-logs-in-slack-notifications/39111
-          name: Get changelog
-          command: |
-            SDK_CHANGELOG=$(cat ./changelog/$CIRCLE_BUILD_NUM.txt | tail -n 10 | jq -aRs . | sed -e 's/^"//' -e 's/"$//')
-            echo $SDK_CHANGELOG
-            echo "export SDK_CHANGELOG='${SDK_CHANGELOG}'" >> $BASH_ENV
       # not saving gradle cache on this job since it is SDK only
       - slack/notify:
           event: fail
           template: basic_fail_1
           channel: team-mobile-bots
-      - slack/notify:
-          event: pass
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "🚀 Android SDK Deployed to GitHub Package Registry",
-                    "emoji": true
-                  }
-                }
-              ],
-              "attachments": [
-                {
-                  "color": "#3DDC84",
-                  "blocks": [
-                  {
-                      "type": "section",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "$SDK_CHANGELOG",
-                        "emoji": true
-                      }
-                    },
-                    {
-                      "type": "actions",
-                      "elements": [
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "View Job",
-                            "emoji": true
-                          },
-                          "url": "$CIRCLE_BUILD_URL"
-                        },
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "View Package",
-                            "emoji": true
-                          },
-                          "url": "https://github.com/appcues/appcues-android-sdk/packages/1386739"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          channel: team-mobile-bots    
 
 # --------------------------
 #        WORKFLOWS
@@ -273,13 +209,13 @@ workflows:
           context:
             - Appcues
 
-  build_and_deploy_package:
+  code_coverage:
     when:
       and:
         - *is_main
         - not: << pipeline.parameters.deploy-sample >>
     jobs:
-      - deploy_github_package:
+      - update_code_coverage:
           context:
             - Appcues
 

--- a/appcues/publish-maven.gradle
+++ b/appcues/publish-maven.gradle
@@ -22,12 +22,7 @@ private String generateVersionName() {
     if (classifier != null) {
         versionName += "-" + classifier
     }
-
-    String build = System.getenv("CIRCLE_BUILD_NUM")
-    if (build != null) {
-        versionName += "+" + build
-    }
-
+    
     return versionName
 }
 
@@ -89,40 +84,6 @@ afterEvaluate {
                 artifactId = appcuesProperties.getProperty("ARTIFACT_ID") + "-debug"
                 version = versionName
             }
-            gpr(MavenPublication) {
-                from components.release
-
-                // You can then customize attributes of the publication as shown below.
-                groupId = appcuesProperties.getProperty("GROUP_ID")
-                artifactId = appcuesProperties.getProperty("ARTIFACT_ID")
-                version = versionName
-
-                pom {
-                    name = appcuesProperties.getProperty("NAME")
-                    description = appcuesProperties.getProperty("DESCRIPTION")
-                    url = appcuesProperties.getProperty("ORG_URL")
-                    licenses {
-                        license {
-                            name = appcuesProperties.getProperty("LICENSE")
-                            url = appcuesProperties.getProperty("LICENSE_URL")
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = appcuesProperties.getProperty("ORG_ID")
-                            name = appcuesProperties.getProperty("ORG_NAME")
-                            organization = appcuesProperties.getProperty("ORG_NAME")
-                            organizationUrl = appcuesProperties.getProperty("ORG_URL")
-                            email = appcuesProperties.getProperty("ORG_EMAIL")
-                        }
-                    }
-                    scm {
-                        connection = 'scm:git:git://github.com/' + appcuesProperties.getProperty("GITHUB_PATH") + '.git'
-                        developerConnection = 'scm:git:ssh://github.com:' + appcuesProperties.getProperty("GITHUB_PATH") + '.git'
-                        url = 'https://github.com/' + appcuesProperties.getProperty("GITHUB_PATH")
-                    }
-                }
-            }
         }
         repositories {
             maven {
@@ -131,14 +92,6 @@ afterEvaluate {
                 credentials {
                     username = ossrhUsername
                     password = ossrhPassword
-                }
-            }
-            maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/appcues/appcues-android-sdk")
-                credentials {
-                    username = System.getenv("GPR_USERNAME")
-                    password = System.getenv("GPR_TOKEN")
                 }
             }
         }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,25 +14,6 @@ platform :android do
     gradle(task: ':appcues:debugUnitTestCoverage')
   end
 
-  desc "Deploy SDK release to GitHub Package Registry"
-  lane :deploy_github_package do
-    gradle(task: ':appcues:versionTxt')
-    gradle(task: ':appcues:publishReleasePublicationToGitHubPackagesRepository')
-
-    sdk_version=File.read("../version.txt")
-
-    git_log = changelog_from_git_commits(
-      commits_count: 5,
-      pretty: "- [%as] %s"
-    )
-    changelog_message = "Version #{sdk_version}\n\nLatest commits on #{ENV["CIRCLE_BRANCH"]}:\n" + git_log
-    
-    metadata_dir = "../changelog"
-    version_changelog = metadata_dir + "/#{ENV["CIRCLE_BUILD_NUM"]}.txt"
-    sh("mkdir", "-p", metadata_dir)
-    sh("echo '#{changelog_message}' > #{version_changelog}")
-  end
-
   desc "Deploy a new version to Google Play internal test"
   lane :deploy_sample do
     sh("sh", "./replace-placeholders.sh", "kotlin-android-app", ENV["EX_APPCUES_ACCOUNT_ID"], ENV["EX_APPCUES_APPLICATION_ID"])

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -23,13 +23,13 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Validate the code in the SDK repo works properly
 
-### android deploy_github_package
+### android code_coverage
 
 ```sh
-[bundle exec] fastlane android deploy_github_package
+[bundle exec] fastlane android code_coverage
 ```
 
-Deploy SDK release to GitHub Package Registry
+Generate unit test code coverage report
 
 ### android deploy_sample
 


### PR DESCRIPTION
I don't think we need these gpr packages created on every merge to main anymore, now that we are publishing as needed on Maven Central.  This was really just a temporary workaround before we made those public.  A merge to main now will just run the code coverage report and upload to codecov.io