### PR TITLE
🐛 Fix to ConcurrencyModificationException on AutoPropertiesDecorator

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -28,6 +28,7 @@ internal class AutoPropertyDecorator(
         const val UPDATED_AT_PROPERTY = "_updatedAt"
     }
 
+    private var userAgent: String? = null
     private var currentScreen: String? = null
     private var previousScreen: String? = null
     private var sessionPageviews = 0
@@ -70,12 +71,14 @@ internal class AutoPropertyDecorator(
     val autoProperties: Map<String, Any>
         get() = hashMapOf<String, Any>().apply {
             putAll(applicationProperties)
+            // add userAgent if exists (userAgent is a mutable property loaded asynchronously) and can be null
+            userAgent?.let { put("_userAgent", it) }
             putAll(sessionProperties)
         }
 
     init {
         appcuesCoroutineScope.launch {
-            applicationProperties["_userAgent"] = contextResources.getUserAgent()
+            userAgent = contextResources.getUserAgent()
         }
     }
 

--- a/appcues/src/main/java/com/appcues/util/ContextResources.kt
+++ b/appcues/src/main/java/com/appcues/util/ContextResources.kt
@@ -55,7 +55,7 @@ internal class ContextResources(private val context: Context) {
         return getCurrentLocale(context).language
     }
 
-    suspend fun getUserAgent() = withContext(Dispatchers.Main) {
+    suspend fun getUserAgent(): String? = withContext(Dispatchers.Main) {
         // this must be on main thread
         return@withContext WebView(context).settings.userAgentString
     }


### PR DESCRIPTION
_userAgent was being put into the hashMap async which could lead to unwanted ConcurrentModificationException.