### PR TITLE
Add error logging when Coil fails to load images

### DIFF
--- a/appcues/src/main/java/com/appcues/logging/Logcues.kt
+++ b/appcues/src/main/java/com/appcues/logging/Logcues.kt
@@ -23,9 +23,9 @@ internal class Logcues(private val loggingLevel: LoggingLevel) {
         }
     }
 
-    fun error(exception: Exception) {
+    fun error(throwable: Throwable) {
         if (loggingLevel > NONE) {
-            Log.e(TAG, exception.message.toString())
+            Log.e(TAG, throwable.message.toString())
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -91,7 +91,8 @@ internal class AppcuesActivity : AppCompatActivity() {
     private fun Composition() {
         CompositionLocalProvider(
             LocalAppcuesActionDelegate provides AppcuesActions { viewModel.onAction(it) },
-            LocalAppcuesPaginationDelegate provides AppcuesPagination { viewModel.onPageChanged(it) }
+            LocalAppcuesPaginationDelegate provides AppcuesPagination { viewModel.onPageChanged(it) },
+            LocalLogcues provides scope.get(),
         ) {
             Box(
                 modifier = Modifier.fillMaxSize(),

--- a/appcues/src/main/java/com/appcues/ui/AppcuesCompositions.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesCompositions.kt
@@ -35,7 +35,11 @@ internal data class AppcuesPagination(val onPageChanged: (Int) -> Unit)
 
 internal val appcuesPaginationData = mutableStateOf(AppcuesPaginationData(1, 0, 0.0f))
 
-internal val LocalLogcues = staticCompositionLocalOf<Logcues?> { null }
+internal val LocalLogcues = staticCompositionLocalOf<Logcues> { noLocalProvidedFor("LocalLogcues") }
+
+private fun noLocalProvidedFor(name: String): Nothing {
+    error("CompositionLocal $name not present")
+}
 
 /**
  * rememberAppcuesPaginationState is used by traits that wants to know updates about pagination data

--- a/appcues/src/main/java/com/appcues/ui/AppcuesCompositions.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesCompositions.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import coil.ImageLoader
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.Action
+import com.appcues.logging.Logcues
 import com.appcues.trait.AppcuesPaginationData
 import java.util.UUID
 
@@ -33,6 +34,8 @@ internal val LocalAppcuesPaginationDelegate = compositionLocalOf { AppcuesPagina
 internal data class AppcuesPagination(val onPageChanged: (Int) -> Unit)
 
 internal val appcuesPaginationData = mutableStateOf(AppcuesPaginationData(1, 0, 0.0f))
+
+internal val LocalLogcues = staticCompositionLocalOf<Logcues?> { null }
 
 /**
  * rememberAppcuesPaginationState is used by traits that wants to know updates about pagination data

--- a/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
@@ -100,7 +100,7 @@ internal fun BoxScope.BackgroundImage(style: ComponentStyle) {
                 alignment = getBoxAlignment(horizontalAlignment, verticalAlignment),
                 error = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
                 onError = {
-                    logcues?.error(it.result.throwable)
+                    logcues.error(it.result.throwable)
                 },
             )
         }

--- a/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
@@ -24,6 +24,7 @@ import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.LocalAppcuesActionDelegate
 import com.appcues.ui.LocalAppcuesActions
 import com.appcues.ui.LocalImageLoader
+import com.appcues.ui.LocalLogcues
 import com.appcues.ui.extensions.PrimitiveGestureProperties
 import com.appcues.ui.extensions.blurHashPlaceholder
 import com.appcues.ui.extensions.getBoxAlignment
@@ -86,6 +87,7 @@ internal fun BoxScope.BackgroundImage(style: ComponentStyle) {
     if (style.backgroundImage != null) {
         with(style.backgroundImage) {
             val context = LocalContext.current
+            val logcues = LocalLogcues.current
             val decodedBlurHash = rememberBlurHashDecoded(blurHash = blurHash)
 
             AsyncImage(
@@ -97,6 +99,9 @@ internal fun BoxScope.BackgroundImage(style: ComponentStyle) {
                 contentScale = contentMode.toImageAsyncContentScale(),
                 alignment = getBoxAlignment(horizontalAlignment, verticalAlignment),
                 error = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
+                onError = {
+                    logcues?.error(it.result.throwable)
+                },
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/ImagePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ImagePrimitive.kt
@@ -32,7 +32,7 @@ internal fun ImagePrimitive.Compose(modifier: Modifier, matchParentBox: BoxScope
         contentScale = contentMode.toImageAsyncContentScale(),
         error = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
         onError = {
-            logcues?.error(it.result.throwable)
+            logcues.error(it.result.throwable)
         },
     )
 }

--- a/appcues/src/main/java/com/appcues/ui/primitive/ImagePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ImagePrimitive.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImage
 import com.appcues.data.model.ExperiencePrimitive.ImagePrimitive
 import com.appcues.ui.LocalImageLoader
+import com.appcues.ui.LocalLogcues
 import com.appcues.ui.extensions.blurHashPlaceholder
 import com.appcues.ui.extensions.getImageLoader
 import com.appcues.ui.extensions.getImageRequest
@@ -19,6 +20,7 @@ import com.appcues.ui.utils.rememberBlurHashDecoded
 @Composable
 internal fun ImagePrimitive.Compose(modifier: Modifier, matchParentBox: BoxScope? = null) {
     val context = LocalContext.current
+    val logcues = LocalLogcues.current
     val decodedBlurHash = rememberBlurHashDecoded(blurHash = blurHash)
 
     AsyncImage(
@@ -29,6 +31,9 @@ internal fun ImagePrimitive.Compose(modifier: Modifier, matchParentBox: BoxScope
         placeholder = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
         contentScale = contentMode.toImageAsyncContentScale(),
         error = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
+        onError = {
+            logcues?.error(it.result.throwable)
+        },
     )
 }
 

--- a/appcues/src/test/java/com/appcues/action/ActionRegistryTest.kt
+++ b/appcues/src/test/java/com/appcues/action/ActionRegistryTest.kt
@@ -47,6 +47,6 @@ internal class ActionRegistryTest : AppcuesScopeTest {
         // THEN
         assertThat(action).isEqualTo(actionFromRegistry)
         assertThat(action).isNotEqualTo(actionDupe)
-        verify { logcues.error(exception = any()) }
+        verify { logcues.error(throwable = any()) }
     }
 }


### PR DESCRIPTION
Minor improvement in logging - noticed while working on dependencies in Xamarin binding that Coil can silently fail for various reasons and our logging did not give any indication as to why.