### PR TITLE
Do not trigger step_completed when dismissing experience early

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -21,6 +21,7 @@ import com.appcues.statemachine.State.Idling
 import com.appcues.statemachine.State.Paused
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.StateMachine
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -39,7 +40,7 @@ internal class ExperienceLifecycleTracker(
     private val stateMachine: StateMachine by inject()
     private val storage: Storage by inject()
 
-    suspend fun start(): Unit = withContext(Dispatchers.IO) {
+    suspend fun start(dispatcher: CoroutineDispatcher = Dispatchers.IO): Unit = withContext(dispatcher) {
         launch { observeState() }
         launch { observeErrors() }
     }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -57,11 +57,13 @@ internal class ExperienceLifecycleTracker(
                         trackLifecycleEvent(StepSeen(it.experience, it.flatStepIndex))
                     }
                     is EndingStep -> {
-                        trackFormSubmission(it.experience, it.flatStepIndex)
-                        trackLifecycleEvent(StepCompleted(it.experience, it.flatStepIndex))
+                        if (it.isStepCompleted) {
+                            trackFormSubmission(it.experience, it.flatStepIndex)
+                            trackLifecycleEvent(StepCompleted(it.experience, it.flatStepIndex))
+                        }
                     }
                     is EndingExperience -> {
-                        if (it.isExperienceCompleted()) {
+                        if (it.isExperienceCompleted) {
                             // if ending on the last step OR an action requested it be considered complete explicitly,
                             // track the experience_completed event
                             trackLifecycleEvent(ExperienceCompleted(it.experience))

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -19,16 +19,21 @@ internal sealed class State {
     data class EndingStep(
         val experience: Experience,
         val flatStepIndex: Int,
+        val markComplete: Boolean,
         // this works as a ContinuationSideEffect that AppcuesViewModel will
         // send to the state machine once it's done dismissing the current container
         // the presence of a non-null value is what tells the UI to dismiss the current container,
         // and it should be set to null if a dismiss is not requested (i.e. moving to next step in same container)
         val dismissAndContinue: (() -> Unit)?,
-    ) : State()
+    ) : State() {
+        val isStepCompleted
+            get() = markComplete || flatStepIndex == experience.flatSteps.count() - 1
+    }
 
     data class EndingExperience(val experience: Experience, val flatStepIndex: Int, val markComplete: Boolean) : State() {
         // this defines whether the experience was completed or dismissed
-        fun isExperienceCompleted() = markComplete || flatStepIndex == experience.flatSteps.count() - 1
+        val isExperienceCompleted
+            get() = markComplete || flatStepIndex == experience.flatSteps.count() - 1
     }
 
     data class Paused(val state: State) : State()

--- a/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
@@ -71,7 +71,7 @@ internal interface Transitions {
                     // in different groups we want to wait for StartStep action from AppcuesViewModel
                     val response = CompletableDeferred<ResultOf<State, Error>>()
                     Transition(
-                        state = EndingStep(experience, flatStepIndex) {
+                        state = EndingStep(experience, flatStepIndex, true) {
                             coroutineScope.launch {
                                 response.complete(continuation())
                             }
@@ -81,7 +81,7 @@ internal interface Transitions {
                 } else {
                     // in same group we can continue to StartStep internally
                     Transition(
-                        state = EndingStep(experience, flatStepIndex, null),
+                        state = EndingStep(experience, flatStepIndex, true, null),
                         sideEffect = ContinuationEffect(StartStep(action.stepReference)),
                     )
                 }
@@ -101,7 +101,7 @@ internal interface Transitions {
             // this means the AppcuesActivity was destroyed externally (i.e. deep link) and we should
             // immediately transition to EndingExperience - not rely on the UI to do it for us (it's gone)
             Transition(
-                state = EndingStep(experience, flatStepIndex, null),
+                state = EndingStep(experience, flatStepIndex, action.markComplete, null),
                 sideEffect = ContinuationEffect(action)
             )
         } else {
@@ -112,7 +112,7 @@ internal interface Transitions {
             // then AppcuesViewModel will continue to EndExperience when appropriate
             val response = CompletableDeferred<ResultOf<State, Error>>()
             Transition(
-                state = EndingStep(experience, flatStepIndex) {
+                state = EndingStep(experience, flatStepIndex, action.markComplete) {
                     coroutineScope.launch {
                         response.complete(continuation())
                     }
@@ -145,7 +145,7 @@ internal interface Transitions {
     }
 
     fun EndingExperience.fromEndingExperienceToIdling(action: Reset): Transition {
-        return Transition(Idling, if (isExperienceCompleted()) ProcessActions(experience.completionActions) else null)
+        return Transition(Idling, if (isExperienceCompleted) ProcessActions(experience.completionActions) else null)
     }
 
     companion object : Transitions

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
@@ -53,7 +53,7 @@ class AnalyticsTrackerTest {
     @Test
     fun `init SHOULD trigger experienceLifecycleTracker start`() {
         // then
-        coVerify { experienceLifecycleTracker.start() }
+        coVerify { experienceLifecycleTracker.start(any()) }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
@@ -1,0 +1,188 @@
+package com.appcues.analytics
+
+import com.appcues.Appcues
+import com.appcues.AppcuesConfig
+import com.appcues.AppcuesCoroutineScope
+import com.appcues.DeepLinkHandler
+import com.appcues.SessionMonitor
+import com.appcues.action.ActionProcessor
+import com.appcues.action.ActionRegistry
+import com.appcues.debugger.AppcuesDebuggerManager
+import com.appcues.logging.Logcues
+import com.appcues.mocks.mockExperience
+import com.appcues.mocks.storageMockk
+import com.appcues.rules.MainDispatcherRule
+import com.appcues.statemachine.Action.EndExperience
+import com.appcues.statemachine.Action.StartStep
+import com.appcues.statemachine.State
+import com.appcues.statemachine.State.BeginningStep
+import com.appcues.statemachine.State.EndingStep
+import com.appcues.statemachine.State.RenderingStep
+import com.appcues.statemachine.StateMachine
+import com.appcues.statemachine.StepReference.StepOffset
+import com.appcues.trait.TraitRegistry
+import com.appcues.ui.ExperienceRenderer
+import com.appcues.util.LinkOpener
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.KoinApplication
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatformTools
+import org.koin.test.KoinTest
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+class ExperienceLifecycleTrackerTest : KoinTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    @After
+    fun shutdown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `RenderingStep SHOULD track step_completed WHEN action is StartStep`() = runTest {
+        // GIVEN
+        val experience = mockExperience()
+        val initialState = RenderingStep(experience, 0, true)
+        val action = StartStep(StepOffset(1))
+        val scope = initScope(initialState)
+        val stateMachine: StateMachine = scope.get()
+        val analyticsTracker: AnalyticsTracker = scope.get()
+
+        // WHEN
+        stateMachine.handleAction(action)
+
+        // THEN
+        verify { analyticsTracker.track("appcues:v2:step_completed", any(), any(), any()) }
+    }
+
+    @Test
+    fun `RenderingStep SHOULD NOT track step_completed WHEN action is EndExperience markComplete=false AND not on last step`() = runTest {
+        // GIVEN
+        val experience = mockExperience()
+        val initialState = RenderingStep(experience, 0, true)
+        val action = EndExperience(destroyed = false, markComplete = false)
+        val scope = initScope(initialState)
+        val stateMachine: StateMachine = scope.get()
+        val analyticsTracker: AnalyticsTracker = scope.get()
+
+        // WHEN
+        stateMachine.handleAction(action)
+
+        // THEN
+        verify(exactly = 0) { analyticsTracker.track("appcues:v2:step_completed", any(), any(), any()) }
+    }
+
+    @Test
+    fun `RenderingStep SHOULD track step_completed WHEN action is EndExperience markComplete=false on last step`() = runTest {
+        // GIVEN
+        val experience = mockExperience()
+        val initialState = RenderingStep(experience, 3, false)
+        val action = EndExperience(destroyed = false, markComplete = false)
+        val scope = initScope(initialState)
+        val stateMachine: StateMachine = scope.get()
+        val analyticsTracker: AnalyticsTracker = scope.get()
+
+        // WHEN
+        stateMachine.handleAction(action)
+
+        // THEN
+        verify { analyticsTracker.track("appcues:v2:step_completed", any(), any(), any()) }
+    }
+
+    @Test
+    fun `RenderingStep SHOULD track step_completed WHEN action is EndExperience markComplete=true AND not on last step`() = runTest {
+        // GIVEN
+        val experience = mockExperience()
+        val initialState = RenderingStep(experience, 0, true)
+        val action = EndExperience(destroyed = false, markComplete = true)
+        val scope = initScope(initialState)
+        val stateMachine: StateMachine = scope.get()
+        val analyticsTracker: AnalyticsTracker = scope.get()
+
+        // WHEN
+        stateMachine.handleAction(action)
+
+        // THEN
+        verify { analyticsTracker.track("appcues:v2:step_completed", any(), any(), any()) }
+    }
+
+    // Helpers
+    private suspend fun initScope(state: State): Scope {
+        val scopeId = UUID.randomUUID().toString()
+        val app = createKoinApp(scopeId, state)
+        val scope = app.koin.getScope(scopeId)
+        val machine: StateMachine = scope.get()
+        val coroutineScope: AppcuesCoroutineScope = scope.get()
+
+        coroutineScope.launch {
+            // this collect on the stateFlow simulates the function of the UI
+            // that is required to progress the state machine forward on UI present/dismiss
+            machine.stateFlow.collect {
+                when (it) {
+                    is BeginningStep -> {
+                        it.presentationComplete.invoke()
+                    }
+                    is EndingStep -> {
+                        it.dismissAndContinue?.invoke()
+                    }
+                    // ignore other state changes
+                    else -> Unit
+                }
+            }
+        }
+
+        coroutineScope.launch {
+            scope.get<ExperienceLifecycleTracker>().start(UnconfinedTestDispatcher())
+        }
+
+        return scope
+    }
+
+    private fun createKoinApp(scopeId: String, state: State): KoinApplication {
+        // close any existing instance
+        KoinPlatformTools.defaultContext().getOrNull()?.close()
+
+        return startKoin {
+            val scope = koin.getOrCreateScope(scopeId = scopeId, qualifier = named(scopeId))
+            modules(
+                module {
+                    scope(named(scopeId)) {
+                        scoped { AppcuesConfig("00000", "123") }
+                        scoped { scope }
+                        scoped { AppcuesCoroutineScope(get()) }
+                        scoped { mockk<AnalyticsTracker>(relaxed = true) }
+                        scoped { mockk<SessionMonitor>(relaxed = true) }
+                        scoped { mockk<Logcues>(relaxed = true) }
+                        scoped { mockk<ExperienceRenderer>(relaxed = true) }
+                        scoped { mockk<AppcuesDebuggerManager>(relaxed = true) }
+                        scoped { mockk<ActivityScreenTracking>(relaxed = true) }
+                        scoped { mockk<TraitRegistry>(relaxed = true) }
+                        scoped { mockk<ActionRegistry>(relaxed = true) }
+                        scoped { mockk<DeepLinkHandler>(relaxed = true) }
+                        scoped { mockk<LinkOpener>(relaxed = true) }
+                        scoped { storageMockk() }
+                        scoped { mockk<Appcues>(relaxed = true) }
+                        scoped { mockk<ActionProcessor>(relaxed = true) }
+                        scoped { ExperienceLifecycleTracker(scope) }
+                        scoped { StateMachine(get(), get(), get(), state) }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -237,7 +237,7 @@ class StateMachineTest : AppcuesScopeTest {
     fun `Paused SHOULD transition back to previous state THEN to Idling WHEN action is EndExperience`() = runTest {
         // GIVEN
         val experience = mockExperience()
-        val pausedState = EndingStep(experience, 1, null)
+        val pausedState = EndingStep(experience, 1, false, null)
         val initialState = Paused(pausedState)
         val stateMachine = initMachine(initialState)
         val action = EndExperience(false)
@@ -348,7 +348,7 @@ class StateMachineTest : AppcuesScopeTest {
 
         // GIVEN
         val experience = mockExperience()
-        val initialState = EndingStep(experience, 1, null)
+        val initialState = EndingStep(experience, 1, true, null)
         val stateMachine = initMachine(initialState)
         val action = StartStep(StepIndex(1000))
 
@@ -517,7 +517,7 @@ class StateMachineTest : AppcuesScopeTest {
     fun `EndingStep SHOULD NOT transition WHEN action is something other than EndExperience, Start Step or Pause`() = runTest {
         // GIVEN
         val experience = mockExperience()
-        val initialState = EndingStep(experience, 0, null)
+        val initialState = EndingStep(experience, 0, false, null)
         val stateMachine = initMachine(initialState)
         val action = Reset
 


### PR DESCRIPTION
This ended up being an easy fix, so knocking out.  We already knew in the EndExperience action whether we should mark a flow complete or use the default behavior (if on last step, its complete).  This just updates the EndingStep state to also be aware of this flag, and then add similar logic around whether or not to record step_completion analytic.

For now, form submission (step_interaction) is also tied to this same logic, but this will change in the near future as we build the new survey submission action support.