### PR TITLE
Fix analytics reporting during activity pause/resume

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -84,8 +84,10 @@ internal class StateMachine(
             // update current state
             _state = state
 
-            // emit state change to all listeners via flow
-            _stateFlow.emit(state)
+            if (transition.emitStateChange) {
+                // emit state change to all listeners via flow
+                _stateFlow.emit(state)
+            }
         }
 
         if (sideEffect != null) {
@@ -174,7 +176,7 @@ internal class StateMachine(
 
             // Paused
             state is Paused && action is Resume ->
-                Transition(state.state)
+                Transition(state.state, emitStateChange = false)
 
             state is Paused && action is EndExperience ->
                 Transition(state.state, ContinuationEffect(action))

--- a/appcues/src/main/java/com/appcues/statemachine/Transition.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transition.kt
@@ -4,7 +4,8 @@ import com.appcues.statemachine.SideEffect.ReportErrorEffect
 
 internal open class Transition(
     val state: State?,
-    val sideEffect: SideEffect? = null
+    val sideEffect: SideEffect? = null,
+    val emitStateChange: Boolean = true,
 ) {
     class ErrorLoggingTransition(error: Error) : Transition(null, ReportErrorEffect(error))
     class EmptyTransition : Transition(null, null)

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.core.os.bundleOf
 import com.appcues.di.AppcuesKoinContext
 import com.appcues.trait.ContentHolderTrait.ContainerPages
@@ -172,6 +173,7 @@ internal class AppcuesActivity : AppCompatActivity() {
                                                 // if we have contentPadding to apply from the WrapContent trait then we apply here
                                                 .then(if (contentPadding != null) Modifier.padding(contentPadding) else Modifier)
                                                 .padding(paddingValues = stepDecoratingPadding.paddingValues.value)
+                                                .testTag("page_$index")
                                         ) {
                                             content.Compose()
                                         }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
@@ -141,6 +141,8 @@ internal class AppcuesViewModel(
     }
 
     fun onPause() {
+        if (uiState.value is Dismissing) return
+
         viewModelScope.launch {
             stateMachine.handleAction(Pause)
         }


### PR DESCRIPTION
Issue found in UI testing

If the `AppcuesActivity` goes through pause/resume, it can trigger extraneous `step_seen` analytic events, since the Resume will reset the state machine back to `RenderingStep` and trigger the listener again.