### PR TITLE
🐛 Adding StepGroupPageIndex as step reference for swipe trait

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/StepReference.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StepReference.kt
@@ -25,6 +25,18 @@ internal sealed class StepReference {
         }
     }
 
+    data class StepGroupPageIndex(val index: Int) : StepReference() {
+
+        override fun getIndex(experience: Experience, currentStepIndex: Int): Int? {
+            // finds the group this step belongs to
+            return experience.groupLookup[currentStepIndex]
+                // get the id of that index we are trying to show start from that same group
+                ?.let { groupIndex -> experience.stepContainers[groupIndex].steps[index].id }
+                // get the index from flatSteps
+                ?.let { experience.flatSteps.indexOfFirst { step -> step.id == it } }
+        }
+    }
+
     data class StepOffset(val offset: Int) : StepReference() {
 
         override fun getIndex(experience: Experience, currentStepIndex: Int): Int? {

--- a/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
@@ -13,7 +13,7 @@ import com.appcues.statemachine.Action.StartStep
 import com.appcues.statemachine.State.BeginningStep
 import com.appcues.statemachine.State.EndingStep
 import com.appcues.statemachine.StateMachine
-import com.appcues.statemachine.StepReference.StepIndex
+import com.appcues.statemachine.StepReference.StepGroupPageIndex
 import com.appcues.ui.AppcuesViewModel.UIState.Dismissing
 import com.appcues.ui.AppcuesViewModel.UIState.Idle
 import com.appcues.ui.AppcuesViewModel.UIState.Rendering
@@ -109,7 +109,7 @@ internal class AppcuesViewModel(
             // then we report new position to state machine
             if (state is Rendering && state.position != index) {
                 appcuesCoroutineScope.launch {
-                    stateMachine.handleAction(StartStep(StepIndex(index)))
+                    stateMachine.handleAction(StartStep(StepGroupPageIndex(index)))
                 }
             }
         }


### PR DESCRIPTION
crazy bug to find at this point in the project.

StepIndex worked for simple flows, but we needed a way to find the correct step index based on the index value from within a step group.