### PR TITLE
Survey control updates and analytics

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
@@ -29,13 +29,17 @@ internal class AnalyticsTracker(
         }
     }
 
-    fun identify(properties: Map<String, Any>? = null) {
+    fun identify(properties: Map<String, Any>? = null, interactive: Boolean = true) {
         if (!analyticsPolicy.canIdentify()) return
 
         activityBuilder.identify(properties).let {
             updateAnalyticsFlow(IDENTIFY, false, it)
 
-            analyticsQueueProcessor.flushThenSend(it)
+            if (interactive) {
+                analyticsQueueProcessor.flushThenSend(it)
+            } else {
+                analyticsQueueProcessor.queue(it)
+            }
         }
     }
 

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -144,8 +144,8 @@ private fun ExperienceStepFormState.formattedAsFormResponse() = hashMapOf(
 
 private fun ExperienceStepFormItemState.formattedValues() =
     when (this) {
-        is TextInputFormItemState -> value
-        is OptionSelectFormItemState -> values.joinToString(",") // need actual CSV-ifying
+        is TextInputFormItemState -> text.value
+        is OptionSelectFormItemState -> values.value.joinToString(",") // need actual CSV-ifying
     }
 
 internal fun ExperienceStepFormState.formattedAsProfileUpdate() = formItems.associate {

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -119,7 +119,7 @@ internal sealed class ExperienceLifecycleEvent(
                     val step = experience.flatSteps[it]
                     hashMapOf(
                         INTERACTION_TYPE_KEY to interactionType.analyticsName(),
-                        INTERACTION_DATA_KEY to when(interactionType) {
+                        INTERACTION_DATA_KEY to when (interactionType) {
                             FORM_SUBMITTED -> step.formState
                         },
                     )

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -1,5 +1,6 @@
 package com.appcues.analytics
 
+import com.appcues.analytics.ExperienceLifecycleEvent.Companion.FORM_RESPONSE_KEY
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.FORM_SUBMITTED
 import com.appcues.data.model.Experience
 import com.appcues.statemachine.Error
@@ -13,6 +14,12 @@ internal sealed class ExperienceLifecycleEvent(
     open val experience: Experience,
     val event: AnalyticsEvent
 ) {
+    companion object {
+        const val INTERACTION_TYPE_KEY = "interactionType"
+        const val INTERACTION_DATA_KEY = "interactionData"
+        const val FORM_RESPONSE_KEY = "formResponse"
+        const val FORM_SUBMITTED_INTERACTION_TYPE = "Form Submitted"
+    }
 
     data class StepSeen(
         override val experience: Experience,
@@ -116,8 +123,8 @@ internal sealed class ExperienceLifecycleEvent(
                 flatStepIndex?.let {
                     val step = experience.flatSteps[it]
                     hashMapOf(
-                        "interactionType" to interactionType.analyticsName(),
-                        "interactionData" to step.formState.formattedAsFormResponse(),
+                        INTERACTION_TYPE_KEY to interactionType.analyticsName(),
+                        INTERACTION_DATA_KEY to step.formState.formattedAsFormResponse(),
                     )
                 }
             }
@@ -126,12 +133,12 @@ internal sealed class ExperienceLifecycleEvent(
 
     private fun StepInteraction.InteractionType.analyticsName() =
         when (this) {
-            FORM_SUBMITTED -> "Form Submitted"
+            FORM_SUBMITTED -> FORM_SUBMITTED_INTERACTION_TYPE
         }
 }
 
 private fun ExperienceStepFormState.formattedAsFormResponse() = hashMapOf(
-    "formResponse" to formItems.map { formItem ->
+    FORM_RESPONSE_KEY to formItems.map { formItem ->
         hashMapOf<String, Any>(
             "fieldId" to formItem.id.toString(),
             "fieldType" to formItem.type,

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -95,7 +95,7 @@ internal class ExperienceLifecycleTracker(
             // must occur before calling this function
 
             // set user profile attributes to capture the form question/answer
-            analyticsTracker.identify(formState.formattedAsProfileUpdate())
+            analyticsTracker.identify(formState.formattedAsProfileUpdate(), interactive = false)
 
             // track the interaction event
             trackLifecycleEvent(StepInteraction(experience, flatStepIndex, FORM_SUBMITTED))

--- a/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
+++ b/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
@@ -1,6 +1,7 @@
 package com.appcues.data
 
 import com.appcues.data.remote.adapters.DateAdapter
+import com.appcues.data.remote.adapters.ExperienceStepFormStateAdapter
 import com.appcues.data.remote.adapters.StepContainerAdapter
 import com.appcues.data.remote.adapters.UUIDAdapter
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse
@@ -25,6 +26,7 @@ internal object MoshiConfiguration {
         .add(UUIDAdapter())
         .add(getPrimitiveFactory())
         .add(StepContainerAdapter())
+        .add(ExperienceStepFormStateAdapter())
         .add(KotlinJsonAdapterFactory())
         .build()
 

--- a/appcues/src/main/java/com/appcues/data/remote/adapters/ExperienceStepFormStateAdapter.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/adapters/ExperienceStepFormStateAdapter.kt
@@ -1,0 +1,39 @@
+package com.appcues.data.remote.adapters
+
+import com.appcues.ui.ExperienceStepFormState
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.ToJson
+import java.util.UUID
+
+@JsonClass(generateAdapter = true)
+internal data class ExperienceStepFormStateRequestItem(
+    val fieldId: UUID,
+    val fieldType: String,
+    val fieldRequired: Boolean,
+    val label: String,
+    val value: String,
+)
+
+internal class ExperienceStepFormStateAdapter {
+    @FromJson
+    @Suppress("UnusedPrivateMember", "UNUSED_PARAMETER") // required by Moshi
+    fun fromJson(formState: ExperienceStepFormStateRequestItem): ExperienceStepFormState {
+        throw UnsupportedOperationException("step container only supports serialization")
+    }
+
+    @ToJson
+    fun toJson(formState: ExperienceStepFormState): Map<String, List<ExperienceStepFormStateRequestItem>> {
+        return hashMapOf(
+            "formResponse" to formState.formItems.map {
+                ExperienceStepFormStateRequestItem(
+                    fieldId = it.id,
+                    fieldType = it.type,
+                    fieldRequired = it.isRequired,
+                    label = it.label,
+                    value = it.value,
+                )
+            }
+        )
+    }
+}

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
@@ -17,6 +17,7 @@ import com.appcues.debugger.model.DebuggerEventItemPropertySection
 import com.appcues.debugger.model.EventType
 import com.appcues.debugger.ui.toEventTitle
 import com.appcues.debugger.ui.toEventType
+import com.appcues.ui.ExperienceStepFormState
 import com.appcues.util.ContextResources
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -167,18 +168,11 @@ internal class DebuggerRecentEventsManager(
     }
 
     private fun Map<String, Any>.getFormResponse(): Map<String, Any?> {
-        @Suppress("UNCHECKED_CAST")
-        val interactionDataValue = this[ExperienceLifecycleEvent.INTERACTION_DATA_KEY] as? Map<String, Any>
-        interactionDataValue?.let { interactionData ->
-            @Suppress("UNCHECKED_CAST")
-            val formResponse = interactionData[ExperienceLifecycleEvent.FORM_RESPONSE_KEY] as? List<Map<String, Any>>
-            formResponse?.let { responseValue ->
-                return responseValue.associate { responseItem ->
-                    responseItem["label"] as String to responseItem["value"]
-                }
+        return (this[ExperienceLifecycleEvent.INTERACTION_DATA_KEY] as? ExperienceStepFormState)?.let {
+            it.formItems.associate { itemState ->
+                itemState.label to itemState.value
             }
-        }
-        return mapOf()
+        } ?: mapOf()
     }
 
     private fun getEventDisplayName(

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
@@ -31,7 +31,6 @@ internal class DebuggerRecentEventsManager(
 ) {
 
     companion object {
-
         private const val MAX_RECENT_EVENTS = 20
         private const val IDENTITY_PROPERTY_PREFIX = "_"
     }
@@ -148,33 +147,6 @@ internal class DebuggerRecentEventsManager(
         }
     }
 
-    private fun Map<String, Any>.filterOutScreenProperties(eventType: EventType): Map<String, Any> {
-        return if (eventType == EventType.SCREEN) {
-            filterNot { it.key == ActivityRequestBuilder.SCREEN_TITLE_ATTRIBUTE }
-        } else this
-    }
-
-    private fun Map<String, Any>.filterOutAutoProperties(): Map<String, Any> {
-        return filterNot { it.key == AutoPropertyDecorator.IDENTITY_PROPERTY }
-    }
-
-    private fun Map<String, Any>.filterOutInteractionData(): Map<String, Any> {
-        return filterNot { it.key == ExperienceLifecycleEvent.INTERACTION_DATA_KEY }
-    }
-
-    private fun Map<String, Any>.getAutoProperties(): Map<String, Any> {
-        @Suppress("UNCHECKED_CAST")
-        return (this[AutoPropertyDecorator.IDENTITY_PROPERTY] as Map<String, Any>?) ?: mapOf()
-    }
-
-    private fun Map<String, Any>.getFormResponse(): Map<String, Any?> {
-        return (this[ExperienceLifecycleEvent.INTERACTION_DATA_KEY] as? ExperienceStepFormState)?.let {
-            it.formItems.associate { itemState ->
-                itemState.label to itemState.value
-            }
-        } ?: mapOf()
-    }
-
     private fun getEventDisplayName(
         event: EventRequest,
         type: EventType,
@@ -192,8 +164,6 @@ internal class DebuggerRecentEventsManager(
             addAll(list.filter { it.first.startsWith(IDENTITY_PROPERTY_PREFIX) }.sortByPropertyName())
         }
     }
-
-    private fun List<Pair<String, Any?>>.sortByPropertyName(): List<Pair<String, Any?>> = sortedBy { it.first }
 
     private fun ArrayList<DebuggerEventItem>.addFirst(element: DebuggerEventItem) {
         add(0, element)
@@ -215,3 +185,32 @@ internal class DebuggerRecentEventsManager(
         _data.emit(list)
     }
 }
+
+private fun Map<String, Any>.filterOutScreenProperties(eventType: EventType): Map<String, Any> {
+    return if (eventType == EventType.SCREEN) {
+        filterNot { it.key == ActivityRequestBuilder.SCREEN_TITLE_ATTRIBUTE }
+    } else this
+}
+
+private fun Map<String, Any>.filterOutAutoProperties(): Map<String, Any> {
+    return filterNot { it.key == AutoPropertyDecorator.IDENTITY_PROPERTY }
+}
+
+private fun Map<String, Any>.getAutoProperties(): Map<String, Any> {
+    @Suppress("UNCHECKED_CAST")
+    return (this[AutoPropertyDecorator.IDENTITY_PROPERTY] as Map<String, Any>?) ?: mapOf()
+}
+
+private fun Map<String, Any>.filterOutInteractionData(): Map<String, Any> {
+    return filterNot { it.key == ExperienceLifecycleEvent.INTERACTION_DATA_KEY }
+}
+
+private fun Map<String, Any>.getFormResponse(): Map<String, Any?> {
+    return (this[ExperienceLifecycleEvent.INTERACTION_DATA_KEY] as? ExperienceStepFormState)?.let {
+        it.formItems.associate { itemState ->
+            itemState.label to itemState.value
+        }
+    } ?: mapOf()
+}
+
+private fun List<Pair<String, Any?>>.sortByPropertyName(): List<Pair<String, Any?>> = sortedBy { it.first }

--- a/appcues/src/main/java/com/appcues/debugger/model/DebuggerEventItem.kt
+++ b/appcues/src/main/java/com/appcues/debugger/model/DebuggerEventItem.kt
@@ -7,11 +7,9 @@ internal data class DebuggerEventItem(
     val type: EventType,
     val timestamp: Long,
     val name: String,
-    val properties: List<Pair<String, Any>>?,
-    val identityProperties: List<Pair<String, Any>>?,
+    val propertySections: List<DebuggerEventItemPropertySection>,
     var showOnFab: Boolean = true,
 ) {
-
     // overriding equals and hashCode allows StateFlow to emit the
     // collection even if elements are the same. useful when we change property showOnFab to false
     // and try to emit the collection again
@@ -24,3 +22,8 @@ internal data class DebuggerEventItem(
 internal enum class EventType {
     EXPERIENCE, GROUP_UPDATE, USER_PROFILE, CUSTOM, SCREEN, SESSION
 }
+
+internal data class DebuggerEventItemPropertySection(
+    val title: String,
+    val properties: List<Pair<String, Any?>>?
+)

--- a/appcues/src/main/java/com/appcues/debugger/ui/details/DebuggerEventDetails.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/details/DebuggerEventDetails.kt
@@ -59,16 +59,11 @@ internal fun DebuggerEventDetails(debuggerEventItem: DebuggerEventItem?, onBackP
 
         details(debuggerEventItem)
 
-        if (debuggerEventItem.properties != null && debuggerEventItem.properties.isNotEmpty()) {
-            propertiesTitle()
-
-            properties(debuggerEventItem.properties)
-        }
-
-        if (debuggerEventItem.identityProperties != null && debuggerEventItem.identityProperties.isNotEmpty()) {
-            identityPropertiesTitle()
-
-            properties(debuggerEventItem.identityProperties)
+        debuggerEventItem.propertySections.forEach {
+            if (it.properties != null && it.properties.isNotEmpty()) {
+                propertiesTitle(it.title)
+                properties(it.properties)
+            }
         }
     }
 
@@ -137,10 +132,10 @@ private fun LazyListScope.details(event: DebuggerEventItem) {
     }
 }
 
-private fun LazyListScope.propertiesTitle() {
+private fun LazyListScope.propertiesTitle(title: String) {
     item {
         Text(
-            text = LocalContext.current.getString(R.string.appcues_debugger_event_details_properties_title),
+            text = title,
             modifier = Modifier.padding(start = 40.dp, top = 20.dp, bottom = 16.dp),
             fontSize = 14.sp,
             fontWeight = FontWeight.SemiBold,
@@ -149,21 +144,9 @@ private fun LazyListScope.propertiesTitle() {
     }
 }
 
-private fun LazyListScope.identityPropertiesTitle() {
-    item {
-        Text(
-            text = LocalContext.current.getString(R.string.appcues_debugger_event_details_identity_auto_properties_title),
-            modifier = Modifier.padding(start = 40.dp, top = 20.dp, bottom = 16.dp),
-            fontSize = 14.sp,
-            fontWeight = FontWeight.SemiBold,
-            color = AppcuesColors.HadfieldBlue,
-        )
-    }
-}
-
-private fun LazyListScope.properties(properties: List<Pair<String, Any>>) {
+private fun LazyListScope.properties(properties: List<Pair<String, Any?>>) {
     items(properties.toList()) { item ->
-        ListItem(key = item.first, value = item.second.toString())
+        ListItem(key = item.first, value = item.second?.toString() ?: "")
     }
 
     item {

--- a/appcues/src/main/java/com/appcues/ui/ExperienceStepFormState.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceStepFormState.kt
@@ -19,11 +19,11 @@ internal class ExperienceStepFormState {
     val isFormComplete = mutableStateOf(true)
 
     fun getValue(primitive: TextInputPrimitive) =
-        getItem(primitive).value
+        getItem(primitive).text
 
     fun setValue(primitive: TextInputPrimitive, value: String) {
         val item = getItem(primitive)
-        item.value = value
+        item.text.value = value
         updateFormItem(item)
     }
 
@@ -32,7 +32,7 @@ internal class ExperienceStepFormState {
 
     fun setValue(primitive: OptionSelectPrimitive, values: Set<String>) {
         val item = getItem(primitive)
-        item.values = values
+        item.values.value = values
         updateFormItem(item)
     }
 
@@ -42,7 +42,9 @@ internal class ExperienceStepFormState {
 
         // create new state tracking object
         item = with(primitive) {
-            TextInputFormItemState(itemIndex++, id, "textInput", label.text, required, defaultValue ?: "")
+            TextInputFormItemState(itemIndex++, id, "textInput", label.text, required).apply {
+                text.value = defaultValue ?: ""
+            }
         }
         updateFormItem(item)
         return item
@@ -54,7 +56,9 @@ internal class ExperienceStepFormState {
 
         // create new state tracking object
         item = with(primitive) {
-            OptionSelectFormItemState(itemIndex++, id, "optionSelect", label.text, required, defaultValue)
+            OptionSelectFormItemState(itemIndex++, id, "optionSelect", label.text, required).apply {
+                values.value = defaultValue
+            }
         }
         updateFormItem(item)
         return item
@@ -77,8 +81,8 @@ internal sealed class ExperienceStepFormItemState(
     val isComplete: Boolean
         get() {
             return when (this) {
-                is OptionSelectFormItemState -> !isRequired || values.isNotEmpty()
-                is TextInputFormItemState -> !isRequired || value.isNotBlank()
+                is OptionSelectFormItemState -> !isRequired || values.value.isNotEmpty()
+                is TextInputFormItemState -> !isRequired || text.value.isNotBlank()
             }
         }
 
@@ -88,8 +92,9 @@ internal sealed class ExperienceStepFormItemState(
         override val type: String,
         override val label: String,
         override val isRequired: Boolean,
-        var value: String,
-    ) : ExperienceStepFormItemState(index, id, type, label, isRequired)
+    ) : ExperienceStepFormItemState(index, id, type, label, isRequired) {
+        var text = mutableStateOf("")
+    }
 
     class OptionSelectFormItemState(
         override val index: Int,
@@ -97,6 +102,7 @@ internal sealed class ExperienceStepFormItemState(
         override val type: String,
         override val label: String,
         override val isRequired: Boolean,
-        var values: Set<String>
-    ) : ExperienceStepFormItemState(index, id, type, label, isRequired)
+    ) : ExperienceStepFormItemState(index, id, type, label, isRequired) {
+        var values = mutableStateOf(setOf<String>())
+    }
 }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceStepFormState.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceStepFormState.kt
@@ -86,6 +86,13 @@ internal sealed class ExperienceStepFormItemState(
             }
         }
 
+    val value: String
+        get() =
+            when (this) {
+                is TextInputFormItemState -> text.value
+                is OptionSelectFormItemState -> values.value.joinToString(",") // need actual CSV-ifying
+            }
+
     class TextInputFormItemState(
         override val index: Int,
         override val id: UUID,

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -53,12 +53,6 @@ import com.appcues.ui.extensions.styleBorder
 @Composable
 internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
     val formState = LocalExperienceStepFormStateDelegate.current
-    val selectedValues = remember { mutableStateOf(formState.getValue(this)) }
-
-    fun setSelectedValues(values: Set<String>) {
-        selectedValues.value = values
-        formState.setValue(this, values)
-    }
 
     Column(
         modifier = modifier,
@@ -71,39 +65,39 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
         when {
             selectMode == SINGLE && displayFormat == PICKER -> {
                 options.ComposePicker(
-                    selectedValues = selectedValues.value,
+                    selectedValues = formState.getValue(this@Compose).value,
                     modifier = Modifier.styleBorder(pickerStyle ?: ComponentStyle(), isSystemInDarkTheme()),
                     placeholder = placeholder,
                     accentColor = accentColor?.getColor(isSystemInDarkTheme()),
                 ) {
-                    setSelectedValues(it)
+                    formState.setValue(this@Compose, it)
                 }
             }
             displayFormat == HORIZONTAL_LIST -> {
                 Row(verticalAlignment = controlPosition.getVerticalAlignment() ?: Alignment.CenterVertically) {
                     options.ComposeSelections(
-                        selectedValues = selectedValues.value,
+                        selectedValues = formState.getValue(this@Compose).value,
                         selectMode = selectMode,
                         controlPosition = controlPosition,
                         selectedColor = selectedColor.getColor(isSystemInDarkTheme()),
                         unselectedColor = unselectedColor.getColor(isSystemInDarkTheme()),
                         accentColor = accentColor.getColor(isSystemInDarkTheme()),
                     ) {
-                        setSelectedValues(it)
+                        formState.setValue(this@Compose, it)
                     }
                 }
             }
             else -> { // VERTICAL_LIST case or a fallback (i.e. a PICKER but with multi-select, invalid)
                 Column(horizontalAlignment = controlPosition.getHorizontalAlignment() ?: Alignment.CenterHorizontally) {
                     options.ComposeSelections(
-                        selectedValues = selectedValues.value,
+                        selectedValues = formState.getValue(this@Compose).value,
                         selectMode = selectMode,
                         controlPosition = controlPosition,
                         selectedColor = selectedColor.getColor(isSystemInDarkTheme()),
                         unselectedColor = unselectedColor.getColor(isSystemInDarkTheme()),
                         accentColor = accentColor.getColor(isSystemInDarkTheme()),
                     ) {
-                        setSelectedValues(it)
+                        formState.setValue(this@Compose, it)
                     }
                 }
             }

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -12,8 +12,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -61,7 +59,6 @@ private const val TEXT_INPUT_PADDING = 16.0
 internal fun TextInputPrimitive.Compose(modifier: Modifier) {
 
     val formState = LocalExperienceStepFormStateDelegate.current
-    val text = remember { mutableStateOf(formState.getValue(this)) }
     val isDark = isSystemInDarkTheme()
     val textStyle = LocalTextStyle.current.applyStyle(
         style = textFieldStyle,
@@ -77,10 +74,9 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
 
         // Several styling customization options for TextField noted here https://stackoverflow.com/a/68592613
         TextField(
-            value = text.value,
+            value = formState.getValue(this@Compose).value,
             onValueChange = {
                 if (maxLength == null || it.length <= maxLength) {
-                    text.value = it
                     formState.setValue(this@Compose, it)
                 }
             },

--- a/appcues/src/main/java/com/appcues/util/StringExt.kt
+++ b/appcues/src/main/java/com/appcues/util/StringExt.kt
@@ -1,0 +1,11 @@
+package com.appcues.util
+
+import java.util.Locale
+
+fun String.toSlug() = lowercase(Locale.getDefault())
+    .replace("\n", " ")
+    .replace("[^a-z\\d\\s]".toRegex(), " ")
+    .split(" ")
+    .joinToString("-")
+    .replace("-+".toRegex(), "-")
+    .trimEnd('-')

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="appcues_debugger_back_description">Back</string>
     <string name="appcues_debugger_event_details_title">Event details</string>
     <string name="appcues_debugger_event_details_properties_title">Properties</string>
+    <string name="appcues_debugger_event_details_form_response_title">Interaction data: form response</string>
     <string name="appcues_debugger_event_details_identity_auto_properties_title">Identity auto-properties</string>
     <string name="appcues_debugger_event_details_type_title">Type</string>
     <string name="appcues_debugger_event_details_name_title">Name</string>


### PR DESCRIPTION
This is the next pass at our survey control analytics, cleaning up a few things along the way.

* support adding the question/answer pairs as profile attributes with `_appcuesForm_` prefix, matching web behavior. This occurs in `ExperienceLifecycleTracker.trackFormSubmission`
* support showing the form results interaction data nicely in the debugger, matching iOS.  This led to some more cleanup where I allowed storing the `ExperienceStepFormState` in the custom attributes of the event directly, then use a Moshi adapter to control how the resulting "formResult" JSON mapping occurs on the network request.  Having the full object model in the in-memory attributes makes it simpler to reference this data in the debugger, not having to dig into nested maps - and is very much like the approach Matt took on iOS here https://github.com/appcues/appcues-ios-sdk/pull/242, which I liked.
* small update to the way form state is referenced from the Composables for textInput and optionSelect - allow them to use mutableState objects directly from the form state container, rather than having a duplicate mirrored copy locally. This was mostly inspired by how the view model was referenced in a similar way in examples here https://medium.com/androiddevelopers/effective-state-management-for-textfield-in-compose-d6e5b070fbe5

The form response data can now be seen on the debugger events like this, at the bottom.
![Screen Shot 2022-09-19 at 2 21 12 PM](https://user-images.githubusercontent.com/19266448/191108095-880b301d-c693-4809-a105-6329c804465f.png)

next up:
There is still more to sort out around the rules for if and when form data can be submitted - right now it's just directly tied to step completion events.  Also, will need to add the handling for required fields and error messaging when not all filled out.
