### PR TITLE
Additional clean up on form controls from test review

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -7,6 +7,8 @@ import com.appcues.data.MoshiConfiguration
 import com.appcues.data.mapper.step.mapPrimitive
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse
 import com.appcues.logging.Logcues
+import com.appcues.ui.ExperienceStepFormState
+import com.appcues.ui.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.LocalImageLoader
 import com.appcues.ui.LocalLogcues
 import com.appcues.ui.primitive.Compose
@@ -20,7 +22,8 @@ fun ComposeContent(json: String, imageLoader: ImageLoader) {
     AppcuesTheme {
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
-            LocalLogcues provides Logcues(LoggingLevel.DEBUG)
+            LocalLogcues provides Logcues(LoggingLevel.DEBUG),
+            LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
         ) {
             primitive.Compose()
         }

--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -10,16 +10,19 @@ import com.appcues.logging.Logcues
 import com.appcues.ui.LocalImageLoader
 import com.appcues.ui.LocalLogcues
 import com.appcues.ui.primitive.Compose
+import com.appcues.ui.theme.AppcuesTheme
 
 @Composable
 fun ComposeContent(json: String, imageLoader: ImageLoader) {
     val response = MoshiConfiguration.moshi.adapter(PrimitiveResponse::class.java).fromJson(json)
     val primitive = response!!.mapPrimitive()
 
-    CompositionLocalProvider(
-        LocalImageLoader provides imageLoader,
-        LocalLogcues provides Logcues(LoggingLevel.DEBUG)
-    ) {
-        primitive.Compose()
+    AppcuesTheme {
+        CompositionLocalProvider(
+            LocalImageLoader provides imageLoader,
+            LocalLogcues provides Logcues(LoggingLevel.DEBUG)
+        ) {
+            primitive.Compose()
+        }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
@@ -81,7 +81,7 @@ internal fun Modifier.modalStyle(
     else Modifier
 )
 
-private fun Modifier.styleBackground(
+internal fun Modifier.styleBackground(
     style: ComponentStyle,
     isDark: Boolean,
     defaultColor: Color? = null
@@ -154,7 +154,7 @@ private fun Modifier.styleDefaultWidth(contentMode: ComponentContentMode) = this
     }
 )
 
-private fun Modifier.styleCorner(style: ComponentStyle) = this.then(
+internal fun Modifier.styleCorner(style: ComponentStyle) = this.then(
     when {
         style.cornerRadius ne 0.0 -> Modifier.clip(RoundedCornerShape(style.cornerRadius.dp))
         else -> Modifier

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -80,7 +80,7 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
                 }
             }
             displayFormat == HORIZONTAL_LIST -> {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(verticalAlignment = controlPosition.getVerticalAlignment() ?: Alignment.CenterVertically) {
                     options.ComposeSelections(
                         selectedValues = selectedValues.value,
                         selectMode = selectMode,
@@ -94,7 +94,7 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
                 }
             }
             else -> { // VERTICAL_LIST case or a fallback (i.e. a PICKER but with multi-select, invalid)
-                Column(horizontalAlignment = Alignment.Start) {
+                Column(horizontalAlignment = controlPosition.getHorizontalAlignment() ?: Alignment.CenterHorizontally) {
                     options.ComposeSelections(
                         selectedValues = selectedValues.value,
                         selectMode = selectMode,
@@ -110,6 +110,20 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
         }
     }
 }
+
+private fun ComponentControlPosition.getVerticalAlignment() =
+    when (this) {
+        TOP -> Alignment.Top
+        BOTTOM -> Alignment.Bottom
+        else -> null
+    }
+
+private fun ComponentControlPosition.getHorizontalAlignment() =
+    when (this) {
+        LEADING -> Alignment.Start
+        TRAILING -> Alignment.End
+        else -> null
+    }
 
 @Composable
 private fun List<OptionSelectPrimitive.OptionItem>.ComposeSelections(


### PR DESCRIPTION
Some touch up work on the optionSelect and textInput components from recent snapshot test review and related iOS work.

* The optionSelect primitive now uses the `controlPosition` alignment value to derive the alignment of the parent vertical or horizontal stack.  ex: a verticalList layout with controlPosition of trailing will align the rows within the column to trailing edge - allowing the checkboxes or radio buttons to line up consistently.
* The ComposeContent helper is updated to wrap the composition in the AppcuesTheme, as it was discovered that the lack of this could lead to some discrepancy in the snapshot test results versus actual rendered content - this should make the tests more realistic
* The textInput primitive will now respect additional styling settings that were missed before - such as backgroundColor and additional padding (16dp default is fixed in the Compose TextField)
* The textInput primitive will set it's height based on the `numberOfLines` property - so a 3 line textInput will allocate a height to show all three lines, rather than a single line that grows as you type (default Compose behavior)