### PR TITLE
Add new LocalLogcues provider to the function used in snapshot testing for primitives

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -11,9 +11,10 @@ import com.appcues.data.mapper.step.primitives.EmbedPrimitiveMapper
 import com.appcues.data.mapper.step.primitives.ImagePrimitiveMapper
 import com.appcues.data.mapper.step.primitives.StackPrimitiveMapper
 import com.appcues.data.mapper.step.primitives.TextPrimitiveMapper
-import com.appcues.data.model.ExperiencePrimitive
 import com.appcues.data.remote.response.step.StepContentResponse
+import com.appcues.logging.Logcues
 import com.appcues.ui.LocalImageLoader
+import com.appcues.ui.LocalLogcues
 import com.appcues.ui.primitive.Compose
 
 @Composable
@@ -29,7 +30,10 @@ fun ComposeContent(json: String, imageLoader: ImageLoader) {
     )
     val primitive = mapper.map(response!!)
 
-    CompositionLocalProvider(LocalImageLoader provides imageLoader) {
+    CompositionLocalProvider(
+        LocalImageLoader provides imageLoader,
+        LocalLogcues provides Logcues(LoggingLevel.DEBUG)
+    ) {
         primitive.Compose()
     }
 }


### PR DESCRIPTION
This is just a detail missed yesterday in #219 - we have this helper function that snapshot tests use to test primitive rendering, and it needs the same LocalLogcues option provided, otherwise tests can throw exceptions.