### PR TITLE
Ensure selectedContent is used, if available, for selected item(s) in optionSelect

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -151,22 +151,22 @@ private fun List<OptionSelectPrimitive.OptionItem>.ComposeSelections(
         when (controlPosition) {
             LEADING -> Row(verticalAlignment = Alignment.CenterVertically) {
                 selectMode.Compose(isSelected, selectedColor, unselectedColor, accentColor) { updateSelection(it.value, !isSelected) }
-                it.content.Compose()
+                it.contentView(isSelected).Compose()
             }
             TRAILING -> Row(verticalAlignment = Alignment.CenterVertically) {
-                it.content.Compose()
+                it.contentView(isSelected).Compose()
                 selectMode.Compose(isSelected, selectedColor, unselectedColor, accentColor) { updateSelection(it.value, !isSelected) }
             }
             TOP -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 selectMode.Compose(isSelected, selectedColor, unselectedColor, accentColor) { updateSelection(it.value, !isSelected) }
-                it.content.Compose()
+                it.contentView(isSelected).Compose()
             }
             BOTTOM -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                it.content.Compose()
+                it.contentView(isSelected).Compose()
                 selectMode.Compose(isSelected, selectedColor, unselectedColor, accentColor) { updateSelection(it.value, !isSelected) }
             }
             HIDDEN -> Box(modifier = Modifier.clickable { updateSelection(it.value, !isSelected) }) {
-                it.content.Compose()
+                it.contentView(isSelected).Compose()
             }
         }
     }
@@ -216,15 +216,15 @@ private fun List<OptionSelectPrimitive.OptionItem>.ComposePicker(
     valueSelectionChanged: (Set<String>) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val selectedValue = selectedValues.firstOrNull()
     Box(modifier = Modifier.clickable(onClick = { expanded = true })) {
         // 1. render the selected item as the collapsed state
         Row(modifier = modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             // we should always either have a selected item, or a placeholder, or this will just be a blank
             // box with a dropdown arrow
-            val selectedValue = selectedValues.firstOrNull()
             if (selectedValue != null) {
                 // if we have a selected value, we assume one of our options will match it, and compose it
-                this@ComposePicker.firstOrNull { it.value == selectedValue }?.content?.Compose()
+                this@ComposePicker.firstOrNull { it.value == selectedValue }?.contentView(true)?.Compose()
             } else {
                 // no selection, render a placeholder, if exists
                 placeholder?.Compose()
@@ -250,9 +250,16 @@ private fun List<OptionSelectPrimitive.OptionItem>.ComposePicker(
                     expanded = false
                     valueSelectionChanged(setOf(it.value))
                 }) {
-                    it.content.Compose()
+                    it.contentView(selectedValue == it.value).Compose()
                 }
             }
         }
     }
 }
+
+private fun OptionSelectPrimitive.OptionItem.contentView(isSelected: Boolean) =
+    if (isSelected) {
+        selectedContent ?: content
+    } else {
+        content
+    }


### PR DESCRIPTION
Bug found in testing recent work - this is so the custom selection mode (not a typical radio/checkbox) like the `8` option shown here will use the defined selected style.

More generally, the data model allows optional custom selected style in any context, which should now be respected.

![Screen Shot 2022-09-09 at 10 09 30 AM](https://user-images.githubusercontent.com/19266448/189369748-6c0030e3-a3a2-4eec-92eb-b4efab2bd215.png)
