### PR TITLE
Configure dokka to ignore debug source set files

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -9,6 +9,7 @@ plugins {
 apply from: 'publish-maven.gradle'
 apply from: 'copy-dependencies.gradle'
 apply from: 'codecov.gradle'
+apply from: 'dokka.gradle'
 
 ext.room_version = '2.4.2'
 ext.compose_version = '1.2.0-rc03'

--- a/appcues/dokka.gradle
+++ b/appcues/dokka.gradle
@@ -1,0 +1,7 @@
+tasks.dokkaHtml.configure {
+    dokkaSourceSets {
+        debug {
+            suppress.set(true)
+        }
+    }
+}


### PR DESCRIPTION
This fix will correct an issue that allowed our debug source public interface for snapshot testing to show up in the published docs from Dokka. I have already pushed the fix to the public docs.