### PR TITLE
Update Koin to version 3.1.6

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -14,6 +14,7 @@ ext.room_version = '2.4.3'
 ext.compose_version = '1.2.0'
 ext.compose_compiler_version = '1.2.0'
 ext.accompanist_version = '0.25.0'
+ext.koin_version = '3.1.6'
 
 android {
     compileSdk 32
@@ -94,8 +95,8 @@ dependencies {
     implementation 'com.squareup.moshi:moshi:1.13.0'
     kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.13.0'
     // Dependency Injection
-    implementation "io.insert-koin:koin-core:3.1.4"
-    implementation "io.insert-koin:koin-android:3.1.4"
+    implementation "io.insert-koin:koin-core:$koin_version"
+    implementation "io.insert-koin:koin-android:$koin_version"
     // View Pager
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     // Webview


### PR DESCRIPTION
Update from 3.1.4 to 3.1.6 brings a few internal fixes https://github.com/InsertKoinIO/koin/blob/main/CHANGELOG.md.  This version was created back on April 18, 2022.