### PR TITLE
Add support for custom attribute name to store survey question results

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -146,6 +146,16 @@ internal sealed class ExperienceLifecycleEvent(
         }
 }
 
-internal fun ExperienceStepFormState.formattedAsProfileUpdate() = formItems.associate {
-    "_appcuesForm_${it.label.toSlug()}" to it.value
+internal fun ExperienceStepFormState.formattedAsProfileUpdate(): Map<String, Any> {
+    val profileUpdate = hashMapOf<String, Any>()
+
+    formItems.forEach {
+        profileUpdate["_appcuesForm_${it.label.toSlug()}"] = it.value
+
+        if (it.attributeName != null) {
+            profileUpdate[it.attributeName] = it.value
+        }
+    }
+
+    return profileUpdate
 }

--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapper.kt
@@ -38,7 +38,8 @@ internal fun OptionSelectPrimitiveResponse.mapOptionSelectPrimitive(): OptionSel
         placeholder = placeholder?.mapPrimitive(),
         selectedColor = selectedColor?.mapComponentColor(),
         unselectedColor = unselectedColor?.mapComponentColor(),
-        accentColor = accentColor?.mapComponentColor()
+        accentColor = accentColor?.mapComponentColor(),
+        attributeName = attributeName,
     )
 }
 

--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/TextInputPrimitiveMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/TextInputPrimitiveMapper.kt
@@ -19,6 +19,7 @@ internal fun TextInputPrimitiveResponse.mapTextInputPrimitive() = TextInputPrimi
     dataType = mapComponentDataType(dataType),
     textFieldStyle = textFieldStyle.mapComponentStyle(),
     cursorColor = cursorColor?.mapComponentColor(),
+    attributeName = attributeName,
 )
 
 private fun mapComponentDataType(value: String?) = when (value) {

--- a/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
@@ -120,6 +120,7 @@ internal sealed class ExperiencePrimitive(
         val dataType: ComponentDataType = TEXT,
         val textFieldStyle: ComponentStyle = ComponentStyle(),
         val cursorColor: ComponentColor? = null,
+        val attributeName: String? = null,
     ) : ExperiencePrimitive(id, style) {
 
         override val textDescription: String = label.textDescription
@@ -142,6 +143,7 @@ internal sealed class ExperiencePrimitive(
         val selectedColor: ComponentColor? = null,
         val unselectedColor: ComponentColor? = null,
         val accentColor: ComponentColor? = null,
+        val attributeName: String? = null,
     ) : ExperiencePrimitive(id, style) {
 
         data class OptionItem(

--- a/appcues/src/main/java/com/appcues/data/model/ExperienceStepFormState.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperienceStepFormState.kt
@@ -75,10 +75,11 @@ internal class ExperienceStepFormState {
 
 internal sealed class ExperienceStepFormItemState(
     open val index: Int,
-    open val id: UUID,
-    open val type: String,
-    open val label: String,
-    open val isRequired: Boolean,
+    val id: UUID,
+    val type: String,
+    val label: String,
+    val isRequired: Boolean,
+    val attributeName: String?,
 ) {
 
     val isComplete: Boolean
@@ -118,7 +119,14 @@ internal sealed class ExperienceStepFormItemState(
     class TextInputFormItemState(
         override val index: Int,
         val primitive: TextInputPrimitive,
-    ) : ExperienceStepFormItemState(index, primitive.id, "textInput", primitive.label.text, primitive.required) {
+    ) : ExperienceStepFormItemState(
+        index = index,
+        id = primitive.id,
+        type = "textInput",
+        label = primitive.label.text,
+        isRequired = primitive.required,
+        attributeName = primitive.attributeName
+    ) {
 
         var text = mutableStateOf("")
 
@@ -135,7 +143,8 @@ internal sealed class ExperienceStepFormItemState(
         id = primitive.id,
         type = "optionSelect",
         label = primitive.label.text,
-        isRequired = primitive.minSelections > 0u
+        isRequired = primitive.minSelections > 0u,
+        attributeName = primitive.attributeName,
     ) {
 
         var values = mutableStateOf(setOf<String>())

--- a/appcues/src/main/java/com/appcues/data/remote/response/step/primitive/PrimitiveResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/step/primitive/PrimitiveResponse.kt
@@ -103,6 +103,7 @@ internal sealed class PrimitiveResponse(
         val selectedColor: StyleColorResponse?,
         val unselectedColor: StyleColorResponse?,
         val accentColor: StyleColorResponse?,
+        val attributeName: String?,
     ) : PrimitiveResponse(OPTION_SELECT) {
 
         data class OptionItem(
@@ -125,5 +126,6 @@ internal sealed class PrimitiveResponse(
         val dataType: String?,
         val textFieldStyle: StyleResponse?,
         val cursorColor: StyleColorResponse?,
+        val attributeName: String?,
     ) : PrimitiveResponse(TEXT_INPUT)
 }

--- a/appcues/src/test/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapperTest.kt
@@ -33,6 +33,7 @@ class OptionSelectPrimitiveMapperTest {
             selectedColor = null,
             unselectedColor = null,
             accentColor = null,
+            attributeName = null,
         )
 
         // WHEN
@@ -67,6 +68,7 @@ class OptionSelectPrimitiveMapperTest {
             selectedColor = null,
             unselectedColor = null,
             accentColor = null,
+            attributeName = null,
         )
 
         // WHEN


### PR DESCRIPTION
Adds an optional additional profile attribute if the `attributeName` is specified in the primitive JSON props.