### PR TITLE
🐛 Clear events from list when SessionReset is sent

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
@@ -2,6 +2,7 @@ package com.appcues.debugger
 
 import com.appcues.R
 import com.appcues.analytics.ActivityRequestBuilder
+import com.appcues.analytics.AnalyticsEvent
 import com.appcues.analytics.AutoPropertyDecorator
 import com.appcues.data.remote.request.ActivityRequest
 import com.appcues.data.remote.request.EventRequest
@@ -46,6 +47,8 @@ internal class DebuggerRecentEventsManager(
                 activityRequest.events.forEach { event ->
                     val type = event.name.toEventType()
                     val title = event.name.toEventTitle()?.let { contextResources.getString(it) } ?: event.name
+
+                    clearEventsOnSessionReset(event)
 
                     events.addFirst(
                         DebuggerEventItem(
@@ -104,6 +107,13 @@ internal class DebuggerRecentEventsManager(
         }
 
         updateData()
+    }
+
+    private fun clearEventsOnSessionReset(event: EventRequest) {
+        // When session reset we clear the current list and start a new one
+        if (event.name == AnalyticsEvent.SessionReset.eventName) {
+            events.clear()
+        }
     }
 
     private fun Map<String, Any>.filterOutScreenProperties(eventType: EventType): Map<String, Any> {


### PR DESCRIPTION
this is a followup on https://app.shortcut.com/appcues/story/35831/show-user-as-unidentified-in-android-debugger-and-clear-events-on-session-reset

to mirror IOS behavior we will clear the recent event list whenever we get a session reset event coming in.