### PR TITLE
Support row level vertical alignment specification

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -155,12 +155,12 @@ internal fun ComponentStyle.getFontWeight(): FontWeight? {
     return null
 }
 
-internal fun ComponentStyle.getVerticalAlignment(): Alignment.Vertical {
+internal fun ComponentStyle.getVerticalAlignment(default: Alignment.Vertical): Alignment.Vertical {
     return when (verticalAlignment) {
         ComponentVerticalAlignment.TOP -> Alignment.Top
         ComponentVerticalAlignment.CENTER -> Alignment.CenterVertically
         ComponentVerticalAlignment.BOTTOM -> Alignment.Bottom
-        null -> Alignment.CenterVertically
+        null -> default
     }
 }
 

--- a/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,14 +29,16 @@ import java.util.UUID
 
 @Composable
 internal fun HorizontalStackPrimitive.Compose(modifier: Modifier) {
+
+    val verticalAlignment = style.getVerticalAlignment(CenterVertically)
     Row(
         modifier = modifier,
         horizontalArrangement = distribution.toHorizontalArrangement(spacing),
-        verticalAlignment = style.getVerticalAlignment()
+        verticalAlignment = verticalAlignment
     ) {
         ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
             items.forEach {
-                ItemBox(distribution = distribution, style = it.style) {
+                ItemBox(distribution = distribution, style = it.style, parentVerticalAlignment = verticalAlignment) {
                     it.Compose()
                 }
             }
@@ -47,11 +50,12 @@ internal fun HorizontalStackPrimitive.Compose(modifier: Modifier) {
 private fun RowScope.ItemBox(
     distribution: ComponentDistribution,
     style: ComponentStyle,
+    parentVerticalAlignment: Alignment.Vertical,
     content: @Composable BoxScope.() -> Unit
 ) {
     Box(
         modifier = Modifier
-            .align(style.getVerticalAlignment())
+            .align(style.getVerticalAlignment(parentVerticalAlignment))
             .then(if (distribution == ComponentDistribution.EQUAL) Modifier.weight(1f) else Modifier),
         contentAlignment = style.getBoxAlignment(),
         content = content


### PR DESCRIPTION
Fairly simple proposed fix for the issue noted here https://app.shortcut.com/appcues/story/39841/image-sizing-issues-from-ui-tests about hstack alignment discrepancies between ios/android

allow the row level vertical alignment to apply to the items within, rather than setting them to CenterVertically by default - that is still the fallback default if nothing else set.