### PR TITLE
Fix logic that links experiments and experiences in response

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -52,7 +52,7 @@ internal class ExperienceMapper(
             priority = priority,
             type = from.type,
             publishedAt = from.publishedAt,
-            experiment = experiments?.getExperiment(from.experimentId),
+            experiment = experiments?.getExperiment(from.id),
             completionActions = arrayListOf<ExperienceAction>().apply {
                 from.redirectUrl?.let { add(LinkAction(it, scope.get())) }
                 from.nextContentId?.let { add(LaunchExperienceAction(it)) }
@@ -91,10 +91,8 @@ internal class ExperienceMapper(
         return filterIsInstance<PresentingTrait>().firstOrNull() ?: DefaultPresentingTrait(null, scope, context)
     }
 
-    private fun List<ExperimentResponse>.getExperiment(experimentId: String?) =
-        experimentId?.let { id ->
-            this.firstOrNull { it.experimentId == id }?.let { experimentResponse ->
-                Experiment(experimentResponse.experimentId, experimentResponse.group)
-            }
+    private fun List<ExperimentResponse>.getExperiment(experienceId: UUID) =
+        this.firstOrNull { it.experienceId == experienceId }?.let { experimentResponse ->
+            Experiment(experimentResponse.experimentId, experimentResponse.group)
         }
 }

--- a/appcues/src/main/java/com/appcues/data/model/Experiment.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experiment.kt
@@ -1,6 +1,8 @@
 package com.appcues.data.model
 
+import java.util.UUID
+
 internal data class Experiment(
-    val id: String,
+    val id: UUID,
     val group: String,
 )

--- a/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
@@ -2,10 +2,13 @@ package com.appcues.data.remote.response
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.util.UUID
 
 @JsonClass(generateAdapter = true)
 internal data class ExperimentResponse(
     val group: String,
     @Json(name = "experiment_id")
-    val experimentId: String
+    val experimentId: UUID,
+    @Json(name = "experience_id")
+    val experienceId: UUID,
 )

--- a/appcues/src/main/java/com/appcues/data/remote/response/experience/ExperienceResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/experience/ExperienceResponse.kt
@@ -3,7 +3,6 @@ package com.appcues.data.remote.response.experience
 import com.appcues.data.remote.response.action.ActionResponse
 import com.appcues.data.remote.response.step.StepContainerResponse
 import com.appcues.data.remote.response.trait.TraitResponse
-import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.UUID
 
@@ -20,6 +19,4 @@ internal data class ExperienceResponse(
     val publishedAt: Long?,
     val nextContentId: String?,
     val redirectUrl: String?,
-    @Json(name = "experiment_id")
-    val experimentId: String?
 )

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -128,7 +128,7 @@ internal class ExperienceRenderer(
         analyticsTracker.track(
             event = AnalyticsEvent.ExperimentEntered,
             properties = mapOf(
-                "experimentId" to id,
+                "experimentId" to id.toString().lowercase(),
                 "group" to group
             ),
             interactive = false

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
@@ -29,7 +29,6 @@ internal val contentModalOneStubs = ExperienceResponse(
     actions = null,
     nextContentId = null,
     redirectUrl = null,
-    experimentId = null,
     traits = arrayListOf(),
     steps = arrayListOf(
         StepContainerResponse(

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -75,14 +75,13 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD NOT show experience WHEN an experiment is active AND group is control`() = runTest {
         // GIVEN
-        val experiment = Experiment("experiment1", "control")
+        val experiment = Experiment(UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"), "control")
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
             coEvery { this@mockk.handleAction(any()) } answers { Success(Idling) }
         }
         val scope = initScope(stateMachine)
-        val analyticsTracker: AnalyticsTracker = scope.get()
         val experienceRenderer = ExperienceRenderer(scope)
 
         // WHEN
@@ -96,7 +95,7 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD show experience WHEN an experiment is active AND group is exposed`() = runTest {
         // GIVEN
-        val experiment = Experiment("experiment1", "exposed")
+        val experiment = Experiment(UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"), "exposed")
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -117,7 +116,7 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD track experiment_entered with group=control WHEN an experiment is active AND group is control`() = runTest {
         // GIVEN
-        val experiment = Experiment("experiment1", "control")
+        val experiment = Experiment(UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"), "control")
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -132,14 +131,18 @@ class ExperienceRendererTest {
 
         // THEN
         verify {
-            analyticsTracker.track(AnalyticsEvent.ExperimentEntered, mapOf("experimentId" to "experiment1", "group" to "control"), false)
+            analyticsTracker.track(
+                AnalyticsEvent.ExperimentEntered,
+                mapOf("experimentId" to "06f9bf87-1921-4919-be55-429b278bf578", "group" to "control"),
+                false
+            )
         }
     }
 
     @Test
     fun `show SHOULD track experiment_entered with group=exposed WHEN an experiment is active AND group is exposed`() = runTest {
         // GIVEN
-        val experiment = Experiment("experiment1", "exposed")
+        val experiment = Experiment(UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"), "exposed")
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -154,7 +157,10 @@ class ExperienceRendererTest {
 
         // THEN
         verify {
-            analyticsTracker.track(AnalyticsEvent.ExperimentEntered, mapOf("experimentId" to "experiment1", "group" to "exposed"), false)
+            analyticsTracker.track(
+                AnalyticsEvent.ExperimentEntered,
+                mapOf("experimentId" to "06f9bf87-1921-4919-be55-429b278bf578", "group" to "exposed"),
+                false)
         }
     }
 


### PR DESCRIPTION
Once we had a real test response to try out, discovered a misunderstanding in the requirements around how the response would look. We need to link the experiment and experience as shown here - matching on the experience ID inside of the experiments array. There is no experiment_id in the experience response object.

![Screen Shot 2022-10-24 at 2 56 24 PM](https://user-images.githubusercontent.com/19266448/197611221-c9561fd0-e90f-49b8-b461-03da3f8e1b35.png)
