### PR TITLE
Implement initial UI controls for textInput and optionSelect primitives

### DIFF
--- a/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
@@ -3,8 +3,11 @@ package com.appcues.data.model
 import com.appcues.data.model.styling.ComponentContentMode
 import com.appcues.data.model.styling.ComponentContentMode.FIT
 import com.appcues.data.model.styling.ComponentControlPosition
+import com.appcues.data.model.styling.ComponentControlPosition.LEADING
 import com.appcues.data.model.styling.ComponentDataType
+import com.appcues.data.model.styling.ComponentDataType.TEXT
 import com.appcues.data.model.styling.ComponentDisplayFormat
+import com.appcues.data.model.styling.ComponentDisplayFormat.VERTICAL_LIST
 import com.appcues.data.model.styling.ComponentDistribution
 import com.appcues.data.model.styling.ComponentDistribution.CENTER
 import com.appcues.data.model.styling.ComponentSelectMode
@@ -71,13 +74,13 @@ internal sealed class ExperiencePrimitive(
         override val id: UUID,
         override val style: ComponentStyle = ComponentStyle(),
         val label: TextPrimitive,
-        val placeholder: String?,
-        val defaultValue: String?,
-        val required: Boolean,
-        val numberOfLines: Int,
-        val maxLength: Int?,
-        val dataType: ComponentDataType,
-        val textFieldStyle: ComponentStyle,
+        val placeholder: String? = null,
+        val defaultValue: String? = null,
+        val required: Boolean = false,
+        val numberOfLines: Int = 1,
+        val maxLength: Int? = null,
+        val dataType: ComponentDataType = TEXT,
+        val textFieldStyle: ComponentStyle = ComponentStyle(),
     ) : ExperiencePrimitive(id, style)
 
     data class OptionSelectPrimitive(
@@ -86,10 +89,10 @@ internal sealed class ExperiencePrimitive(
         val label: TextPrimitive,
         val selectMode: ComponentSelectMode,
         val options: List<OptionItem>,
-        val defaultValue: List<String>,
-        val required: Boolean,
-        val controlPosition: ComponentControlPosition,
-        val displayFormat: ComponentDisplayFormat,
+        val defaultValue: List<String> = listOf(),
+        val required: Boolean = false,
+        val controlPosition: ComponentControlPosition = LEADING,
+        val displayFormat: ComponentDisplayFormat = VERTICAL_LIST,
     ) : ExperiencePrimitive(id, style) {
         data class OptionItem(
             val value: String,

--- a/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
@@ -67,8 +67,8 @@ internal fun ExperiencePrimitive.Compose(matchParentBox: BoxScope? = null) {
                 is ImagePrimitive -> Compose(modifier, matchParentBox)
                 is TextPrimitive -> Compose(modifier)
                 is VerticalStackPrimitive -> Compose(modifier)
-                is TextInputPrimitive -> throw NotImplementedError()
-                is OptionSelectPrimitive -> throw NotImplementedError()
+                is TextInputPrimitive -> Compose(modifier)
+                is OptionSelectPrimitive -> Compose(modifier)
             }
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -1,0 +1,139 @@
+package com.appcues.ui.primitive
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.zIndex
+import com.appcues.R
+import com.appcues.data.model.ExperiencePrimitive.OptionSelectPrimitive
+import com.appcues.data.model.styling.ComponentControlPosition
+import com.appcues.data.model.styling.ComponentControlPosition.BOTTOM
+import com.appcues.data.model.styling.ComponentControlPosition.HIDDEN
+import com.appcues.data.model.styling.ComponentControlPosition.LEADING
+import com.appcues.data.model.styling.ComponentControlPosition.TOP
+import com.appcues.data.model.styling.ComponentControlPosition.TRAILING
+import com.appcues.data.model.styling.ComponentDisplayFormat.HORIZONTAL_LIST
+import com.appcues.data.model.styling.ComponentDisplayFormat.PICKER
+import com.appcues.data.model.styling.ComponentDisplayFormat.VERTICAL_LIST
+import com.appcues.data.model.styling.ComponentSelectMode
+import com.appcues.data.model.styling.ComponentSelectMode.MULTIPLE
+import com.appcues.data.model.styling.ComponentSelectMode.SINGLE
+import com.appcues.ui.extensions.getHorizontalAlignment
+
+@Composable
+internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = style.getHorizontalAlignment(),
+    ) {
+        label.Compose()
+
+        when {
+            selectMode == SINGLE && displayFormat == PICKER -> {
+                var expanded by remember { mutableStateOf(false) }
+                var selectedIndex by remember { mutableStateOf(0) }
+
+                Box(modifier = Modifier.clickable(onClick = { expanded = true })) {
+                    options[selectedIndex].content.Compose()
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false },
+                        modifier = Modifier
+                            .background(Color.White)
+                    ) {
+                        options.forEachIndexed { index, optionItem ->
+                            DropdownMenuItem(onClick = {
+                                selectedIndex = index
+                                expanded = false
+                            }) {
+                                optionItem.content.Compose()
+                            }
+                        }
+                    }
+                }
+            }
+            displayFormat == HORIZONTAL_LIST -> {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    options.Compose(selected = false, selectMode = selectMode, controlPosition = controlPosition)
+                }
+            }
+            displayFormat == VERTICAL_LIST -> {
+                Column(horizontalAlignment = Alignment.Start) {
+                    options.Compose(selected = false, selectMode = selectMode, controlPosition = controlPosition)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun List<OptionSelectPrimitive.OptionItem>.Compose(
+    selected: Boolean,
+    selectMode: ComponentSelectMode,
+    controlPosition: ComponentControlPosition
+) {
+    forEach {
+
+        var isSelected by remember { mutableStateOf(selected) }
+
+        val selectionToggle = Modifier.clickable { isSelected = !isSelected }
+
+        when (controlPosition) {
+            LEADING -> Row(modifier = selectionToggle) {
+                selectMode.Compose(selected = isSelected)
+                it.content.Compose()
+            }
+            TRAILING -> Row(modifier = selectionToggle) {
+                it.content.Compose()
+                selectMode.Compose(selected = isSelected)
+            }
+            TOP -> Column(modifier = selectionToggle) {
+                selectMode.Compose(selected = isSelected)
+                it.content.Compose()
+            }
+            BOTTOM -> Column(modifier = selectionToggle) {
+                it.content.Compose()
+                selectMode.Compose(selected = isSelected)
+            }
+            HIDDEN -> Box(modifier = selectionToggle) {
+                it.content.Compose()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ComponentSelectMode.Compose(
+    selected: Boolean
+) {
+    val resId = when (this) {
+        SINGLE -> when (selected) {
+            true -> R.drawable.appcues_ic_radio_button_selected
+            false -> R.drawable.appcues_ic_radio_button_unselected
+        }
+        MULTIPLE -> when (selected) {
+            true -> R.drawable.appcues_ic_check_box_selected
+            false -> R.drawable.appcues_ic_check_box_unselected
+        }
+    }
+
+    Image(
+        painter = painterResource(id = resId), 
+        contentDescription = null,
+        modifier = Modifier.zIndex(1f)
+    )
+}

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -1,0 +1,127 @@
+package com.appcues.ui.primitive
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import com.appcues.data.model.ExperiencePrimitive.TextInputPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.styling.ComponentColor
+import com.appcues.data.model.styling.ComponentDataType
+import com.appcues.data.model.styling.ComponentDataType.ADDRESS
+import com.appcues.data.model.styling.ComponentDataType.EMAIL
+import com.appcues.data.model.styling.ComponentDataType.NAME
+import com.appcues.data.model.styling.ComponentDataType.NUMBER
+import com.appcues.data.model.styling.ComponentDataType.PHONE
+import com.appcues.data.model.styling.ComponentDataType.TEXT
+import com.appcues.ui.extensions.applyStyle
+import com.appcues.ui.theme.AppcuesPreviewPrimitive
+import java.util.UUID
+
+@Composable
+internal fun TextInputPrimitive.Compose(modifier: Modifier) {
+
+    var text by remember { mutableStateOf(defaultValue ?: "") }
+
+    // TBD what this should actually look like in our product, and how builder
+    // styling options will apply.
+    // Several customization options for TextField noted here https://stackoverflow.com/a/68592613
+    TextField(
+        value = text,
+        onValueChange = {
+            if (maxLength == null || it.length <= maxLength) {
+                text = it
+            }
+        },
+        modifier = modifier,
+        label = { label.Compose(modifier = Modifier) },
+        textStyle = LocalTextStyle.current.applyStyle(
+            style = textFieldStyle,
+            context = LocalContext.current,
+            isDark = isSystemInDarkTheme(),
+        ),
+        maxLines = numberOfLines,
+        singleLine = numberOfLines == 1,
+        placeholder = placeholder?.let {
+            // future plan is to replace this with a text primitive directly
+            {
+                Text(text = it)
+            }
+        },
+        keyboardOptions = KeyboardOptions(keyboardType = mapKeyboardType(dataType)),
+    )
+}
+
+private fun mapKeyboardType(value: ComponentDataType): KeyboardType = when (value) {
+    TEXT -> KeyboardType.Text
+    NUMBER -> KeyboardType.Number
+    EMAIL -> KeyboardType.Email
+    PHONE -> KeyboardType.Phone
+    NAME -> KeyboardType.Text
+    ADDRESS -> KeyboardType.Text
+}
+
+private val textPrimitive = TextPrimitive(
+    id = UUID.randomUUID(),
+    text = "Enter a value",
+)
+
+private val textInputPrimitive = TextInputPrimitive(
+    id = UUID.randomUUID(),
+    label = textPrimitive,
+    defaultValue = "text input",
+)
+
+@Composable
+@Preview(name = "textInput default", group = "basic")
+internal fun PreviewTestInputDefault() {
+    AppcuesPreviewPrimitive {
+        textInputPrimitive
+    }
+}
+
+@Composable
+@Preview(name = "textInput multiline", group = "basic")
+internal fun PreviewTestInputMultiline() {
+    AppcuesPreviewPrimitive {
+        textInputPrimitive.copy(
+            numberOfLines = 3,
+            defaultValue = "here is\nsome text that\ngoes multi line\nover limit"
+        )
+    }
+}
+
+@Composable
+@Preview(name = "textInput foregroundColor", group = "properties")
+internal fun PreviewTextInputComponentColor() {
+    val previewPrimitive = textInputPrimitive.copy(
+        textFieldStyle = textInputPrimitive.textFieldStyle.copy(
+            foregroundColor = ComponentColor(light = 0xFF000000, dark = 0xFFFFFFFF)
+        ),
+        label = textPrimitive.copy(
+            style = textPrimitive.style.copy(
+                foregroundColor = ComponentColor(light = 0xFF101010, dark = 0xFF808080)
+            )
+        )
+    )
+
+    Column {
+        AppcuesPreviewPrimitive(isDark = true) {
+            previewPrimitive
+        }
+        AppcuesPreviewPrimitive(isDark = false) {
+            previewPrimitive
+        }
+    }
+}

--- a/appcues/src/main/res/drawable/appcues_ic_check_box_selected.xml
+++ b/appcues/src/main/res/drawable/appcues_ic_check_box_selected.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.11,0 2,-0.9 2,-2L21,5c0,-1.1 -0.89,-2 -2,-2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/appcues/src/main/res/drawable/appcues_ic_check_box_unselected.xml
+++ b/appcues/src/main/res/drawable/appcues_ic_check_box_unselected.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M19,5v14H5V5h14m0,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/appcues/src/main/res/drawable/appcues_ic_radio_button_selected.xml
+++ b/appcues/src/main/res/drawable/appcues_ic_radio_button_selected.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5 5,-2.24 5,-5 -2.24,-5 -5,-5zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/appcues/src/main/res/drawable/appcues_ic_radio_button_unselected.xml
+++ b/appcues/src/main/res/drawable/appcues_ic_radio_button_unselected.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>


### PR DESCRIPTION
Spent some time looking at UI options and implemented a basic first version that just uses standard controls for now.  We don't have final requirements for how this is actually supposed to look and the related stying options, so I'm just going to checkpoint this work here for now and go look at the actual persisting/reporting of user input state portion.  We can come back to UI styling when the requirements are known.

| checkbox - vertical | checkbox - horizontal | radio | picker |
| ---- | ----- | ----- | ----|
| ![checkbox_vert](https://user-images.githubusercontent.com/19266448/187491157-fd704ef6-0ba4-4f4c-8d62-731b7e87c883.gif) | ![checkbox_horiz](https://user-images.githubusercontent.com/19266448/187491314-ea5acdaf-ac3d-4fdf-8604-b02de6b9dbb0.gif) | ![radio_vert](https://user-images.githubusercontent.com/19266448/187491329-0884e826-2e0c-49c5-a53d-a217c454cdd9.gif) | ![picker](https://user-images.githubusercontent.com/19266448/187491354-2abd2ee4-8d6d-4746-828a-ece7401eb82b.gif) | 



