### PR TITLE
Add support for mocking Coil ImageLoader for testing

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -1,6 +1,8 @@
 package com.appcues
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import coil.ImageLoader
 import com.appcues.data.MoshiConfiguration
 import com.appcues.data.mapper.step.StepContentMapper
 import com.appcues.data.mapper.step.primitives.BoxPrimitiveMapper
@@ -9,11 +11,13 @@ import com.appcues.data.mapper.step.primitives.EmbedPrimitiveMapper
 import com.appcues.data.mapper.step.primitives.ImagePrimitiveMapper
 import com.appcues.data.mapper.step.primitives.StackPrimitiveMapper
 import com.appcues.data.mapper.step.primitives.TextPrimitiveMapper
+import com.appcues.data.model.ExperiencePrimitive
 import com.appcues.data.remote.response.step.StepContentResponse
+import com.appcues.ui.LocalImageLoader
 import com.appcues.ui.primitive.Compose
 
 @Composable
-fun SnapshotTest(json: String) {
+fun ComposeContent(json: String, imageLoader: ImageLoader) {
     val response = MoshiConfiguration.moshi.adapter(StepContentResponse::class.java).fromJson(json)
     val mapper = StepContentMapper(
         stackMapper = StackPrimitiveMapper(),
@@ -24,5 +28,8 @@ fun SnapshotTest(json: String) {
         embedMapper = EmbedPrimitiveMapper()
     )
     val primitive = mapper.map(response!!)
-    primitive.Compose()
+
+    CompositionLocalProvider(LocalImageLoader provides imageLoader) {
+        primitive.Compose()
+    }
 }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesCompositions.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesCompositions.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import coil.ImageLoader
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.Action
 import com.appcues.trait.AppcuesPaginationData
@@ -18,6 +19,9 @@ internal val LocalAppcuesActionDelegate = staticCompositionLocalOf { AppcuesActi
 internal data class AppcuesActions(val onAction: (ExperienceAction) -> Unit)
 
 internal val LocalAppcuesActions = staticCompositionLocalOf<Map<UUID, List<Action>>> { hashMapOf() }
+
+// used to support UI testing and mocking of image loading
+internal val LocalImageLoader = staticCompositionLocalOf<ImageLoader?> { null }
 
 /**
  * LocalAppcuesPagination is used to report back any page change that

--- a/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
@@ -23,6 +23,7 @@ import com.appcues.data.model.ExperiencePrimitive.VerticalStackPrimitive
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.LocalAppcuesActionDelegate
 import com.appcues.ui.LocalAppcuesActions
+import com.appcues.ui.LocalImageLoader
 import com.appcues.ui.extensions.PrimitiveGestureProperties
 import com.appcues.ui.extensions.blurHashPlaceholder
 import com.appcues.ui.extensions.getBoxAlignment
@@ -90,10 +91,11 @@ internal fun BoxScope.BackgroundImage(style: ComponentStyle) {
                 modifier = Modifier.matchParentSize(),
                 model = context.getImageRequest(imageUrl, contentMode),
                 contentDescription = null,
-                imageLoader = context.getImageLoader(),
+                imageLoader = LocalImageLoader.current ?: context.getImageLoader(),
                 placeholder = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
                 contentScale = contentMode.toImageAsyncContentScale(),
-                alignment = getBoxAlignment(horizontalAlignment, verticalAlignment)
+                alignment = getBoxAlignment(horizontalAlignment, verticalAlignment),
+                error = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/ImagePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ImagePrimitive.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImage
 import com.appcues.data.model.ExperiencePrimitive.ImagePrimitive
+import com.appcues.ui.LocalImageLoader
 import com.appcues.ui.extensions.blurHashPlaceholder
 import com.appcues.ui.extensions.getImageLoader
 import com.appcues.ui.extensions.getImageRequest
@@ -21,8 +22,9 @@ internal fun ImagePrimitive.Compose(modifier: Modifier) {
         modifier = modifier.then(Modifier.styleSize(style, true)),
         model = context.getImageRequest(url, contentMode),
         contentDescription = accessibilityLabel,
-        imageLoader = context.getImageLoader(),
+        imageLoader = LocalImageLoader.current ?: context.getImageLoader(),
         placeholder = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
         contentScale = contentMode.toImageAsyncContentScale(),
+        error = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
     )
 }


### PR DESCRIPTION
This is a new approach that I've found workable for loading images from our snapshot testing library - allow an optional override of the Coil `ImageLoader` that gets send down into the composition using a `CompsitionLocalProvider`.  By default, it's null, and the normal logic stays the same.  In tests, we can pass in our own ImageLoader that loads static resources synchronously.  Will post the updates to the test code in the spec repo.