### PR TITLE
Update experiments for array representation in JSON

### DIFF
--- a/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
+++ b/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
@@ -148,8 +148,7 @@ internal class AppcuesRepository(
 
             qualifyResult.doIfSuccess { response ->
                 val priority: ExperiencePriority = if (response.qualificationReason == "screen_view") LOW else NORMAL
-                val experiments = response.experiments ?: emptyMap()
-                experiences += response.experiences.map { experienceMapper.map(it, priority, experiments) }
+                experiences += response.experiences.map { experienceMapper.map(it, priority, response.experiments) }
             }
 
             qualifyResult.doIfFailure {

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -40,7 +40,7 @@ internal class ExperienceMapper(
     fun map(
         from: ExperienceResponse,
         priority: ExperiencePriority = NORMAL,
-        experiments: Map<String, ExperimentResponse> = emptyMap()
+        experiments: List<ExperimentResponse>? = null,
     ): Experience {
         val experienceTraits = from.traits.map { it to EXPERIENCE }
         return Experience(
@@ -51,7 +51,7 @@ internal class ExperienceMapper(
             priority = priority,
             type = from.type,
             publishedAt = from.publishedAt,
-            experiment = experiments.getExperiment(from.experimentId),
+            experiment = experiments?.getExperiment(from.experimentId),
             completionActions = arrayListOf<ExperienceAction>().apply {
                 from.redirectUrl?.let { add(LinkAction(it, scope.get())) }
                 from.nextContentId?.let { add(LaunchExperienceAction(it)) }
@@ -89,10 +89,10 @@ internal class ExperienceMapper(
         return filterIsInstance<PresentingTrait>().firstOrNull() ?: DefaultPresentingTrait(null, scope, context)
     }
 
-    private fun Map<String, ExperimentResponse>.getExperiment(experimentId: String?) =
+    private fun List<ExperimentResponse>.getExperiment(experimentId: String?) =
         experimentId?.let { id ->
-            this[id]?.let { experimentResponse ->
-                Experiment(id, experimentResponse.group)
+            this.firstOrNull { it.experimentId == id }?.let { experimentResponse ->
+                Experiment(experimentResponse.experimentId, experimentResponse.group)
             }
         }
 }

--- a/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
@@ -1,8 +1,11 @@
 package com.appcues.data.remote.response
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 internal data class ExperimentResponse(
-    val group: String
+    val group: String,
+    @Json(name = "experiment_id")
+    val experimentId: String
 )

--- a/appcues/src/main/java/com/appcues/data/remote/response/QualifyResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/QualifyResponse.kt
@@ -8,7 +8,7 @@ import com.squareup.moshi.JsonClass
 internal data class QualifyResponse(
     val experiences: List<ExperienceResponse>,
 
-    val experiments: Map<String, ExperimentResponse>?,
+    val experiments: List<ExperimentResponse>?,
 
     @Json(name = "performed_qualification")
     val performedQualification: Boolean,

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -109,7 +109,7 @@ class AppcuesRepositoryTest {
             experiences = listOf(mockk(), mockk()),
             performedQualification = true,
             qualificationReason = "screen_view",
-            experiments = emptyMap(),
+            experiments = null,
         )
         coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()
@@ -247,7 +247,7 @@ class AppcuesRepositoryTest {
             experiences = listOf(mockk(), mockk()),
             performedQualification = true,
             qualificationReason = "screen_view",
-            experiments = emptyMap(),
+            experiments = null,
         )
         coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()
@@ -268,7 +268,7 @@ class AppcuesRepositoryTest {
             experiences = listOf(mockk(), mockk()),
             performedQualification = true,
             qualificationReason = "event_trigger",
-            experiments = emptyMap(),
+            experiments = null,
         )
         coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()


### PR DESCRIPTION
Discovered the JSON representation is an array, not a dictionary as previously thought from the ticket - this fixes up.