### PR TITLE
Revise the UI for form input controls from review/feedback

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -29,7 +29,6 @@ import com.appcues.data.model.styling.ComponentControlPosition.TOP
 import com.appcues.data.model.styling.ComponentControlPosition.TRAILING
 import com.appcues.data.model.styling.ComponentDisplayFormat.HORIZONTAL_LIST
 import com.appcues.data.model.styling.ComponentDisplayFormat.PICKER
-import com.appcues.data.model.styling.ComponentDisplayFormat.VERTICAL_LIST
 import com.appcues.data.model.styling.ComponentSelectMode
 import com.appcues.data.model.styling.ComponentSelectMode.MULTIPLE
 import com.appcues.data.model.styling.ComponentSelectMode.SINGLE
@@ -76,7 +75,7 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
                     }
                 }
             }
-            displayFormat == VERTICAL_LIST -> {
+            else -> { // VERTICAL_LIST case or a fallback (i.e. a PICKER but with multi-select, invalid)
                 Column(horizontalAlignment = Alignment.Start) {
                     options.ComposeSelections(
                         selectedValues = selectedValues.value,

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -2,18 +2,23 @@ package com.appcues.ui.primitive
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.appcues.data.model.ExperiencePrimitive.TextInputPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
 import com.appcues.data.model.styling.ComponentColor
@@ -27,6 +32,7 @@ import com.appcues.data.model.styling.ComponentDataType.TEXT
 import com.appcues.ui.ExperienceStepFormItem.SingleTextFormItem
 import com.appcues.ui.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.extensions.applyStyle
+import com.appcues.ui.extensions.getHorizontalAlignment
 import com.appcues.ui.theme.AppcuesPreviewPrimitive
 import java.util.UUID
 
@@ -40,33 +46,44 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
         formState.captureFormItem(this@Compose.id, SingleTextFormItem(label.text, required, text.value))
     }
 
-    // TBD what this should actually look like in our product, and how builder
-    // styling options will apply.
-    // Several customization options for TextField noted here https://stackoverflow.com/a/68592613
-    TextField(
-        value = text.value,
-        onValueChange = {
-            if (maxLength == null || it.length <= maxLength) {
-                text.value = it
-            }
-        },
-        modifier = modifier,
-        label = { label.Compose(modifier = Modifier) },
-        textStyle = LocalTextStyle.current.applyStyle(
-            style = textFieldStyle,
-            context = LocalContext.current,
-            isDark = isSystemInDarkTheme(),
-        ),
-        maxLines = numberOfLines,
-        singleLine = numberOfLines == 1,
-        placeholder = placeholder?.let {
-            // future plan is to replace this with a text primitive directly
-            {
-                Text(text = it)
-            }
-        },
-        keyboardOptions = KeyboardOptions(keyboardType = mapKeyboardType(dataType)),
-    )
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = style.getHorizontalAlignment(),
+    ) {
+        label.Compose()
+
+        // Several styling customization options for TextField noted here https://stackoverflow.com/a/68592613
+        OutlinedTextField(
+            value = text.value,
+            onValueChange = {
+                if (maxLength == null || it.length <= maxLength) {
+                    text.value = it
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            textStyle = LocalTextStyle.current.applyStyle(
+                style = textFieldStyle,
+                context = LocalContext.current,
+                isDark = isSystemInDarkTheme(),
+            ),
+            shape = RoundedCornerShape(8.dp),
+            maxLines = numberOfLines,
+            singleLine = numberOfLines == 1,
+            placeholder = placeholder?.let {
+                // future plan is to replace this with a text primitive directly
+                {
+                    Text(text = it)
+                }
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = mapKeyboardType(dataType)),
+            colors = TextFieldDefaults.textFieldColors(
+                backgroundColor = Color.Transparent,
+                cursorColor = Color.Black,
+                focusedIndicatorColor = Color.LightGray,
+                unfocusedIndicatorColor = Color.LightGray
+            ),
+        )
+    }
 }
 
 private fun mapKeyboardType(value: ComponentDataType): KeyboardType = when (value) {

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -32,6 +32,7 @@ import com.appcues.data.model.styling.ComponentDataType.TEXT
 import com.appcues.ui.ExperienceStepFormItem.SingleTextFormItem
 import com.appcues.ui.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.extensions.applyStyle
+import com.appcues.ui.extensions.getColor
 import com.appcues.ui.extensions.getHorizontalAlignment
 import com.appcues.ui.theme.AppcuesPreviewPrimitive
 import java.util.UUID
@@ -79,8 +80,8 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
             colors = TextFieldDefaults.textFieldColors(
                 backgroundColor = Color.Transparent,
                 cursorColor = Color.Black,
-                focusedIndicatorColor = Color.LightGray,
-                unfocusedIndicatorColor = Color.LightGray
+                focusedIndicatorColor = textFieldStyle.borderColor?.getColor(isSystemInDarkTheme()) ?: Color.Transparent,
+                unfocusedIndicatorColor = textFieldStyle.borderColor?.getColor(isSystemInDarkTheme()) ?: Color.Transparent,
             ),
         )
     }


### PR DESCRIPTION
* optionSelect - ensure `verticalList` form is used as fallback for any invalid settings
* textField - revisions to provide a more basic / standardized look and feel - using OutlinedTextField but with no label animation or highlight colors, a border defined by `textFieldStyle.borderColor`; special case control that defaults to fill available width (`fillMaxWidth()` usage here)

![android_inputs](https://user-images.githubusercontent.com/19266448/188008033-0eeb71dc-8bbe-4d68-bb76-527e2da52f86.gif)
