### PR TITLE
Update dependencies for Compose, Accompanist, and Room

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -11,10 +11,10 @@ apply from: 'copy-dependencies.gradle'
 apply from: 'codecov.gradle'
 apply from: 'dokka.gradle'
 
-ext.room_version = '2.4.2'
-ext.compose_version = '1.2.0-rc03'
+ext.room_version = '2.4.3'
+ext.compose_version = '1.2.0'
 ext.compose_compiler_version = '1.2.0'
-ext.accompanist_version = '0.24.13-rc'
+ext.accompanist_version = '0.25.0'
 
 android {
     compileSdk 32
@@ -71,28 +71,24 @@ android {
 dependencies {
     // Androidx
     implementation "androidx.core:core-ktx:1.8.0"
-    implementation 'androidx.activity:activity-compose:1.5.0'
+    implementation 'androidx.activity:activity-compose:1.5.1'
     implementation "androidx.browser:browser:1.4.0"
+    implementation "androidx.navigation:navigation-compose:2.5.1"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.navigation:navigation-compose:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
     // Workaround for an issue that will be fixed by google some day.
     // https://issuetracker.google.com/issues/227767363
     debugImplementation "androidx.customview:customview:1.2.0-alpha01"
-    debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0-rc01"
+    debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0"
     // ----
     implementation "com.google.android.material:material:1.6.1"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
-    // Line below is a temporary workaround for an issue that will be fixed in Room 2.5.0 - since
-    // Room 2.4.2 has a compatibility issue with Kotlin 1.7.0
-    // https://issuetracker.google.com/issues/236612358
-    kapt "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0"
     // Image Loader
     implementation "io.coil-kt:coil-compose:2.1.0"
     implementation "io.coil-kt:coil-gif:2.1.0"


### PR DESCRIPTION
https://android-developers.googleblog.com/2022/07/jetpack-compose-1-2-is-now-stable.html

We're now able to use stable 1.2.0 Compose, and the accompanying stable 0.25.0 of the Accompanist libs 🎉

Also, Room 2.4.3 has the fix for [this bug](https://issuetracker.google.com/issues/236612358) that we had to work around with Kotlin 1.7.0, so patched that up.