### PR TITLE
Add support for experiments

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -30,14 +30,7 @@ internal object AppcuesKoin : KoinScopePlugin {
         }
         scoped { AppcuesDebuggerManager(context = get(), koinScope = this) }
         scoped { ContextResources(context = get()) }
-        scoped {
-            ExperienceRenderer(
-                repository = get(),
-                stateMachine = get(),
-                sessionMonitor = get(),
-                config = get(),
-            )
-        }
+        scoped { ExperienceRenderer(scope = get()) }
         scoped {
             AppcuesRepository(
                 appcuesRemoteSource = get(),

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsEvent.kt
@@ -15,4 +15,5 @@ internal enum class AnalyticsEvent(val eventName: String) {
     ExperienceCompleted("appcues:v2:experience_completed"),
     ExperienceDismissed("appcues:v2:experience_dismissed"),
     ExperienceError("appcues:v2:experience_error"),
+    ExperimentEntered("appcues:experiment_entered"),
 }

--- a/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
+++ b/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
@@ -148,7 +148,7 @@ internal class AppcuesRepository(
 
             qualifyResult.doIfSuccess { response ->
                 val priority: ExperiencePriority = if (response.qualificationReason == "screen_view") LOW else NORMAL
-                experiences += response.experiences.map { experienceMapper.map(it, priority) }
+                experiences += response.experiences.map { experienceMapper.map(it, priority, response.experiments) }
             }
 
             qualifyResult.doIfFailure {

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -13,8 +13,6 @@ import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePriority
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.Experiment
-import com.appcues.data.model.Experiment.ExperimentGroup.CONTROL
-import com.appcues.data.model.Experiment.ExperimentGroup.EXPOSED
 import com.appcues.data.model.StepContainer
 import com.appcues.data.remote.response.ExperimentResponse
 import com.appcues.data.remote.response.action.ActionResponse
@@ -94,13 +92,7 @@ internal class ExperienceMapper(
     private fun Map<String, ExperimentResponse>.getExperiment(experimentId: String?) =
         experimentId?.let { id ->
             this[id]?.let { experimentResponse ->
-                when (experimentResponse.group) {
-                    "control" -> CONTROL
-                    "exposed" -> EXPOSED
-                    else -> null
-                }?.let { group ->
-                    Experiment(id, group)
-                }
+                Experiment(id, experimentResponse.group)
             }
         }
 }

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -11,6 +11,7 @@ internal data class Experience(
     val priority: ExperiencePriority,
     val type: String?,
     val publishedAt: Long?,
+    val experiment: Experiment?,
     val completionActions: List<ExperienceAction>,
 ) {
 

--- a/appcues/src/main/java/com/appcues/data/model/Experiment.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experiment.kt
@@ -1,0 +1,11 @@
+package com.appcues.data.model
+
+internal data class Experiment(
+    val id: String,
+    val group: ExperimentGroup
+) {
+    enum class ExperimentGroup(val analyticsName: String) {
+        CONTROL("control"),
+        EXPOSED("exposed"),
+    }
+}

--- a/appcues/src/main/java/com/appcues/data/model/Experiment.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experiment.kt
@@ -2,10 +2,5 @@ package com.appcues.data.model
 
 internal data class Experiment(
     val id: String,
-    val group: ExperimentGroup
-) {
-    enum class ExperimentGroup(val analyticsName: String) {
-        CONTROL("control"),
-        EXPOSED("exposed"),
-    }
-}
+    val group: String,
+)

--- a/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
@@ -1,0 +1,8 @@
+package com.appcues.data.remote.response
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class ExperimentResponse(
+    val group: String?
+)

--- a/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
@@ -4,5 +4,5 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 internal data class ExperimentResponse(
-    val group: String?
+    val group: String
 )

--- a/appcues/src/main/java/com/appcues/data/remote/response/QualifyResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/QualifyResponse.kt
@@ -8,6 +8,8 @@ import com.squareup.moshi.JsonClass
 internal data class QualifyResponse(
     val experiences: List<ExperienceResponse>,
 
+    val experiments: Map<String, ExperimentResponse>,
+
     @Json(name = "performed_qualification")
     val performedQualification: Boolean,
 

--- a/appcues/src/main/java/com/appcues/data/remote/response/experience/ExperienceResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/experience/ExperienceResponse.kt
@@ -3,6 +3,7 @@ package com.appcues.data.remote.response.experience
 import com.appcues.data.remote.response.action.ActionResponse
 import com.appcues.data.remote.response.step.StepContainerResponse
 import com.appcues.data.remote.response.trait.TraitResponse
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.UUID
 
@@ -19,4 +20,6 @@ internal data class ExperienceResponse(
     val publishedAt: Long?,
     val nextContentId: String?,
     val redirectUrl: String?,
+    @Json(name = "experiment_id")
+    val experimentId: String?
 )

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -35,11 +35,9 @@ internal class ExperienceRenderer(
     private val analyticsTracker by inject<AnalyticsTracker>()
 
     suspend fun show(experience: Experience): Boolean {
-        val canShow = config.interceptor?.canDisplayExperience(experience.id) ?: true
+        var canShow = config.interceptor?.canDisplayExperience(experience.id) ?: true
 
-        if (!canShow) return false
-
-        if (experience.experiment != null) {
+        if (canShow && experience.experiment != null) {
             // send analytics
             analyticsTracker.track(
                 event = AnalyticsEvent.ExperimentEntered,
@@ -51,10 +49,10 @@ internal class ExperienceRenderer(
             )
 
             // if this user is in the control group, it should not show
-            if (experience.experiment.group == CONTROL) {
-                return false
-            }
+            canShow = experience.experiment.group != CONTROL
         }
+
+        if (!canShow) return false
 
         // "event_trigger" or "forced" experience priority is NORMAL, "screen_view" is low -
         // if an experience is currently showing and the new experience coming in is normal priority

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -7,7 +7,6 @@ import com.appcues.analytics.AnalyticsTracker
 import com.appcues.data.AppcuesRepository
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePriority.NORMAL
-import com.appcues.data.model.Experiment.ExperimentGroup.CONTROL
 import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.Error
@@ -43,13 +42,13 @@ internal class ExperienceRenderer(
                 event = AnalyticsEvent.ExperimentEntered,
                 properties = mapOf(
                     "experimentId" to experience.experiment.id,
-                    "group" to experience.experiment.group.analyticsName
+                    "group" to experience.experiment.group
                 ),
                 interactive = false
             )
 
             // if this user is in the control group, it should not show
-            canShow = experience.experiment.group != CONTROL
+            canShow = experience.experiment.group != "control"
         }
 
         if (!canShow) return false

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -47,7 +47,8 @@ internal class ExperienceRenderer(
                     "experimentId" to experience.experiment.id,
                     "group" to experience.experiment.group.analyticsName
                 ),
-                interactive = false)
+                interactive = false
+            )
 
             // if this user is in the control group, it should not show
             if (experience.experiment.group == CONTROL) {

--- a/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
@@ -252,6 +252,7 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         priority = NORMAL,
         type = "mobile",
         publishedAt = Date().time,
-        completionActions = listOf()
+        completionActions = listOf(),
+        experiment = null,
     )
 }

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -108,7 +108,8 @@ class AppcuesRepositoryTest {
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk(), mockk()),
             performedQualification = true,
-            qualificationReason = "screen_view"
+            qualificationReason = "screen_view",
+            experiments = emptyMap(),
         )
         coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()
@@ -245,7 +246,8 @@ class AppcuesRepositoryTest {
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk(), mockk()),
             performedQualification = true,
-            qualificationReason = "screen_view"
+            qualificationReason = "screen_view",
+            experiments = emptyMap(),
         )
         coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()
@@ -265,7 +267,8 @@ class AppcuesRepositoryTest {
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk(), mockk()),
             performedQualification = true,
-            qualificationReason = "event_trigger"
+            qualificationReason = "event_trigger",
+            experiments = emptyMap(),
         )
         coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
@@ -29,6 +29,7 @@ internal val contentModalOneStubs = ExperienceResponse(
     actions = null,
     nextContentId = null,
     redirectUrl = null,
+    experimentId = null,
     traits = arrayListOf(),
     steps = arrayListOf(
         StepContainerResponse(

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -49,6 +49,7 @@ internal fun mockExperience(onPresent: (() -> Unit)? = null) =
         published = true,
         priority = NORMAL,
         publishedAt = 1652895835000,
+        experiment = null,
         completionActions = arrayListOf(LaunchExperienceAction("1234"), TrackEventAction(hashMapOf()))
     )
 

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -5,6 +5,7 @@ import com.appcues.action.appcues.TrackEventAction
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
 import com.appcues.data.model.ExperiencePriority.NORMAL
+import com.appcues.data.model.Experiment
 import com.appcues.data.model.Step
 import com.appcues.data.model.StepContainer
 import com.appcues.trait.PresentingTrait
@@ -63,4 +64,28 @@ internal fun mockStep(id: UUID) =
         stepDecoratingTraits = listOf(),
         actions = mapOf(),
         type = "modal"
+    )
+
+internal fun mockExperienceExperiment(experiment: Experiment) =
+    Experience(
+        id = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
+        name = "Mock Experience with Experiment",
+        type = "mobile",
+        stepContainers = listOf(
+            StepContainer(
+                steps = listOf(
+                    mockStep(UUID.fromString("01d8a05a-3a55-4ecc-872d-d140cd628902")),
+                ),
+                presentingTrait = mockPresentingTrait(),
+                contentHolderTrait = mockk(relaxed = true),
+                contentWrappingTrait = mockk(relaxed = true),
+                backdropDecoratingTraits = listOf(),
+                containerDecoratingTraits = listOf(),
+            )
+        ),
+        published = true,
+        priority = NORMAL,
+        publishedAt = 1652895835000,
+        experiment = experiment,
+        completionActions = emptyList()
     )

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -264,6 +264,7 @@ class StateMachineTest : AppcuesScopeTest {
             type = "mobile",
             publishedAt = 1652895835000,
             completionActions = arrayListOf(),
+            experiment = null,
         )
         val initialState = Idling
         val stateMachine = initMachine(initialState)

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -4,8 +4,6 @@ import com.appcues.AppcuesConfig
 import com.appcues.analytics.AnalyticsEvent
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.data.model.Experiment
-import com.appcues.data.model.Experiment.ExperimentGroup.CONTROL
-import com.appcues.data.model.Experiment.ExperimentGroup.EXPOSED
 import com.appcues.mocks.mockExperience
 import com.appcues.mocks.mockExperienceExperiment
 import com.appcues.statemachine.Action.EndExperience
@@ -77,7 +75,7 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD NOT show experience WHEN an experiment is active AND group is control`() = runTest {
         // GIVEN
-        val experiment = Experiment("experiment1", CONTROL)
+        val experiment = Experiment("experiment1", "control")
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -98,7 +96,7 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD show experience WHEN an experiment is active AND group is exposed`() = runTest {
         // GIVEN
-        val experiment = Experiment("experiment1", EXPOSED)
+        val experiment = Experiment("experiment1", "exposed")
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -119,7 +117,7 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD track experiment_entered with group=control WHEN an experiment is active AND group is control`() = runTest {
         // GIVEN
-        val experiment = Experiment("experiment1", CONTROL)
+        val experiment = Experiment("experiment1", "control")
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -141,7 +139,7 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD track experiment_entered with group=exposed WHEN an experiment is active AND group is exposed`() = runTest {
         // GIVEN
-        val experiment = Experiment("experiment1", EXPOSED)
+        val experiment = Experiment("experiment1", "exposed")
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -2,6 +2,7 @@ package com.appcues.ui
 
 import com.appcues.mocks.mockExperience
 import com.appcues.statemachine.Action.EndExperience
+import com.appcues.statemachine.State
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.StateMachine
 import io.mockk.coVerify
@@ -9,21 +10,29 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatformTools
+import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ExperienceRendererTest {
+    @After
+    fun shutdown() {
+        stopKoin()
+    }
 
     @Test
     fun `dismissCurrentExperience SHOULD mark complete WHEN current state is on last step`() = runTest {
         // GIVEN
-        val experience = mockExperience()
-        val state = RenderingStep(experience, 3, false)
-        val stateMachine: StateMachine = mockk(relaxed = true) {
-            every { this@mockk.state } answers { state }
-        }
-
-        val experienceRenderer = ExperienceRenderer(mockk(), stateMachine, mockk(), mockk())
+        val scope = initScope(RenderingStep(mockExperience(), 3, false))
+        val stateMachine: StateMachine = scope.get()
+        val experienceRenderer = ExperienceRenderer(scope)
 
         // WHEN
         experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
@@ -35,18 +44,34 @@ class ExperienceRendererTest {
     @Test
     fun `dismissCurrentExperience SHOULD NOT mark complete WHEN current state is not on last step`() = runTest {
         // GIVEN
-        val experience = mockExperience()
-        val state = RenderingStep(experience, 2, false)
-        val stateMachine: StateMachine = mockk(relaxed = true) {
-            every { this@mockk.state } answers { state }
-        }
-
-        val experienceRenderer = ExperienceRenderer(mockk(), stateMachine, mockk(), mockk())
+        val scope = initScope(RenderingStep(mockExperience(), 2, false))
+        val stateMachine: StateMachine = scope.get()
+        val experienceRenderer = ExperienceRenderer(scope)
 
         // WHEN
         experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
 
         // THEN
         coVerify { stateMachine.handleAction(EndExperience(markComplete = false, destroyed = false)) }
+    }
+
+    private fun initScope(state: State): Scope {
+        // close any existing instance
+        KoinPlatformTools.defaultContext().getOrNull()?.close()
+        val scopeId = UUID.randomUUID().toString()
+        return startKoin {
+            val scope = koin.getOrCreateScope(scopeId = scopeId, qualifier = named(scopeId))
+            modules(
+                module {
+                    scope(named(scopeId)) {
+                        scoped {
+                            mockk<StateMachine>(relaxed = true) {
+                                every { this@mockk.state } answers { state }
+                            }
+                        }
+                    }
+                }
+            )
+        }.koin.getScope(scopeId)
     }
 }


### PR DESCRIPTION
similar updates to the [iOS changes here](https://github.com/appcues/appcues-ios-sdk/pull/258)

* decode a top level `experiments` mapping on the `QualifyResponse`
* add support for an optional `experiment_id` on the `ExperienceResponse`
* add mapping for an optional `Experiment` object on the `Experience`, when a matching experiment is found for the `experiement_id`
* modify `ExperienceRenderer` to support experiment logic, if there is a matching experiment for an `Experience` being rendered:
    * if group is `control` - block rendering the experience and move on to next priority, if any
    * if not (group `exposed`) - continue rendering the experience as usual
    * in both cases, trigger an `appcues:experiment_entered` analytic for the user, with the group and experiment ID

note: a bit of work was restructuring `ExperienceRenderer` (and tests) to use lazy props instead of constructor injection with Koin, to avoid a circular dependency noted in code comment.