### PR TITLE
Update release script to be explicit about branch name

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -135,7 +135,7 @@ sed -i '' "/^VERSION_CLASSIFIER /s/=.*$/= $newVersionClassifier/" ./appcues/appc
 git commit -am "🔖 Update version to $newVersion"
 git push
 # gh release will make both the tag and the release itself.
-gh release create $newVersion -F $tempFile -t $newVersion
+gh release create $newVersion -F $tempFile -t $newVersion --target $branch
 
 # remove the tempfile.
 rm $tempFile


### PR DESCRIPTION
Mirroring the fix discovered on the iOS side here https://github.com/appcues/appcues-ios-sdk/pull/268