### PR TITLE
🐛 Fix debugger position overlayed on Experiences

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -20,10 +20,13 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.core.os.bundleOf
@@ -39,6 +42,9 @@ import com.appcues.ui.AppcuesViewModel.UIState.Dismissing
 import com.appcues.ui.AppcuesViewModel.UIState.Rendering
 import com.appcues.ui.primitive.Compose
 import com.appcues.ui.theme.AppcuesTheme
+import com.appcues.ui.utils.margin
+import com.appcues.util.getNavigationBarHeight
+import com.appcues.util.getStatusBarHeight
 import org.koin.core.scope.Scope
 
 internal class AppcuesActivity : AppCompatActivity() {
@@ -95,7 +101,9 @@ internal class AppcuesActivity : AppCompatActivity() {
             LocalLogcues provides scope.get(),
         ) {
             Box(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .margin(rememberSystemMarginsState().value),
                 contentAlignment = Alignment.Center,
             ) {
                 // collect all UIState
@@ -116,6 +124,16 @@ internal class AppcuesActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    @Composable
+    private fun rememberSystemMarginsState(): State<PaddingValues> {
+        val density = LocalDensity.current
+        val topMargin = rememberUpdatedState(newValue = with(density) { LocalContext.current.getStatusBarHeight().toDp() })
+        val bottomMargin = rememberUpdatedState(newValue = with(density) { LocalContext.current.getNavigationBarHeight().toDp() })
+        // will calculate status bar height and navigation bar height and return it in PaddingValues
+        // this is derived state to handle possible changes to values in top and bottom margin
+        return derivedStateOf { PaddingValues(top = topMargin.value, bottom = bottomMargin.value) }
     }
 
     @Composable

--- a/appcues/src/main/res/values/themes.xml
+++ b/appcues/src/main/res/values/themes.xml
@@ -14,6 +14,6 @@
         <item name="android:backgroundDimEnabled">false</item>
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">true</item>
-        <item name="android:fitsSystemWindows">true</item>
+        <item name="android:fitsSystemWindows">false</item>
     </style>
 </resources>


### PR DESCRIPTION
While preparing Ionic samples I noticed that the debugger was not properly being displayed on top of experiences. this is because of a change for a previous bug we worked on, so instead of using fitSystemWindow=true that forces the activity content (decorView) to apply padding we are applying the padding ourselves in root composition, this way we dont mess up with debugger standard behavior to apply padding.

PS: accidentally pushed UI tests updates to main, but here is the commit: https://github.com/appcues/appcues-mobile-experience-spec/commit/c292d23588bbea15fab925102b7b68d5ea98756a