### PR TITLE
Update form controls for latest model spec changes

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapper.kt
@@ -1,6 +1,7 @@
 package com.appcues.data.mapper.step.primitives
 
 import com.appcues.data.mapper.step.mapPrimitive
+import com.appcues.data.mapper.styling.mapComponentColor
 import com.appcues.data.mapper.styling.mapComponentStyle
 import com.appcues.data.model.ExperiencePrimitive.OptionSelectPrimitive
 import com.appcues.data.model.ExperiencePrimitive.OptionSelectPrimitive.OptionItem
@@ -19,6 +20,11 @@ internal fun OptionSelectPrimitiveResponse.mapOptionSelectPrimitive() = OptionSe
     required = required ?: false,
     controlPosition = mapComponentControlPosition(controlPosition),
     displayFormat = mapComponentDisplayFormat(displayFormat),
+    pickerStyle = pickerStyle?.mapComponentStyle(),
+    placeholder = placeholder?.mapPrimitive(),
+    selectedColor = selectedColor?.mapComponentColor(),
+    unselectedColor = unselectedColor?.mapComponentColor(),
+    accentColor = accentColor?.mapComponentColor()
 )
 
 private fun mapComponentSelectMode(value: String) = when (value) {

--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/TextInputPrimitiveMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/TextInputPrimitiveMapper.kt
@@ -1,5 +1,6 @@
 package com.appcues.data.mapper.step.primitives
 
+import com.appcues.data.mapper.styling.mapComponentColor
 import com.appcues.data.mapper.styling.mapComponentStyle
 import com.appcues.data.model.ExperiencePrimitive.TextInputPrimitive
 import com.appcues.data.model.styling.ComponentDataType
@@ -9,13 +10,14 @@ internal fun TextInputPrimitiveResponse.mapTextInputPrimitive() = TextInputPrimi
     id = id,
     style = style.mapComponentStyle(),
     label = label.mapTextPrimitive(),
-    placeholder = placeholder,
+    placeholder = placeholder?.mapTextPrimitive(),
     defaultValue = defaultValue,
     required = required ?: false,
     numberOfLines = numberOfLines ?: 1,
     maxLength = maxLength,
     dataType = mapComponentDataType(dataType),
     textFieldStyle = textFieldStyle.mapComponentStyle(),
+    cursorColor = cursorColor?.mapComponentColor(),
 )
 
 private fun mapComponentDataType(value: String?) = when (value) {

--- a/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
@@ -1,5 +1,6 @@
 package com.appcues.data.model
 
+import com.appcues.data.model.styling.ComponentColor
 import com.appcues.data.model.styling.ComponentContentMode
 import com.appcues.data.model.styling.ComponentContentMode.FIT
 import com.appcues.data.model.styling.ComponentControlPosition
@@ -74,13 +75,14 @@ internal sealed class ExperiencePrimitive(
         override val id: UUID,
         override val style: ComponentStyle = ComponentStyle(),
         val label: TextPrimitive,
-        val placeholder: String? = null,
+        val placeholder: ExperiencePrimitive? = null,
         val defaultValue: String? = null,
         val required: Boolean = false,
         val numberOfLines: Int = 1,
         val maxLength: Int? = null,
         val dataType: ComponentDataType = TEXT,
         val textFieldStyle: ComponentStyle = ComponentStyle(),
+        val cursorColor: ComponentColor? = null,
     ) : ExperiencePrimitive(id, style)
 
     data class OptionSelectPrimitive(
@@ -93,6 +95,11 @@ internal sealed class ExperiencePrimitive(
         val required: Boolean = false,
         val controlPosition: ComponentControlPosition = LEADING,
         val displayFormat: ComponentDisplayFormat = VERTICAL_LIST,
+        val pickerStyle: ComponentStyle? = ComponentStyle(),
+        val placeholder: ExperiencePrimitive? = null,
+        val selectedColor: ComponentColor? = null,
+        val unselectedColor: ComponentColor? = null,
+        val accentColor: ComponentColor? = null,
     ) : ExperiencePrimitive(id, style) {
         data class OptionItem(
             val value: String,

--- a/appcues/src/main/java/com/appcues/data/remote/response/step/primitive/PrimitiveResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/step/primitive/PrimitiveResponse.kt
@@ -10,6 +10,7 @@ import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.Type.OP
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.Type.STACK
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.Type.TEXT
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.Type.TEXT_INPUT
+import com.appcues.data.remote.response.styling.StyleColorResponse
 import com.appcues.data.remote.response.styling.StyleResponse
 import com.appcues.data.remote.response.styling.StyleSizeResponse
 import java.util.UUID
@@ -88,6 +89,11 @@ internal sealed class PrimitiveResponse(
         val required: Boolean?,
         val controlPosition: String?,
         val displayFormat: String?,
+        val placeholder: PrimitiveResponse?,
+        val pickerStyle: StyleResponse?,
+        val selectedColor: StyleColorResponse?,
+        val unselectedColor: StyleColorResponse?,
+        val accentColor: StyleColorResponse?,
     ) : PrimitiveResponse(OPTION_SELECT) {
 
         data class OptionItem(
@@ -101,12 +107,13 @@ internal sealed class PrimitiveResponse(
         val id: UUID,
         val style: StyleResponse? = null,
         val label: TextPrimitiveResponse,
-        val placeholder: String?,
+        val placeholder: TextPrimitiveResponse?,
         val defaultValue: String?,
         val required: Boolean?,
         val numberOfLines: Int?,
         val maxLength: Int?,
         val dataType: String?,
         val textFieldStyle: StyleResponse?,
+        val cursorColor: StyleColorResponse?,
     ) : PrimitiveResponse(TEXT_INPUT)
 }

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,6 +34,7 @@ import com.appcues.ui.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.extensions.applyStyle
 import com.appcues.ui.extensions.getColor
 import com.appcues.ui.extensions.getHorizontalAlignment
+import com.appcues.ui.extensions.styleBorder
 import com.appcues.ui.theme.AppcuesPreviewPrimitive
 import java.util.UUID
 
@@ -61,7 +62,9 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
                     text.value = it
                 }
             },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .styleBorder(textFieldStyle, isSystemInDarkTheme()),
             textStyle = LocalTextStyle.current.applyStyle(
                 style = textFieldStyle,
                 context = LocalContext.current,
@@ -71,17 +74,17 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
             maxLines = numberOfLines,
             singleLine = numberOfLines == 1,
             placeholder = placeholder?.let {
-                // future plan is to replace this with a text primitive directly
                 {
-                    Text(text = it)
+                    it.Compose()
                 }
             },
             keyboardOptions = KeyboardOptions(keyboardType = mapKeyboardType(dataType)),
             colors = TextFieldDefaults.textFieldColors(
                 backgroundColor = Color.Transparent,
-                cursorColor = Color.Black,
-                focusedIndicatorColor = textFieldStyle.borderColor?.getColor(isSystemInDarkTheme()) ?: Color.Transparent,
-                unfocusedIndicatorColor = textFieldStyle.borderColor?.getColor(isSystemInDarkTheme()) ?: Color.Transparent,
+                // the builder should always send this value, but default to the theme like the standard default behavior
+                cursorColor = cursorColor?.getColor(isSystemInDarkTheme()) ?: MaterialTheme.colors.primary,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
             ),
         )
     }

--- a/appcues/src/main/res/drawable/appcues_ic_drop_down.xml
+++ b/appcues/src/main/res/drawable/appcues_ic_drop_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,15 L7,10H17Z"/>
+</vector>


### PR DESCRIPTION
This gets things up to speed with the model changes in https://github.com/appcues/appcues-mobile-experience-spec/pull/74

Also, adds the `picker` styling to match general speculation about what it should look like from recent convos

![Screen Shot 2022-09-02 at 11 41 49 AM](https://user-images.githubusercontent.com/19266448/188190355-53a86186-ec96-4f90-b45c-fc5b426b7024.png)
