### PR TITLE
Add support for maintaining form state at Step level, initial analytics tracking

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -1,7 +1,11 @@
 package com.appcues.analytics
 
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.FORM_SUBMITTED
 import com.appcues.data.model.Experience
 import com.appcues.statemachine.Error
+import com.appcues.ui.ExperienceStepFormItemState
+import com.appcues.ui.ExperienceStepFormItemState.OptionSelectFormItemState
+import com.appcues.ui.ExperienceStepFormItemState.TextInputFormItemState
 
 internal sealed class ExperienceLifecycleEvent(
     open val experience: Experience,
@@ -16,7 +20,12 @@ internal sealed class ExperienceLifecycleEvent(
     data class StepInteraction(
         override val experience: Experience,
         val stepIndex: Int,
-    ) : ExperienceLifecycleEvent(experience, AnalyticsEvent.ExperienceStepInteraction)
+        val interactionType: InteractionType,
+    ) : ExperienceLifecycleEvent(experience, AnalyticsEvent.ExperienceStepInteraction) {
+        enum class InteractionType {
+            FORM_SUBMITTED
+        }
+    }
 
     data class StepCompleted(
         override val experience: Experience,
@@ -72,6 +81,9 @@ internal sealed class ExperienceLifecycleEvent(
                 this["stepIndex"] = "${experience.groupLookup[it] ?: 0},${experience.stepIndexLookup[it] ?: 0}"
                 this["stepType"] = step.type
             }
+            customProperties?.let {
+                putAll(it)
+            }
             error?.let {
                 this["message"] = it.message
                 this["errorId"] = it.id.toString()
@@ -94,5 +106,43 @@ internal sealed class ExperienceLifecycleEvent(
             is StepError -> stepError
             is ExperienceError -> experienceError
             else -> null
+        }
+
+    private val customProperties: HashMap<String, Any>?
+        get() = when (this) {
+            is StepInteraction -> {
+                flatStepIndex?.let {
+                    val step = experience.flatSteps[it]
+                    hashMapOf(
+                        "interactionType" to interactionType.analyticsName(),
+                        "interactionData" to hashMapOf(
+                            "formResponse" to step.formState.formItems.map { formItem ->
+                                formItem.analyticsProperties()
+                            }
+                        ),
+                    )
+                }
+            }
+            else -> null
+        }
+
+    private fun StepInteraction.InteractionType.analyticsName() =
+        when (this) {
+            FORM_SUBMITTED -> "Form Submitted"
+        }
+
+    private fun ExperienceStepFormItemState.analyticsProperties() =
+        hashMapOf<String, Any>(
+            "fieldId" to id.toString(),
+            "fieldType" to type,
+            "fieldRequired" to isRequired,
+            "label" to label,
+            "value" to formattedValues()
+        )
+
+    private fun ExperienceStepFormItemState.formattedValues() =
+        when (this) {
+            is TextInputFormItemState -> value
+            is OptionSelectFormItemState -> values.joinToString(",") // need actual CSV-ifying
         }
 }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -7,6 +7,8 @@ import com.appcues.analytics.ExperienceLifecycleEvent.ExperienceError
 import com.appcues.analytics.ExperienceLifecycleEvent.ExperienceStarted
 import com.appcues.analytics.ExperienceLifecycleEvent.StepCompleted
 import com.appcues.analytics.ExperienceLifecycleEvent.StepError
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.FORM_SUBMITTED
 import com.appcues.analytics.ExperienceLifecycleEvent.StepSeen
 import com.appcues.statemachine.Error
 import com.appcues.statemachine.State
@@ -55,6 +57,15 @@ internal class ExperienceLifecycleTracker(
                     }
                     is EndingStep -> {
                         trackLifecycleEvent(StepCompleted(it.experience, it.flatStepIndex))
+
+                        // TESTING!
+                        // this is a spot where we can output the interaction analytics to validate structure, but still TBD
+                        // on the rules around when these should be submitted related to actions in the UI.  Also, may need
+                        // a way to plug in user profile attributes with the form answers, as web does.
+                        val formState = it.experience.flatSteps[it.flatStepIndex].formState
+                        if (formState.formItems.any() && formState.isFormComplete.value) {
+                            trackLifecycleEvent(StepInteraction(it.experience, it.flatStepIndex, FORM_SUBMITTED))
+                        }
                     }
                     is EndingExperience -> {
                         if (it.isExperienceCompleted()) {

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -7,8 +7,6 @@ import com.appcues.analytics.ExperienceLifecycleEvent.ExperienceError
 import com.appcues.analytics.ExperienceLifecycleEvent.ExperienceStarted
 import com.appcues.analytics.ExperienceLifecycleEvent.StepCompleted
 import com.appcues.analytics.ExperienceLifecycleEvent.StepError
-import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction
-import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.FORM_SUBMITTED
 import com.appcues.analytics.ExperienceLifecycleEvent.StepSeen
 import com.appcues.statemachine.Error
 import com.appcues.statemachine.State
@@ -57,15 +55,6 @@ internal class ExperienceLifecycleTracker(
                     }
                     is EndingStep -> {
                         trackLifecycleEvent(StepCompleted(it.experience, it.flatStepIndex))
-
-                        // TESTING!
-                        // this is a spot where we can output the interaction analytics to validate structure, but still TBD
-                        // on the rules around when these should be submitted related to actions in the UI.  Also, may need
-                        // a way to plug in user profile attributes with the form answers, as web does.
-                        val formState = it.experience.flatSteps[it.flatStepIndex].formState
-                        if (formState.formItems.any() && formState.isFormComplete.value) {
-                            trackLifecycleEvent(StepInteraction(it.experience, it.flatStepIndex, FORM_SUBMITTED))
-                        }
                     }
                     is EndingExperience -> {
                         if (it.isExperienceCompleted()) {

--- a/appcues/src/main/java/com/appcues/data/model/Step.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Step.kt
@@ -1,6 +1,7 @@
 package com.appcues.data.model
 
 import com.appcues.trait.StepDecoratingTrait
+import com.appcues.ui.ExperienceStepFormState
 import java.util.UUID
 
 internal data class Step(
@@ -9,4 +10,5 @@ internal data class Step(
     val stepDecoratingTraits: List<StepDecoratingTrait>,
     val actions: Map<UUID, List<Action>>,
     val type: String?,
+    val formState: ExperienceStepFormState = ExperienceStepFormState(),
 )

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -242,7 +242,7 @@ internal class AppcuesActivity : AppCompatActivity() {
                 .padding(paddingValues = stepDecoratingPadding.paddingValues.value)
                 .testTag("page_$index")
         ) {
-            CompositionLocalProvider(LocalExperienceStepFormStateDelegate provides ExperienceStepFormState()) {
+            CompositionLocalProvider(LocalExperienceStepFormStateDelegate provides formState) {
                 content.Compose()
             }
         }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceStepFormState.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceStepFormState.kt
@@ -1,39 +1,102 @@
 package com.appcues.ui
 
 import androidx.compose.runtime.mutableStateOf
+import com.appcues.data.model.ExperiencePrimitive.OptionSelectPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextInputPrimitive
+import com.appcues.ui.ExperienceStepFormItemState.OptionSelectFormItemState
+import com.appcues.ui.ExperienceStepFormItemState.TextInputFormItemState
 import java.util.UUID
 
 internal class ExperienceStepFormState {
-    private var formItems: HashMap<UUID, ExperienceStepFormItem> = hashMapOf()
+    private var _formItems: HashMap<UUID, ExperienceStepFormItemState> = hashMapOf()
+
+    private var itemIndex = 0
+
+    val formItems: Collection<ExperienceStepFormItemState>
+        get() = _formItems.values.sortedBy { it.index }
 
     // this can be used by buttons needing to know if they are enabled or not based on required input
     val isFormComplete = mutableStateOf(true)
 
-    fun captureFormItem(id: UUID, item: ExperienceStepFormItem) {
-        formItems[id] = item
-        isFormComplete.value = !formItems.values.any { !it.isComplete }
+    fun getValue(primitive: TextInputPrimitive) =
+        getItem(primitive).value
+
+    fun setValue(primitive: TextInputPrimitive, value: String) {
+        val item = getItem(primitive)
+        item.value = value
+        updateFormItem(item)
+    }
+
+    fun getValue(primitive: OptionSelectPrimitive) =
+        getItem(primitive).values
+
+    fun setValue(primitive: OptionSelectPrimitive, values: Set<String>) {
+        val item = getItem(primitive)
+        item.values = values
+        updateFormItem(item)
+    }
+
+    private fun getItem(primitive: TextInputPrimitive): TextInputFormItemState {
+        var item = _formItems[primitive.id] as? TextInputFormItemState
+        if (item != null) return item
+
+        // create new state tracking object
+        item = with(primitive) {
+            TextInputFormItemState(itemIndex++, id, "textInput", label.text, required, defaultValue ?: "")
+        }
+        updateFormItem(item)
+        return item
+    }
+
+    private fun getItem(primitive: OptionSelectPrimitive): OptionSelectFormItemState {
+        var item = _formItems[primitive.id] as? OptionSelectFormItemState
+        if (item != null) return item
+
+        // create new state tracking object
+        item = with(primitive) {
+            OptionSelectFormItemState(itemIndex++, id, "optionSelect", label.text, required, defaultValue)
+        }
+        updateFormItem(item)
+        return item
+    }
+
+    private fun updateFormItem(item: ExperienceStepFormItemState) {
+        _formItems[item.id] = item
+        isFormComplete.value = !_formItems.values.any { !it.isComplete }
     }
 }
 
-internal sealed class ExperienceStepFormItem(open val label: String, open val isRequired: Boolean) {
+internal sealed class ExperienceStepFormItemState(
+    open val index: Int,
+    open val id: UUID,
+    open val type: String,
+    open val label: String,
+    open val isRequired: Boolean,
+) {
 
     val isComplete: Boolean
         get() {
             return when (this) {
-                is MultipleTextFormItem -> !isRequired || values.isNotEmpty()
-                is SingleTextFormItem -> !isRequired || value.isNotBlank()
+                is OptionSelectFormItemState -> !isRequired || values.isNotEmpty()
+                is TextInputFormItemState -> !isRequired || value.isNotBlank()
             }
         }
 
-    class SingleTextFormItem(
+    class TextInputFormItemState(
+        override val index: Int,
+        override val id: UUID,
+        override val type: String,
         override val label: String,
         override val isRequired: Boolean,
         var value: String,
-    ) : ExperienceStepFormItem(label, isRequired)
+    ) : ExperienceStepFormItemState(index, id, type, label, isRequired)
 
-    class MultipleTextFormItem(
+    class OptionSelectFormItemState(
+        override val index: Int,
+        override val id: UUID,
+        override val type: String,
         override val label: String,
         override val isRequired: Boolean,
-        val values: Set<String>
-    ) : ExperienceStepFormItem(label, isRequired)
+        var values: Set<String>
+    ) : ExperienceStepFormItemState(index, id, type, label, isRequired)
 }

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,8 +45,6 @@ import com.appcues.data.model.styling.ComponentSelectMode
 import com.appcues.data.model.styling.ComponentSelectMode.MULTIPLE
 import com.appcues.data.model.styling.ComponentSelectMode.SINGLE
 import com.appcues.data.model.styling.ComponentStyle
-import com.appcues.ui.ExperienceStepFormItem.MultipleTextFormItem
-import com.appcues.ui.ExperienceStepFormItem.SingleTextFormItem
 import com.appcues.ui.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.extensions.getColor
 import com.appcues.ui.extensions.getHorizontalAlignment
@@ -56,14 +53,11 @@ import com.appcues.ui.extensions.styleBorder
 @Composable
 internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
     val formState = LocalExperienceStepFormStateDelegate.current
-    val selectedValues = remember { mutableStateOf(defaultValue) }
+    val selectedValues = remember { mutableStateOf(formState.getValue(this)) }
 
-    LaunchedEffect(key1 = selectedValues.value) {
-        val formItem = when (selectMode) {
-            MULTIPLE -> MultipleTextFormItem(label.text, required, selectedValues.value)
-            SINGLE -> SingleTextFormItem(label.text, required, selectedValues.value.firstOrNull() ?: "")
-        }
-        formState.captureFormItem(this@Compose.id, formItem)
+    fun setSelectedValues(values: Set<String>) {
+        selectedValues.value = values
+        formState.setValue(this, values)
     }
 
     Column(
@@ -82,7 +76,7 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
                     placeholder = placeholder,
                     accentColor = accentColor?.getColor(isSystemInDarkTheme()),
                 ) {
-                    selectedValues.value = it
+                    setSelectedValues(it)
                 }
             }
             displayFormat == HORIZONTAL_LIST -> {
@@ -95,7 +89,7 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
                         unselectedColor = unselectedColor.getColor(isSystemInDarkTheme()),
                         accentColor = accentColor.getColor(isSystemInDarkTheme()),
                     ) {
-                        selectedValues.value = it
+                        setSelectedValues(it)
                     }
                 }
             }
@@ -109,7 +103,7 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
                         unselectedColor = unselectedColor.getColor(isSystemInDarkTheme()),
                         accentColor = accentColor.getColor(isSystemInDarkTheme()),
                     ) {
-                        selectedValues.value = it
+                        setSelectedValues(it)
                     }
                 }
             }

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -10,7 +10,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -29,7 +28,6 @@ import com.appcues.data.model.styling.ComponentDataType.NAME
 import com.appcues.data.model.styling.ComponentDataType.NUMBER
 import com.appcues.data.model.styling.ComponentDataType.PHONE
 import com.appcues.data.model.styling.ComponentDataType.TEXT
-import com.appcues.ui.ExperienceStepFormItem.SingleTextFormItem
 import com.appcues.ui.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.extensions.applyStyle
 import com.appcues.ui.extensions.getColor
@@ -42,11 +40,7 @@ import java.util.UUID
 internal fun TextInputPrimitive.Compose(modifier: Modifier) {
 
     val formState = LocalExperienceStepFormStateDelegate.current
-    val text = remember { mutableStateOf(defaultValue ?: "") }
-
-    LaunchedEffect(key1 = text.value) {
-        formState.captureFormItem(this@Compose.id, SingleTextFormItem(label.text, required, text.value))
-    }
+    val text = remember { mutableStateOf(formState.getValue(this)) }
 
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -60,6 +54,7 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
             onValueChange = {
                 if (maxLength == null || it.length <= maxLength) {
                     text.value = it
+                    formState.setValue(this@Compose, it)
                 }
             },
             modifier = Modifier


### PR DESCRIPTION
Adds our form state object `ExperienceStepFormState` to the domain model for `Step`, and then use this value in the CompositionLocal that gets sent into the compose primitives.  This way, we can retain the form state in the domain model as the user moves through steps, and restore previous values if they return to a step.  It also has the data prepared in a way that makes it easy to submit analytics from the Experience and Step model later on.

This change also takes a first pass at formatting the `appcues:v2:step_interaction` event with the `interactionType` and `interactionData` from the initial proposal. This form is still TBD, but this gets some initial structure in place that we can fine tune formatting on as needed later.

There are still some details to polish up, and I'll note inline as needed - but this should at least progress things forward as much as possible at this point, as we continue to refine the requirements for exactly how the form UX should work.

Example of form state persisting through steps in different containers / compositions:
![form_state_steps](https://user-images.githubusercontent.com/19266448/189210097-dfbfb4d1-5557-4e40-980a-e96e4d427e68.gif)

Example analytics output:
![Screen Shot 2022-09-08 at 3 33 41 PM](https://user-images.githubusercontent.com/19266448/189210259-a57aad93-1ba5-4ce0-838c-de17c6bad9ce.png)
