### PR TITLE
Add SDK metrics to capture timings around experience rendering

### DIFF
--- a/appcues/src/main/java/com/appcues/SessionMonitor.kt
+++ b/appcues/src/main/java/com/appcues/SessionMonitor.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.appcues.analytics.AnalyticsEvent
 import com.appcues.analytics.AnalyticsTracker
+import com.appcues.analytics.SdkMetrics
 import com.appcues.logging.Logcues
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinScopeComponent
@@ -82,5 +83,8 @@ internal class SessionMonitor(
 
         // ensure any pending in-memory analytics get processed asap
         analyticsTracker.flushPendingActivity()
+
+        // clear out any pending metrics upon backgrounding
+        SdkMetrics.clear()
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsQueueProcessor.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsQueueProcessor.kt
@@ -105,7 +105,13 @@ internal class AnalyticsQueueProcessor(
             // this will respond with qualified experiences, if applicable
             repository.trackActivity(activity).also {
                 // we will try to show an experience from this list
-                experienceRenderer.show(it)
+                if (it.isNotEmpty()) {
+                    experienceRenderer.show(it)
+                } else {
+                    // we know we are not rendering any experiences, so no metrics needed
+                    // can proactively clear this request out
+                    SdkMetrics.remove(activity.requestId)
+                }
             }
         }
     }

--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -23,7 +23,6 @@ internal class AutoPropertyDecorator(
 ) {
 
     companion object {
-
         const val IDENTITY_PROPERTY = "_identity"
         const val UPDATED_AT_PROPERTY = "_updatedAt"
     }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -50,7 +50,7 @@ internal class ExperienceLifecycleTracker(
                         if (it.isFirst) {
                             // update this value for auto-properties
                             storage.lastContentShownAt = Date()
-                            trackLifecycleEvent(ExperienceStarted(it.experience))
+                            trackLifecycleEvent(ExperienceStarted(it.experience), SdkMetrics.trackRender(it.experience.requestId))
                         }
                         trackLifecycleEvent(StepSeen(it.experience, it.flatStepIndex))
                     }
@@ -87,8 +87,10 @@ internal class ExperienceLifecycleTracker(
         }
     }
 
-    private fun trackLifecycleEvent(event: ExperienceLifecycleEvent) {
-        analyticsTracker.track(event.name, event.properties, interactive = false, isInternal = true)
+    private fun trackLifecycleEvent(event: ExperienceLifecycleEvent, additionalProperties: Map<String, Any> = emptyMap()) {
+        val properties = event.properties.toMutableMap()
+        properties.putAll(additionalProperties)
+        analyticsTracker.track(event.name, properties, interactive = false, isInternal = true)
     }
 
     private fun State.shouldTrack(): Boolean =

--- a/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
+++ b/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
@@ -10,6 +10,9 @@ internal data class SdkMetrics(
     private var renderStartAt: Date? = null,
 ) {
     companion object {
+
+        const val METRICS_PROPERTY = "_sdkMetrics"
+
         private val metrics = hashMapOf<UUID, SdkMetrics>()
 
         fun clear() {
@@ -57,7 +60,7 @@ internal data class SdkMetrics(
 
                     remove(it)
 
-                    properties["_sdkMetrics"] = mapOf(
+                    properties[METRICS_PROPERTY] = mapOf(
                         "timeBeforeRequest" to timeBeforeRequest,
                         "timeNetwork" to timeNetwork,
                         "timeProcessingResponse" to timeProcessingResponse,

--- a/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
+++ b/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
@@ -1,0 +1,64 @@
+package com.appcues.analytics
+
+import java.util.Date
+import java.util.UUID
+
+internal data class SdkMetrics(
+    private var trackedAt: Date? = null,
+    private var requestedAt: Date? = null,
+    private var respondedAt: Date? = null,
+) {
+    companion object {
+        private val metrics = hashMapOf<UUID, SdkMetrics>()
+
+        fun clear() {
+            metrics.clear()
+        }
+
+        fun tracked(id: UUID, time: Date?) {
+            time?.let { metrics.getOrPut(id) { SdkMetrics() }.trackedAt = time }
+        }
+
+        fun requested(id: String?, time: Date = Date()) {
+            id?.let { metrics[UUID.fromString(it)]?.requestedAt = time }
+        }
+
+        fun responded(id: String?, time: Date = Date()) {
+            id?.let { metrics[UUID.fromString(it)]?.respondedAt = time }
+        }
+
+        fun remove(id: UUID) {
+            metrics.remove(id)
+        }
+
+        fun trackRender(id: UUID?): Map<String, Any> {
+            val properties = hashMapOf<String, Any>()
+            id?.let {
+                val item = metrics[it]
+                val trackedAt = item?.trackedAt
+                val requestedAt = item?.requestedAt
+                val respondedAt = item?.respondedAt
+
+                if (trackedAt != null && requestedAt != null && respondedAt != null) {
+                    val renderedAt = Date()
+
+                    val timeTotal = (renderedAt.time - trackedAt.time).toInt()
+                    val timeAfterResponse = (renderedAt.time - respondedAt.time).toInt()
+                    val timeNetwork = (respondedAt.time - requestedAt.time).toInt()
+                    val timeBeforeRequest = (requestedAt.time - trackedAt.time).toInt()
+
+                    remove(it)
+
+                    properties["_sdkMetrics"] = mapOf(
+                        "timeBeforeRequest" to timeBeforeRequest,
+                        "timeNetwork" to timeNetwork,
+                        "timeAfterResponse" to timeAfterResponse,
+                        "timeTotal" to timeTotal,
+                    )
+                }
+            }
+
+            return properties
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
+++ b/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
@@ -7,6 +7,7 @@ internal data class SdkMetrics(
     private var trackedAt: Date? = null,
     private var requestedAt: Date? = null,
     private var respondedAt: Date? = null,
+    private var renderStartAt: Date? = null,
 ) {
     companion object {
         private val metrics = hashMapOf<UUID, SdkMetrics>()
@@ -27,6 +28,10 @@ internal data class SdkMetrics(
             id?.let { metrics[UUID.fromString(it)]?.respondedAt = time }
         }
 
+        fun renderStart(id: UUID?, time: Date = Date()) {
+            id?.let { metrics[it]?.renderStartAt = time }
+        }
+
         fun remove(id: UUID) {
             metrics.remove(id)
         }
@@ -38,21 +43,24 @@ internal data class SdkMetrics(
                 val trackedAt = item?.trackedAt
                 val requestedAt = item?.requestedAt
                 val respondedAt = item?.respondedAt
+                val renderStartAt = item?.renderStartAt
 
-                if (trackedAt != null && requestedAt != null && respondedAt != null) {
+                if (trackedAt != null && requestedAt != null && respondedAt != null && renderStartAt != null) {
                     val renderedAt = Date()
 
-                    val timeTotal = (renderedAt.time - trackedAt.time).toInt()
-                    val timeAfterResponse = (renderedAt.time - respondedAt.time).toInt()
-                    val timeNetwork = (respondedAt.time - requestedAt.time).toInt()
                     val timeBeforeRequest = (requestedAt.time - trackedAt.time).toInt()
+                    val timeNetwork = (respondedAt.time - requestedAt.time).toInt()
+                    val timeProcessingResponse = (renderStartAt.time - respondedAt.time).toInt()
+                    val timePresenting = (renderedAt.time - renderStartAt.time).toInt()
+                    val timeTotal = (renderedAt.time - trackedAt.time).toInt()
 
                     remove(it)
 
                     properties["_sdkMetrics"] = mapOf(
                         "timeBeforeRequest" to timeBeforeRequest,
                         "timeNetwork" to timeNetwork,
-                        "timeAfterResponse" to timeAfterResponse,
+                        "timeProcessingResponse" to timeProcessingResponse,
+                        "timePresenting" to timePresenting,
                         "timeTotal" to timeTotal,
                     )
                 }

--- a/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
+++ b/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
@@ -45,6 +45,7 @@ internal data class SdkMetrics(
                 val respondedAt = item?.respondedAt
                 val renderStartAt = item?.renderStartAt
 
+                @Suppress("ComplexCondition")
                 if (trackedAt != null && requestedAt != null && respondedAt != null && renderStartAt != null) {
                     val renderedAt = Date()
 

--- a/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
+++ b/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
@@ -144,11 +144,11 @@ internal class AppcuesRepository(
         if (isCurrent) {
             // if we are processing the current item (last item in queue) - then use the /qualify
             // endpoint and optionally get back qualified experiences to render
-            val qualifyResult = appcuesRemoteSource.qualify(activity.userId, activity.data)
+            val qualifyResult = appcuesRemoteSource.qualify(activity.userId, activity.requestId, activity.data)
 
             qualifyResult.doIfSuccess { response ->
                 val priority: ExperiencePriority = if (response.qualificationReason == "screen_view") LOW else NORMAL
-                experiences += response.experiences.map { experienceMapper.map(it, priority, response.experiments) }
+                experiences += response.experiences.map { experienceMapper.map(it, priority, response.experiments, activity.requestId) }
             }
 
             qualifyResult.doIfFailure {

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -41,6 +41,7 @@ internal class ExperienceMapper(
         from: ExperienceResponse,
         priority: ExperiencePriority = NORMAL,
         experiments: List<ExperimentResponse>? = null,
+        requestId: UUID? = null,
     ): Experience {
         val experienceTraits = from.traits.map { it to EXPERIENCE }
         return Experience(
@@ -55,7 +56,8 @@ internal class ExperienceMapper(
             completionActions = arrayListOf<ExperienceAction>().apply {
                 from.redirectUrl?.let { add(LinkAction(it, scope.get())) }
                 from.nextContentId?.let { add(LaunchExperienceAction(it)) }
-            }
+            },
+            requestId = requestId,
         )
     }
 

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -13,6 +13,7 @@ internal data class Experience(
     val publishedAt: Long?,
     val experiment: Experiment?,
     val completionActions: List<ExperienceAction>,
+    val requestId: UUID? = null,
 ) {
 
     // a unique identifier for this instance of the Experience, for comparison purposes, in the

--- a/appcues/src/main/java/com/appcues/data/remote/AppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/AppcuesRemoteSource.kt
@@ -4,11 +4,12 @@ import com.appcues.data.remote.response.ActivityResponse
 import com.appcues.data.remote.response.QualifyResponse
 import com.appcues.data.remote.response.experience.ExperienceResponse
 import com.appcues.util.ResultOf
+import java.util.UUID
 
 internal interface AppcuesRemoteSource {
     suspend fun getExperienceContent(experienceId: String): ResultOf<ExperienceResponse, RemoteError>
     suspend fun getExperiencePreview(experienceId: String): ResultOf<ExperienceResponse, RemoteError>
     suspend fun postActivity(userId: String, activityJson: String): ResultOf<ActivityResponse, RemoteError>
-    suspend fun qualify(userId: String, activityJson: String): ResultOf<QualifyResponse, RemoteError>
+    suspend fun qualify(userId: String, requestId: UUID, activityJson: String): ResultOf<QualifyResponse, RemoteError>
     suspend fun checkAppcuesConnection(): Boolean
 }

--- a/appcues/src/main/java/com/appcues/data/remote/request/ActivityRequest.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/request/ActivityRequest.kt
@@ -3,6 +3,7 @@ package com.appcues.data.remote.request
 import com.appcues.data.MoshiConfiguration.SerializeNull
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.util.Date
 import java.util.UUID
 
 @JsonClass(generateAdapter = true)
@@ -20,5 +21,7 @@ internal data class ActivityRequest(
     @SerializeNull
     val groupId: String? = null,
     @Json(name = "group_update")
-    val groupUpdate: Map<String, Any>? = null
+    val groupUpdate: Map<String, Any>? = null,
+    @Json(ignore = true)
+    val timestamp: Date = Date(),
 )

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/AppcuesService.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/AppcuesService.kt
@@ -7,8 +7,10 @@ import com.appcues.data.remote.response.experience.ExperienceResponse
 import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
+import java.util.UUID
 
 internal interface AppcuesService {
 
@@ -23,6 +25,7 @@ internal interface AppcuesService {
     suspend fun qualify(
         @Path("account") account: String,
         @Path("user") user: String,
+        @Header("appcues-request-id") requestId: UUID,
         @Body activity: RequestBody
     ): QualifyResponse
 

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSource.kt
@@ -14,6 +14,7 @@ import com.squareup.moshi.JsonDataException
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import retrofit2.HttpException
+import java.util.UUID
 
 internal class RetrofitAppcuesRemoteSource(
     private val appcuesService: AppcuesService,
@@ -48,11 +49,12 @@ internal class RetrofitAppcuesRemoteSource(
             )
         }
 
-    override suspend fun qualify(userId: String, activityJson: String): ResultOf<QualifyResponse, RemoteError> =
+    override suspend fun qualify(userId: String, requestId: UUID, activityJson: String): ResultOf<QualifyResponse, RemoteError> =
         request {
             appcuesService.qualify(
                 account = accountId,
                 user = userId,
+                requestId = requestId,
                 activity = activityJson.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
             )
         }

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitWrapper.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitWrapper.kt
@@ -53,7 +53,7 @@ internal class RetrofitWrapper(
     }
 }
 
-internal class MetricsInterceptor: Interceptor {
+internal class MetricsInterceptor : Interceptor {
 
     override fun intercept(chain: Chain): Response {
         val request = chain.request()

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
@@ -9,6 +9,7 @@ import com.appcues.analytics.ActivityRequestBuilder
 import com.appcues.analytics.AnalyticsEvent
 import com.appcues.analytics.AutoPropertyDecorator
 import com.appcues.analytics.ExperienceLifecycleEvent
+import com.appcues.analytics.SdkMetrics
 import com.appcues.analytics.TrackingData
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.data.remote.request.ActivityRequest
@@ -118,6 +119,7 @@ internal class DebuggerRecentEventsManager(
                             properties = event.attributes
                                 .filterOutScreenProperties(type)
                                 .filterOutAutoProperties()
+                                .filterOutMetricsProperties()
                                 .filterOutInteractionData()
                                 .toSortedList(),
                         ),
@@ -137,6 +139,12 @@ internal class DebuggerRecentEventsManager(
                             title = contextResources.getString(R.string.appcues_debugger_event_details_identity_auto_properties_title),
                             properties = event.attributes
                                 .getAutoProperties()
+                                .toSortedList()
+                        ),
+                        DebuggerEventItemPropertySection(
+                            title = contextResources.getString(R.string.appcues_debugger_event_details_sdk_metrics_properties_title),
+                            properties = event.attributes
+                                .getMetricsProperties()
                                 .toSortedList()
                         )
                     )
@@ -203,9 +211,18 @@ private fun Map<String, Any>.filterOutAutoProperties(): Map<String, Any> {
     return filterNot { it.key == AutoPropertyDecorator.IDENTITY_PROPERTY }
 }
 
+private fun Map<String, Any>.filterOutMetricsProperties(): Map<String, Any> {
+    return filterNot { it.key == SdkMetrics.METRICS_PROPERTY }
+}
+
 private fun Map<String, Any>.getAutoProperties(): Map<String, Any> {
     @Suppress("UNCHECKED_CAST")
     return (this[AutoPropertyDecorator.IDENTITY_PROPERTY] as Map<String, Any>?) ?: mapOf()
+}
+
+private fun Map<String, Any>.getMetricsProperties(): Map<String, Any> {
+    @Suppress("UNCHECKED_CAST")
+    return (this[SdkMetrics.METRICS_PROPERTY] as Map<String, Any>?) ?: mapOf()
 }
 
 private fun Map<String, Any>.filterOutInteractionData(): Map<String, Any> {

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
@@ -224,6 +224,7 @@ private fun Map<String, Any>.getInteractionData(): Map<String, Any?> {
     this[ExperienceLifecycleEvent.INTERACTION_DATA_KEY].let {
         if (it is ExperienceStepFormState || it == null) return mapOf()
 
+        @Suppress("UNCHECKED_CAST")
         return it as Map<String, Any>
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/AppcuesAnimatedTraitVisibility.kt
+++ b/appcues/src/main/java/com/appcues/trait/AppcuesAnimatedTraitVisibility.kt
@@ -4,13 +4,13 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.expandIn
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkOut
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.appcues.ui.composables.rememberAppcuesContentVisibility
 
 /**
  * AppcuesTraitAnimatedVisibility is used to animate traits based on internal state of Appcues SDK
@@ -20,6 +20,7 @@ import com.appcues.ui.composables.rememberAppcuesContentVisibility
  */
 @Composable
 fun AppcuesTraitAnimatedVisibility(
+    visibleState: MutableTransitionState<Boolean>,
     modifier: Modifier = Modifier,
     enter: EnterTransition = fadeIn() + expandIn(),
     exit: ExitTransition = fadeOut() + shrinkOut(),
@@ -27,7 +28,7 @@ fun AppcuesTraitAnimatedVisibility(
 ) {
     AnimatedVisibility(
         modifier = modifier,
-        visibleState = rememberAppcuesContentVisibility(),
+        visibleState = visibleState,
         enter = enter,
         exit = exit,
         content = content

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropTrait.kt
@@ -17,6 +17,7 @@ import com.appcues.data.model.getConfigColor
 import com.appcues.data.model.styling.ComponentColor
 import com.appcues.trait.AppcuesTraitAnimatedVisibility
 import com.appcues.trait.BackdropDecoratingTrait
+import com.appcues.ui.composables.rememberAppcuesBackdropVisibility
 import com.appcues.ui.extensions.getColor
 
 internal class BackdropTrait(
@@ -33,6 +34,7 @@ internal class BackdropTrait(
     @Composable
     override fun BoxScope.Backdrop() {
         AppcuesTraitAnimatedVisibility(
+            visibleState = rememberAppcuesBackdropVisibility(),
             enter = enterTransition(),
             exit = exitTransition(),
         ) {

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -67,6 +67,13 @@ private fun MainSurface(
                 value?.let { ComposeLastRenderingState(it) }
             }
 
+            LaunchOnShowAnimationCompleted {
+                val currentState = state.value
+                if (currentState is Rendering) {
+                    currentState.presentationComplete.invoke()
+                }
+            }
+
             // will run when transition from visible to gone is completed
             LaunchOnHideAnimationCompleted {
                 // if state is dismissing then finish activity

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
@@ -22,10 +22,12 @@ internal fun rememberLastRenderingState(state: State<UIState>) = remember { muta
             if (uiState is Rendering) {
                 // if UIState is rendering then we set new value and show content
                 isContentVisible.targetState = true
+                isBackdropVisible.targetState = true
                 uiState
             } else {
                 // else we keep the same value and hide content to trigger dismissing animation
                 isContentVisible.targetState = false
+                isBackdropVisible.targetState = false
                 value
             }
         }
@@ -57,6 +59,8 @@ internal fun rememberAppcuesPaginationState() = remember<State<AppcuesPagination
 
 internal val isContentVisible = MutableTransitionState(false)
 
+internal val isBackdropVisible = MutableTransitionState(false)
+
 @Composable
 internal fun LaunchOnHideAnimationCompleted(block: () -> Unit) {
     with(remember { mutableStateOf(isContentVisible) }.value) {
@@ -67,9 +71,22 @@ internal fun LaunchOnHideAnimationCompleted(block: () -> Unit) {
     }
 }
 
+@Composable
+internal fun LaunchOnShowAnimationCompleted(block: () -> Unit) {
+    with(remember { mutableStateOf(isContentVisible) }.value) {
+        // if show animation is completed
+        if (isIdle && currentState) {
+            block()
+        }
+    }
+}
+
 // we could make this public to give more flexibility in the future
 @Composable
 internal fun rememberAppcuesContentVisibility() = remember { isContentVisible }
+
+@Composable
+internal fun rememberAppcuesBackdropVisibility() = remember { isBackdropVisible }
 
 @Composable
 internal fun rememberSystemMarginsState(): State<PaddingValues> {

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.trait.AppcuesTraitAnimatedVisibility
+import com.appcues.ui.composables.rememberAppcuesContentVisibility
 import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
 import com.appcues.ui.utils.AppcuesWindowInfo
@@ -59,6 +60,7 @@ internal fun BottomSheetModal(
             contentAlignment = Alignment.BottomCenter
         ) {
             AppcuesTraitAnimatedVisibility(
+                visibleState = rememberAppcuesContentVisibility(),
                 enter = enterAnimation.value,
                 exit = exitAnimation.value,
             ) {

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.trait.AppcuesTraitAnimatedVisibility
+import com.appcues.ui.composables.rememberAppcuesContentVisibility
 import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
 import com.appcues.ui.utils.AppcuesWindowInfo
@@ -45,6 +46,7 @@ internal fun DialogModal(
     val maxHeight = maxHeightDerivedOf(windowInfo)
 
     AppcuesTraitAnimatedVisibility(
+        visibleState = rememberAppcuesContentVisibility(),
         enter = dialogEnterTransition(),
         exit = dialogExitTransition(),
     ) {

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.trait.AppcuesTraitAnimatedVisibility
+import com.appcues.ui.composables.rememberAppcuesContentVisibility
 import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
 import com.appcues.ui.utils.AppcuesWindowInfo
@@ -55,6 +56,7 @@ internal fun ExpandedBottomSheetModal(
             contentAlignment = if (windowInfo.deviceType == MOBILE) Alignment.BottomCenter else Alignment.Center
         ) {
             AppcuesTraitAnimatedVisibility(
+                visibleState = rememberAppcuesContentVisibility(),
                 enter = enterAnimation.value,
                 exit = exitAnimation.value,
             ) {

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.trait.AppcuesTraitAnimatedVisibility
+import com.appcues.ui.composables.rememberAppcuesContentVisibility
 import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
 import com.appcues.ui.utils.AppcuesWindowInfo
@@ -58,6 +59,7 @@ internal fun FullScreenModal(
             contentAlignment = if (windowInfo.deviceType == MOBILE) Alignment.BottomCenter else Alignment.Center
         ) {
             AppcuesTraitAnimatedVisibility(
+                visibleState = rememberAppcuesContentVisibility(),
                 enter = enterAnimation.value,
                 exit = exitAnimation.value,
             ) {

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="appcues_debugger_event_details_form_response_title">Interaction data: form response</string>
     <string name="appcues_debugger_event_details_interaction_data">Interaction data</string>
     <string name="appcues_debugger_event_details_identity_auto_properties_title">Identity auto-properties</string>
+    <string name="appcues_debugger_event_details_sdk_metrics_properties_title">SDK metrics</string>
     <string name="appcues_debugger_event_details_type_title">Type</string>
     <string name="appcues_debugger_event_details_name_title">Name</string>
     <string name="appcues_debugger_event_details_timestamp_title">Timestamp</string>

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -111,16 +111,16 @@ class AppcuesRepositoryTest {
             qualificationReason = "screen_view",
             experiments = null,
         )
-        coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
+        coEvery { appcuesRemoteSource.qualify(any(), request.requestId, any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()
-        coEvery { experienceMapper.map(any(), any()) } returns mappedExperience
+        coEvery { experienceMapper.map(any(), any(), null, request.requestId) } returns mappedExperience
 
         // WHEN
         val result = repository.trackActivity(request)
 
         // THEN
         coVerify { appcuesLocalSource.saveActivity(any()) }
-        coVerify { appcuesRemoteSource.qualify("userId", any()) }
+        coVerify { appcuesRemoteSource.qualify("userId", request.requestId, any()) }
         assertThat(result.count()).isEqualTo(2)
         assertThat(result.first()).isEqualTo(mappedExperience)
         coVerify { appcuesLocalSource.removeActivity(any()) }
@@ -144,7 +144,7 @@ class AppcuesRepositoryTest {
     fun `trackActivity SHOULD retain cache item WHEN the qualify request fails with a NetworkError`() = runTest {
         // GIVEN
         val request = ActivityRequest(accountId = "123", userId = "userId")
-        coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Failure(NetworkError())
+        coEvery { appcuesRemoteSource.qualify(any(), request.requestId, any()) } returns Failure(NetworkError())
 
         // WHEN
         repository.trackActivity(request)
@@ -158,7 +158,7 @@ class AppcuesRepositoryTest {
     fun `trackActivity SHOULD NOT retain cache item WHEN the qualify request fails with an HTTPError`() = runTest {
         // GIVEN
         val request = ActivityRequest(accountId = "123", userId = "userId")
-        coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Failure(HttpError())
+        coEvery { appcuesRemoteSource.qualify(any(), request.requestId, any()) } returns Failure(HttpError())
 
         // WHEN
         repository.trackActivity(request)
@@ -249,15 +249,15 @@ class AppcuesRepositoryTest {
             qualificationReason = "screen_view",
             experiments = null,
         )
-        coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
+        coEvery { appcuesRemoteSource.qualify(any(), request.requestId, any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()
-        coEvery { experienceMapper.map(any(), any()) } returns mappedExperience
+        coEvery { experienceMapper.map(any(), any(), null, request.requestId) } returns mappedExperience
 
         // WHEN
         repository.trackActivity(request)
 
         // THEN
-        coVerify { experienceMapper.map(any(), LOW) }
+        coVerify { experienceMapper.map(any(), LOW, null, request.requestId) }
     }
 
     @Test
@@ -270,15 +270,15 @@ class AppcuesRepositoryTest {
             qualificationReason = "event_trigger",
             experiments = null,
         )
-        coEvery { appcuesRemoteSource.qualify(any(), any()) } returns Success(qualifyResponse)
+        coEvery { appcuesRemoteSource.qualify(any(), request.requestId, any()) } returns Success(qualifyResponse)
         val mappedExperience = mockk<Experience>()
-        coEvery { experienceMapper.map(any(), any()) } returns mappedExperience
+        coEvery { experienceMapper.map(any(), any(), null, request.requestId) } returns mappedExperience
 
         // WHEN
         repository.trackActivity(request)
 
         // THEN
-        coVerify { experienceMapper.map(any(), NORMAL) }
+        coVerify { experienceMapper.map(any(), NORMAL, null, request.requestId) }
     }
 
     // test items already in processing don't get included again


### PR DESCRIPTION
The idea here is to use a static registry of metrics by request ID - in `SdkMetrics`.  This is where other spots can track key points in the qualification/rendering lifecycle
* the moment the analytic comes in to the sdk
* when it is sent out in the network request
* when it returns from the network
* when it starts presentation in the UI

Then, when the `experience_started` analytic is trigged on initial render, we can capture and send the new `_sdkMetrics` node in the attributes, for reporting usage.

A few approaches are used to keep this metrics collection from bloating in size at runtime
* only adds entries for things that might potentially trigger qualification - analytics sent in that are "interactive" / processed immediately (i.e. the customer app screens and events).  Does not capture entries for non-qualifying background/internal events like flow analytics
* remove items when a response comes back with no qualified experiences (common case) - since we know we'll never be rendering any thing there
* does not do any tracking for non-traditional experience rendering: ex. deeplinks, show(id), flow triggering another flow
* clean up other items that do have qualification as soon as the render metrics are sent out
* clean up all items on app backgrounding, as a safety net, since no longer current/relevant apples

One interesting aspect of this was hooking in a `MetricsInterceptor`, in Retrofit, to capture the moment of request/response accurately. To accomplish this, we add a temporary request header for `appcues-request-id` on the /qualify POST request.  Then we read this value and use it to capture the timings, and remove it from the request - so it never actually goes out to the API.

Another interesting aspect was reworking the logic around Compose presentation slightly, such that the `presentationComplete` callback does not get invoked now until we have actually fully completed the presentation, including any animated transition. Previously, this was triggered immediately upon state transition in the view model.  Having it also capture the time around the presentation will give a closer comparison in metrics to how iOS presentation works. A new `LaunchOnShowAnimationCompleted` is added to handle this, and the `isContentVisible` is split out from a new `isBackdropVisible` to ensure that we can always accurately detect when the real content is showing, not just the backdrop (as both use similar AnimatedVisibility approaches.

end result gets us data like this example
![Screen Shot 2022-10-20 at 12 03 26 PM](https://user-images.githubusercontent.com/19266448/197018339-a370ebab-8c08-41cb-9285-ad657e1e0267.png)
