### PR TITLE
Fix group_id null value not being sent when cleared

### DIFF
--- a/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
+++ b/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
@@ -15,16 +15,41 @@ import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.StackPr
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.TextInputPrimitiveResponse
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.TextPrimitiveResponse
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonAdapter.Factory
+import com.squareup.moshi.JsonQualifier
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.lang.reflect.Type
+import kotlin.annotation.AnnotationRetention.RUNTIME
 
 internal object MoshiConfiguration {
+
+    // can be used to add a @SerializeNull annotation on any optional property in a model that is desired
+    // to have a null value output in JSON rather than the property being omitted. Adapted from
+    // https://stackoverflow.com/a/52265735
+    @Retention(RUNTIME)
+    @JsonQualifier
+    annotation class SerializeNull {
+        companion object {
+            val JSON_ADAPTER_FACTORY = object : Factory {
+                override fun create(type: Type, annotations: Set<Annotation?>, moshi: Moshi): JsonAdapter<*>? {
+                    val nextAnnotations = Types.nextAnnotations(
+                        annotations,
+                        SerializeNull::class.java
+                    ) ?: return null
+                    return moshi.nextAdapter<Any>(this, type, nextAnnotations).serializeNulls()
+                }
+            }
+        }
+    }
 
     val moshi: Moshi = Moshi.Builder()
         .add(DateAdapter())
         .add(UUIDAdapter())
         .add(getPrimitiveFactory())
+        .add(SerializeNull.JSON_ADAPTER_FACTORY)
         .add(StepContainerAdapter())
         .add(ExperienceStepFormStateAdapter())
         .add(KotlinJsonAdapterFactory())

--- a/appcues/src/main/java/com/appcues/data/remote/request/ActivityRequest.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/request/ActivityRequest.kt
@@ -1,5 +1,6 @@
 package com.appcues.data.remote.request
 
+import com.appcues.data.MoshiConfiguration.SerializeNull
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.UUID
@@ -16,6 +17,7 @@ internal data class ActivityRequest(
     @Json(name = "account_id")
     val accountId: String,
     @Json(name = "group_id")
+    @SerializeNull
     val groupId: String? = null,
     @Json(name = "group_update")
     val groupUpdate: Map<String, Any>? = null


### PR DESCRIPTION
This adds a new annotation `@SeralizeNull`, that can be used on our Moshi JSON models to indicate a field should serialize the null value, rather than being omitted in the output (default behavior).  Idea is inspired by https://stackoverflow.com/a/52265735 .

The reason this came up - when you unset the `groupId` on a group call, passing null, this is meant to remove the associated group for the current user.  Right now, it will just post a payload to the API that removes the `group_id` property entirely, on android:
```js
{
    "request_id": "1c3bcc00-bd7d-426f-9df7-660b9f458442",
    "user_id": "default-00000",
    "account_id": "123"
}
```

This will make it match iOS instead, like
```js
{
    "request_id": "1c3bcc00-bd7d-426f-9df7-660b9f458442",
    "user_id": "default-00000",
    "account_id": "123",
    "group_id": null
}
```

It is unclear to me how the API handles the absence of a value versus the explicit setting of null for a value, but for this case of clearing the group, I think it would be best to be explicit about it.