### PR TITLE
Only trigger pause and resume in the state machine with the AppcuesViewModel is active

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
@@ -136,13 +136,13 @@ internal class AppcuesViewModel(
     }
 
     fun onPause() {
-        appcuesCoroutineScope.launch {
+        viewModelScope.launch {
             stateMachine.handleAction(Pause)
         }
     }
 
     fun onResume() {
-        appcuesCoroutineScope.launch {
+        viewModelScope.launch {
             stateMachine.handleAction(Resume)
         }
     }


### PR DESCRIPTION
This is a bit of a subtle one, but I think it is the proper fix for what I'm observing in the bug in this ticket.

Previously, when an Experience was being dismissed - killing it off - it would send a `Pause` action to the state machine, since it was in the `appcuesViewModelScope` and the `AppcuesViewModel.onPause()` was being triggered.  But the VM was actually detached by this point, as it was being closed, and we should not be sending a `Pause` action in this case - which is more appropriately handled now by using the `viewModelScope` for this StateMachine call - which will go out of scope when the VM is dying off.

The issue this caused was that the StateMachine would get into a `Paused` state, erroneously, as the first Experience was closed out.  This Experience would never `Resume` then, because it was dead.  Then, when the next Experience attempted to start - it would hit line 119 in the StateMachine - invalid attempt to `StartExperience` in a state other than `Idling` - "Experience already active".

Solution - we should never by triggering a `Pause` when the Experience is being closed.

I believe this to be an Android only issue, as iOS does not have the same lifecycle pause/resume effects to be concerned with, but I'll test that out.