### PR TITLE
Fix step_completed event being improperly triggered on backwards navigation

### DIFF
--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -19,7 +19,7 @@ internal object ActionKoin : KoinScopePlugin {
         factory { params ->
             CloseAction(
                 config = params.getOrNull(),
-                stateMachine = get(),
+                experienceRenderer = get(),
             )
         }
 

--- a/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
@@ -4,12 +4,11 @@ import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfigOrDefault
-import com.appcues.statemachine.Action.EndExperience
-import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer
 
 internal class CloseAction(
     override val config: AppcuesConfigMap,
-    private val stateMachine: StateMachine
+    private val experienceRenderer: ExperienceRenderer,
 ) : ExperienceAction {
 
     companion object {
@@ -19,6 +18,6 @@ internal class CloseAction(
     private val markComplete = config.getConfigOrDefault("markComplete", false)
 
     override suspend fun execute(appcues: Appcues) {
-        stateMachine.handleAction(EndExperience(false, markComplete))
+        experienceRenderer.dismissCurrentExperience(markComplete = markComplete, destroyed = false)
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -55,7 +55,7 @@ internal class ExperienceLifecycleTracker(
                         trackLifecycleEvent(StepSeen(it.experience, it.flatStepIndex))
                     }
                     is EndingStep -> {
-                        if (it.isStepCompleted) {
+                        if (it.markComplete) {
                             trackLifecycleEvent(StepCompleted(it.experience, it.flatStepIndex))
                         }
                     }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -60,7 +60,7 @@ internal class ExperienceLifecycleTracker(
                         }
                     }
                     is EndingExperience -> {
-                        if (it.isExperienceCompleted) {
+                        if (it.markComplete) {
                             // if ending on the last step OR an action requested it be considered complete explicitly,
                             // track the experience_completed event
                             trackLifecycleEvent(ExperienceCompleted(it.experience))

--- a/appcues/src/main/java/com/appcues/statemachine/Action.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Action.kt
@@ -6,7 +6,7 @@ internal sealed class Action {
     data class StartExperience(val experience: Experience) : Action()
     data class StartStep(val stepReference: StepReference) : Action()
     object RenderStep : Action()
-    data class EndExperience(val destroyed: Boolean, val markComplete: Boolean = false) : Action()
+    data class EndExperience(val markComplete: Boolean, val destroyed: Boolean) : Action()
     object Reset : Action()
     data class ReportError(val error: Error) : Action()
     object Pause : Action()

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -25,10 +25,7 @@ internal sealed class State {
         // the presence of a non-null value is what tells the UI to dismiss the current container,
         // and it should be set to null if a dismiss is not requested (i.e. moving to next step in same container)
         val dismissAndContinue: (() -> Unit)?,
-    ) : State() {
-        val isStepCompleted
-            get() = markComplete || flatStepIndex == experience.flatSteps.count() - 1
-    }
+    ) : State()
 
     data class EndingExperience(val experience: Experience, val flatStepIndex: Int, val markComplete: Boolean) : State() {
         // this defines whether the experience was completed or dismissed

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -27,11 +27,7 @@ internal sealed class State {
         val dismissAndContinue: (() -> Unit)?,
     ) : State()
 
-    data class EndingExperience(val experience: Experience, val flatStepIndex: Int, val markComplete: Boolean) : State() {
-        // this defines whether the experience was completed or dismissed
-        val isExperienceCompleted
-            get() = markComplete || flatStepIndex == experience.flatSteps.count() - 1
-    }
+    data class EndingExperience(val experience: Experience, val flatStepIndex: Int, val markComplete: Boolean) : State()
 
     data class Paused(val state: State) : State()
 
@@ -55,5 +51,18 @@ internal sealed class State {
             is EndingStep -> this.flatStepIndex
             is Paused -> this.state.currentStepIndex
             is RenderingStep -> this.flatStepIndex
+        }
+
+    val isOnLastStep: Boolean
+        get() {
+            val currentStepIndex = currentStepIndex
+            val stepCount = currentExperience?.flatSteps?.count()
+
+            return if (currentStepIndex != null && stepCount != null) {
+                // force it to mark complete (the last step and the experience) if on the last step
+                currentStepIndex == stepCount - 1
+            } else {
+                false
+            }
         }
 }

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -197,7 +197,7 @@ internal class StateMachine(
             // we are sitting on the last step if we get here - check if this is a continue with offset 1 (default continue)
             if (action.stepReference is StepOffset && action.stepReference.offset == 1) {
                 // for a continue -> next, on the last step, treat this the same as a close
-                val endExperience = EndExperience(destroyed = false)
+                val endExperience = EndExperience(markComplete = true, destroyed = false)
                 return state.fromRenderingStepToEndingExperience(endExperience, appcuesCoroutineScope) {
                     handleActionInternal(endExperience)
                 }
@@ -212,7 +212,7 @@ internal class StateMachine(
 
     fun stop() {
         appcuesCoroutineScope.launch {
-            handleAction(EndExperience(destroyed = true))
+            handleAction(EndExperience(markComplete = state.isOnLastStep, destroyed = true))
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
@@ -71,7 +71,7 @@ internal interface Transitions {
                     // in different groups we want to wait for StartStep action from AppcuesViewModel
                     val response = CompletableDeferred<ResultOf<State, Error>>()
                     Transition(
-                        state = EndingStep(experience, flatStepIndex, true) {
+                        state = EndingStep(experience, flatStepIndex, nextStepIndex > flatStepIndex) {
                             coroutineScope.launch {
                                 response.complete(continuation())
                             }
@@ -81,7 +81,7 @@ internal interface Transitions {
                 } else {
                     // in same group we can continue to StartStep internally
                     Transition(
-                        state = EndingStep(experience, flatStepIndex, true, null),
+                        state = EndingStep(experience, flatStepIndex, nextStepIndex > flatStepIndex, null),
                         sideEffect = ContinuationEffect(StartStep(action.stepReference)),
                     )
                 }

--- a/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
@@ -145,7 +145,7 @@ internal interface Transitions {
     }
 
     fun EndingExperience.fromEndingExperienceToIdling(action: Reset): Transition {
-        return Transition(Idling, if (isExperienceCompleted) ProcessActions(experience.completionActions) else null)
+        return Transition(Idling, if (markComplete) ProcessActions(experience.completionActions) else null)
     }
 
     companion object : Transitions

--- a/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
@@ -35,7 +35,7 @@ internal object TraitKoin : KoinScopePlugin {
         factory { params ->
             SkippableTrait(
                 config = params.getOrNull(),
-                stateMachine = get(),
+                experienceRenderer = get(),
                 appcuesCoroutineScope = get(),
             )
         }

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -19,16 +19,15 @@ import androidx.compose.ui.unit.dp
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.R
 import com.appcues.data.model.AppcuesConfigMap
-import com.appcues.statemachine.Action.EndExperience
-import com.appcues.statemachine.StateMachine
 import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.ContainerDecoratingTrait
 import com.appcues.trait.ContainerDecoratingTrait.ContainerDecoratingType
+import com.appcues.ui.ExperienceRenderer
 import kotlinx.coroutines.launch
 
 internal class SkippableTrait(
     override val config: AppcuesConfigMap,
-    private val stateMachine: StateMachine,
+    private val experienceRenderer: ExperienceRenderer,
     private val appcuesCoroutineScope: AppcuesCoroutineScope,
 ) : ContainerDecoratingTrait, BackdropDecoratingTrait {
 
@@ -49,7 +48,7 @@ internal class SkippableTrait(
                 .size(30.dp, 30.dp),
             onClick = {
                 appcuesCoroutineScope.launch {
-                    stateMachine.handleAction(EndExperience(false))
+                    experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
                 }
             }
         ) {
@@ -69,7 +68,7 @@ internal class SkippableTrait(
                 .pointerInput(Unit) {
                     detectTapGestures {
                         appcuesCoroutineScope.launch {
-                            stateMachine.handleAction(EndExperience(false))
+                            experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
                         }
                     }
                 },

--- a/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesViewModel.kt
@@ -6,7 +6,6 @@ import com.appcues.AppcuesCoroutineScope
 import com.appcues.action.ActionProcessor
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.StepContainer
-import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.Action.Pause
 import com.appcues.statemachine.Action.Resume
 import com.appcues.statemachine.Action.StartStep
@@ -84,7 +83,7 @@ internal class AppcuesViewModel(
             // from an external source (ex deep link) and we should end the experience
             if (state is Rendering) {
                 appcuesCoroutineScope.launch {
-                    stateMachine.handleAction(EndExperience(true))
+                    experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = true)
                 }
             }
         }
@@ -125,7 +124,7 @@ internal class AppcuesViewModel(
             // if current state IS Rendering then we process the action
             if (state is Rendering) {
                 appcuesCoroutineScope.launch {
-                    stateMachine.handleAction(EndExperience(false))
+                    experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
                 }
             }
         }

--- a/appcues/src/test/java/com/appcues/action/appcues/CloseActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/CloseActionTest.kt
@@ -2,8 +2,7 @@ package com.appcues.action.appcues
 
 import com.appcues.AppcuesScopeTest
 import com.appcues.rules.KoinScopeRule
-import com.appcues.statemachine.Action.EndExperience
-import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coVerify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -24,28 +23,28 @@ internal class CloseActionTest : AppcuesScopeTest {
     }
 
     @Test
-    fun `close SHOULD trigger StateMachine EndExperience action`() = runTest {
+    fun `close SHOULD call ExperienceRenderer to dismiss current experience`() = runTest {
         // GIVEN
-        val stateMachine: StateMachine = get()
-        val action = CloseAction(mapOf(), stateMachine)
+        val experienceRenderer: ExperienceRenderer = get()
+        val action = CloseAction(mapOf(), experienceRenderer)
 
         // WHEN
         action.execute(get())
 
         // THEN
-        coVerify { stateMachine.handleAction(EndExperience(destroyed = false, markComplete = false)) }
+        coVerify { experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false) }
     }
 
     @Test
-    fun `close SHOULD trigger StateMachine EndExperience action with markComplete true WHEN config is true`() = runTest {
+    fun `close SHOULD call ExperienceRenderer to dismiss current experience with markComplete true WHEN config is true`() = runTest {
         // GIVEN
-        val stateMachine: StateMachine = get()
-        val action = CloseAction(mapOf("markComplete" to true), stateMachine)
+        val experienceRenderer: ExperienceRenderer = get()
+        val action = CloseAction(mapOf("markComplete" to true), experienceRenderer)
 
         // WHEN
         action.execute(get())
 
         // THEN
-        coVerify { stateMachine.handleAction(EndExperience(destroyed = false, markComplete = true)) }
+        coVerify { experienceRenderer.dismissCurrentExperience(markComplete = true, destroyed = false) }
     }
 }

--- a/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
@@ -88,11 +88,11 @@ class ExperienceLifecycleTrackerTest : KoinTest {
     }
 
     @Test
-    fun `RenderingStep SHOULD track step_completed WHEN action is EndExperience markComplete=false on last step`() = runTest {
+    fun `RenderingStep SHOULD track step_completed WHEN action is EndExperience markComplete=true on last step`() = runTest {
         // GIVEN
         val experience = mockExperience()
         val initialState = RenderingStep(experience, 3, false)
-        val action = EndExperience(destroyed = false, markComplete = false)
+        val action = EndExperience(destroyed = false, markComplete = true)
         val scope = initScope(initialState)
         val stateMachine: StateMachine = scope.get()
         val analyticsTracker: AnalyticsTracker = scope.get()

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -239,7 +239,7 @@ class StateMachineTest : AppcuesScopeTest {
         val pausedState = EndingStep(experience, 1, false, null)
         val initialState = Paused(pausedState)
         val stateMachine = initMachine(initialState)
-        val action = EndExperience(false)
+        val action = EndExperience(markComplete = false, destroyed = false)
         val targetState = Idling
 
         // WHEN

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -1,0 +1,52 @@
+package com.appcues.ui
+
+import com.appcues.mocks.mockExperience
+import com.appcues.statemachine.Action.EndExperience
+import com.appcues.statemachine.State.RenderingStep
+import com.appcues.statemachine.StateMachine
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ExperienceRendererTest {
+
+    @Test
+    fun `dismissCurrentExperience SHOULD mark complete WHEN current state is on last step`() = runTest {
+        // GIVEN
+        val experience = mockExperience()
+        val state = RenderingStep(experience, 3, false)
+        val stateMachine: StateMachine = mockk(relaxed = true) {
+            every { this@mockk.state } answers { state }
+        }
+
+        val experienceRenderer = ExperienceRenderer(mockk(), stateMachine, mockk(), mockk())
+
+        // WHEN
+        experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
+
+        // THEN
+        coVerify { stateMachine.handleAction(EndExperience(markComplete = true, destroyed = false)) }
+    }
+
+    @Test
+    fun `dismissCurrentExperience SHOULD NOT mark complete WHEN current state is not on last step`() = runTest {
+        // GIVEN
+        val experience = mockExperience()
+        val state = RenderingStep(experience, 2, false)
+        val stateMachine: StateMachine = mockk(relaxed = true) {
+            every { this@mockk.state } answers { state }
+        }
+
+        val experienceRenderer = ExperienceRenderer(mockk(), stateMachine, mockk(), mockk())
+
+        // WHEN
+        experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
+
+        // THEN
+        coVerify { stateMachine.handleAction(EndExperience(markComplete = false, destroyed = false)) }
+    }
+}


### PR DESCRIPTION
these are the same logical changes as were applied on iOS in https://github.com/appcues/appcues-ios-sdk/pull/249, plus the logic adjustment in https://github.com/appcues/appcues-ios-sdk/pull/250

* when processing the transition from rendering step to ending step, only mark the step complete if we are moving forward in the experience.  moving backward (i.e. previous button) will not trigger step_completed analytics
* remove other logic that was being layered on top of the `markComplete` flag in the state (the `isStepCompleted` and `isExperienceCompleted`, as the state is now the true source of whether it should be marked complete
* refactor to process all `EndExperience` actions through a single funnel in the `ExperienceRenderer.dismissCurrentExperience` function - this allows us to consolidate the logic check where we see if the experience is on the last step when it is being ended - and set the `markComplete` flag accordingly

key cases that this should resolve, examples consider a 3-step carousel flow, skippable
* on step 3 and move back to step 2 - no `step_completed` for step 3
* on step 3 and skip/dismiss - does trigger `step_completed` and `experience_completed`, since last step
* on step 2 and skip/dismiss - no `step_completed` on step 2, and `experience_dismissed`, since not on last step