### PR TITLE
Simplify to use TextField instead of OutlinedTextField

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -55,7 +55,7 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
         label.Compose()
 
         // Several styling customization options for TextField noted here https://stackoverflow.com/a/68592613
-        OutlinedTextField(
+        TextField(
             value = text.value,
             onValueChange = {
                 if (maxLength == null || it.length <= maxLength) {


### PR DESCRIPTION
Minor update, but no reason we would need `OutlinedTextField` really, since we draw our own border around the input based on the component JSON definition.

Side note, came up in discussion that the Compose TextField bakes in 16dp padding around the input, which cannot easily be adjusted or edited based on `textFieldStyle` in the JSON.  It looks like to do so, we'd need to do something like this https://stackoverflow.com/a/68601606 and copy the TextField source and modify it - hoping to avoid that.  Maybe 16dp default padding is ok here, similar to radio and checkbox padding, to give standard Android touch target behaviors.