### PR TITLE
Update to use safe cast in Debugger

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
@@ -80,7 +80,7 @@ internal class AppcuesDebuggerManager(context: Context, private val koinScope: S
         // control native back press by enabling and disabling on our side
         setDebuggerBackPressCallback(activity)
         // also to make sure that if they change fragment, we will register again after the new fragment is attached
-        (activity as FragmentActivity).supportFragmentManager.addFragmentOnAttachListener { _, _ ->
+        (activity as? FragmentActivity)?.supportFragmentManager?.addFragmentOnAttachListener { _, _ ->
             setDebuggerBackPressCallback(activity)
         }
     }


### PR DESCRIPTION
Discovered during some UI testing that we had this cast to `FragmentActivity` in the `AppcuesDebuggerManager` that may not always be valid - updating this to use `as?` to be safe.