### PR TITLE
♻️ Updated Size finder logic to match specs

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -3,11 +3,15 @@ package com.appcues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import coil.ImageLoader
+import com.appcues.action.ExperienceAction
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
 import com.appcues.data.MoshiConfiguration
 import com.appcues.data.mapper.step.primitives.mapPrimitive
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse
 import com.appcues.logging.Logcues
+import com.appcues.ui.composables.AppcuesActionsDelegate
+import com.appcues.ui.composables.LocalAppcuesActionDelegate
 import com.appcues.ui.composables.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.composables.LocalImageLoader
 import com.appcues.ui.composables.LocalLogcues
@@ -24,8 +28,16 @@ fun ComposeContent(json: String, imageLoader: ImageLoader) {
             LocalImageLoader provides imageLoader,
             LocalLogcues provides Logcues(LoggingLevel.DEBUG),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
+            LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate()
         ) {
             primitive.Compose()
         }
+    }
+}
+
+private class FakeAppcuesActionDelegate : AppcuesActionsDelegate {
+
+    override fun onActions(actions: List<ExperienceAction>, interactionType: InteractionType, viewDescription: String?) {
+        // do nothing
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -38,7 +38,7 @@ internal fun AppcuesComposition(
             LocalViewModel provides viewModel,
             LocalShakeGestureListener provides shakeGestureListener,
             LocalLogcues provides logcues,
-            LocalAppcuesActionDelegate provides AppcuesActionsDelegate(viewModel),
+            LocalAppcuesActionDelegate provides DefaultAppcuesActionsDelegate(viewModel),
             LocalAppcuesPaginationDelegate provides AppcuesPagination { viewModel.onPageChanged(it) },
         ) {
             MainSurface(

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -1,6 +1,8 @@
 package com.appcues.ui.composables
 
+import androidx.compose.runtime.State
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import coil.ImageLoader
 import com.appcues.action.ExperienceAction
@@ -10,7 +12,7 @@ import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.logging.Logcues
 import com.appcues.ui.AppcuesViewModel
 import com.appcues.ui.ShakeGestureListener
-import com.appcues.ui.composables.StackScope.COLUMN
+import com.appcues.ui.composables.StackScope.ColumnStackScope
 import java.util.UUID
 
 // used to register callback for all Actions triggered from primitives
@@ -18,11 +20,16 @@ internal val LocalAppcuesActionDelegate = staticCompositionLocalOf<AppcuesAction
     noLocalProvidedFor("LocalAppcuesActionDelegate")
 }
 
-// class to make it easier to understand the bridge between the
-// LocalAppcuesActionDelegate and the AppcuesViewModel
-internal class AppcuesActionsDelegate(private val viewModel: AppcuesViewModel) {
+// interface to facilitate understanding the bridge
+// between LocalAppcuesActionDelegate and the AppcuesViewModel
+internal interface AppcuesActionsDelegate {
 
-    fun onActions(actions: List<ExperienceAction>, interactionType: InteractionType, viewDescription: String?) {
+    fun onActions(actions: List<ExperienceAction>, interactionType: InteractionType, viewDescription: String?)
+}
+
+internal class DefaultAppcuesActionsDelegate(private val viewModel: AppcuesViewModel) : AppcuesActionsDelegate {
+
+    override fun onActions(actions: List<ExperienceAction>, interactionType: InteractionType, viewDescription: String?) {
         viewModel.onActions(actions, interactionType, viewDescription)
     }
 }
@@ -49,10 +56,26 @@ internal val LocalLogcues = staticCompositionLocalOf<Logcues> { noLocalProvidedF
 
 internal val LocalExperienceStepFormStateDelegate = compositionLocalOf { ExperienceStepFormState() }
 
-internal val LocalStackScope = compositionLocalOf { COLUMN }
+internal val LocalStackScope = compositionLocalOf<StackScope> { ColumnStackScope(null, 0) }
 
-internal enum class StackScope {
-    ROW, COLUMN
+internal sealed class StackScope(private val childrenCount: Int) {
+
+    private var childrenSizes = hashMapOf<UUID, Int>()
+    private val _greaterHeight = mutableStateOf(0)
+    val greaterHeight: State<Int> = _greaterHeight
+
+    fun updateChildSize(id: UUID, size: Int) {
+        if (!childrenSizes.containsKey(id)) {
+            childrenSizes[id] = size
+        }
+
+        if (childrenSizes.size == childrenCount) {
+            _greaterHeight.value = childrenSizes.maxOf { it.value }
+        }
+    }
+
+    class RowStackScope(val height: Double?, childrenCount: Int) : StackScope(childrenCount)
+    class ColumnStackScope(val width: Double?, childrenCount: Int) : StackScope(childrenCount)
 }
 
 private fun noLocalProvidedFor(name: String): Nothing {

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -61,16 +61,25 @@ internal val LocalStackScope = compositionLocalOf<StackScope> { ColumnStackScope
 internal sealed class StackScope(private val childrenCount: Int) {
 
     private var childrenSizes = hashMapOf<UUID, Int>()
-    private val _greaterHeight = mutableStateOf(0)
-    val greaterHeight: State<Int> = _greaterHeight
+    private val _greaterSize = mutableStateOf<Float?>(null)
+    val greaterSize: State<Float?> = _greaterSize
 
     fun updateChildSize(id: UUID, size: Int) {
+        // if there is only one child we don't collect size
+        if (childrenCount <= 1) {
+            // negative value means no size will be set
+            _greaterSize.value = -1.0f
+            return
+        }
+
+        // collect size once per each child
         if (!childrenSizes.containsKey(id)) {
             childrenSizes[id] = size
         }
 
+        // when all children have reported its size, update the greaterSize value
         if (childrenSizes.size == childrenCount) {
-            _greaterHeight.value = childrenSizes.maxOf { it.value }
+            _greaterSize.value = childrenSizes.maxOf { it.value.toFloat() }
         }
     }
 

--- a/appcues/src/main/java/com/appcues/ui/primitive/EmbedHtmlPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/EmbedHtmlPrimitive.kt
@@ -3,7 +3,9 @@ package com.appcues.ui.primitive
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import com.appcues.data.model.ExperiencePrimitive.EmbedHtmlPrimitive
+import com.appcues.ui.composables.LocalStackScope
 import com.appcues.ui.extensions.imageAspectRatio
 import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewStateWithHTMLData
@@ -11,6 +13,7 @@ import com.google.accompanist.web.rememberWebViewStateWithHTMLData
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 internal fun EmbedHtmlPrimitive.Compose(modifier: Modifier) {
+    val stackScope = LocalStackScope.current
     val webViewState = rememberWebViewStateWithHTMLData(
         data = """
         <head>
@@ -25,7 +28,9 @@ internal fun EmbedHtmlPrimitive.Compose(modifier: Modifier) {
     )
 
     WebView(
-        modifier = modifier.then(Modifier.imageAspectRatio(intrinsicSize)),
+        modifier = modifier.then(
+            Modifier.imageAspectRatio(intrinsicSize, stackScope, style, LocalDensity.current)
+        ),
         state = webViewState,
         onCreated = {
             it.isNestedScrollingEnabled = false

--- a/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import coil.compose.AsyncImage
@@ -28,6 +29,10 @@ import com.appcues.ui.composables.LocalAppcuesActionDelegate
 import com.appcues.ui.composables.LocalAppcuesActions
 import com.appcues.ui.composables.LocalImageLoader
 import com.appcues.ui.composables.LocalLogcues
+import com.appcues.ui.composables.LocalStackScope
+import com.appcues.ui.composables.StackScope
+import com.appcues.ui.composables.StackScope.ColumnStackScope
+import com.appcues.ui.composables.StackScope.RowStackScope
 import com.appcues.ui.extensions.PrimitiveGestureProperties
 import com.appcues.ui.extensions.blurHashPlaceholder
 import com.appcues.ui.extensions.getBoxAlignment
@@ -37,23 +42,27 @@ import com.appcues.ui.extensions.innerPrimitiveStyle
 import com.appcues.ui.extensions.outerPrimitiveStyle
 import com.appcues.ui.extensions.toImageAsyncContentScale
 import com.appcues.ui.utils.rememberBlurHashDecoded
+import java.util.UUID
 
 @Composable
 internal fun ExperiencePrimitive.Compose(matchParentBox: BoxScope? = null) {
+    val stackScope = LocalStackScope.current
     Box(
-        modifier = Modifier.outerPrimitiveStyle(
-            component = this,
-            gestureProperties = PrimitiveGestureProperties(
-                actionsDelegate = LocalAppcuesActionDelegate.current,
-                actions = LocalAppcuesActions.current,
-                interactionSource = remember { MutableInteractionSource() },
-                indication = rememberRipple(),
-                enabled = remember { true },
-                role = getRole()
-            ),
-            isDark = isSystemInDarkTheme(),
-            matchParentBox = matchParentBox,
-        ),
+        modifier = Modifier
+            .outerPrimitiveStyle(
+                component = this,
+                gestureProperties = PrimitiveGestureProperties(
+                    actionsDelegate = LocalAppcuesActionDelegate.current,
+                    actions = LocalAppcuesActions.current,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = rememberRipple(),
+                    enabled = remember { true },
+                    role = getRole()
+                ),
+                isDark = isSystemInDarkTheme(),
+                matchParentBox = matchParentBox,
+            )
+            .updateStackScope(stackScope, id),
         contentAlignment = Alignment.Center
     ) {
         BackgroundImage(style)
@@ -75,6 +84,15 @@ internal fun ExperiencePrimitive.Compose(matchParentBox: BoxScope? = null) {
         }
     }
 }
+
+private fun Modifier.updateStackScope(stackScope: StackScope, id: UUID) = this.then(
+    Modifier.onSizeChanged {
+        when (stackScope) {
+            is ColumnStackScope -> stackScope.updateChildSize(id, it.width)
+            is RowStackScope -> stackScope.updateChildSize(id, it.height)
+        }
+    }
+)
 
 private fun ExperiencePrimitive.getRole(): Role {
     // This is for any tap actions in the experience which currently only

--- a/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
@@ -25,7 +25,7 @@ import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment
 import com.appcues.data.model.styling.ComponentStyle.ComponentVerticalAlignment
 import com.appcues.ui.composables.LocalStackScope
-import com.appcues.ui.composables.StackScope
+import com.appcues.ui.composables.StackScope.RowStackScope
 import com.appcues.ui.extensions.getTextStyle
 import com.appcues.ui.extensions.getVerticalAlignment
 import com.appcues.ui.theme.AppcuesPreviewPrimitive
@@ -42,7 +42,7 @@ internal fun HorizontalStackPrimitive.Compose(modifier: Modifier) {
         horizontalArrangement = distribution.toHorizontalArrangement(spacing),
         verticalAlignment = verticalAlignment
     ) {
-        CompositionLocalProvider(LocalStackScope provides StackScope.ROW) {
+        CompositionLocalProvider(LocalStackScope provides RowStackScope(style.height, items.size)) {
             ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
                 items.forEach {
                     ItemBox(distribution = distribution, primitive = it, parentVerticalAlignment = verticalAlignment) {

--- a/appcues/src/main/java/com/appcues/ui/primitive/ImagePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ImagePrimitive.kt
@@ -1,15 +1,19 @@
 package com.appcues.ui.primitive
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import coil.compose.AsyncImage
 import com.appcues.data.model.ExperiencePrimitive.ImagePrimitive
 import com.appcues.ui.composables.LocalImageLoader
 import com.appcues.ui.composables.LocalLogcues
+import com.appcues.ui.composables.LocalStackScope
+import com.appcues.ui.composables.StackScope
 import com.appcues.ui.extensions.blurHashPlaceholder
+import com.appcues.ui.extensions.getBoxAlignment
 import com.appcues.ui.extensions.getImageLoader
 import com.appcues.ui.extensions.getImageRequest
 import com.appcues.ui.extensions.imageAspectRatio
@@ -21,15 +25,17 @@ import com.appcues.ui.utils.rememberBlurHashDecoded
 internal fun ImagePrimitive.Compose(modifier: Modifier, matchParentBox: BoxScope? = null) {
     val context = LocalContext.current
     val logcues = LocalLogcues.current
+    val stackScope = LocalStackScope.current
     val decodedBlurHash = rememberBlurHashDecoded(blurHash = blurHash)
 
     AsyncImage(
-        modifier = modifier.applyImageModifier(this, matchParentBox),
+        modifier = modifier.applyImageModifier(this, matchParentBox, stackScope, LocalDensity.current),
         model = context.getImageRequest(url, contentMode),
         contentDescription = accessibilityLabel,
         imageLoader = LocalImageLoader.current ?: context.getImageLoader(),
         placeholder = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
         contentScale = contentMode.toImageAsyncContentScale(),
+        alignment = style.getBoxAlignment(),
         error = context.blurHashPlaceholder(decodedBlurHash, intrinsicSize),
         onError = {
             logcues.error(it.result.throwable)
@@ -37,9 +43,8 @@ internal fun ImagePrimitive.Compose(modifier: Modifier, matchParentBox: BoxScope
     )
 }
 
-private fun Modifier.applyImageModifier(image: ImagePrimitive, matchParentBox: BoxScope?) = then(
+private fun Modifier.applyImageModifier(image: ImagePrimitive, matchParentBox: BoxScope?, stackScope: StackScope, density: Density) = then(
     Modifier
         .styleSize(image.style, matchParentBox, image.contentMode)
-        .animateContentSize()
-        .imageAspectRatio(image.intrinsicSize, image.contentMode)
+        .imageAspectRatio(image.intrinsicSize, stackScope, image.style, density, image.contentMode)
 )

--- a/appcues/src/main/java/com/appcues/ui/primitive/SpacerPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/SpacerPrimitive.kt
@@ -16,10 +16,8 @@ internal fun SpacerPrimitive.Compose(modifier: Modifier) {
     // use spacing to set width or height based on LocalStackScope
     if (spacing > 0) {
         val sizeModifier = when (LocalStackScope.current) {
-            is ColumnStackScope -> Modifier
-                .width(spacing.dp)
-            is RowStackScope -> Modifier
-                .height(spacing.dp)
+            is ColumnStackScope -> Modifier.height(spacing.dp)
+            is RowStackScope -> Modifier.width(spacing.dp)
         }
 
         Spacer(

--- a/appcues/src/main/java/com/appcues/ui/primitive/SpacerPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/SpacerPrimitive.kt
@@ -8,17 +8,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.ExperiencePrimitive.SpacerPrimitive
 import com.appcues.ui.composables.LocalStackScope
-import com.appcues.ui.composables.StackScope.COLUMN
-import com.appcues.ui.composables.StackScope.ROW
+import com.appcues.ui.composables.StackScope.ColumnStackScope
+import com.appcues.ui.composables.StackScope.RowStackScope
 
 @Composable
 internal fun SpacerPrimitive.Compose(modifier: Modifier) {
     // use spacing to set width or height based on LocalStackScope
     if (spacing > 0) {
         val sizeModifier = when (LocalStackScope.current) {
-            ROW -> Modifier
+            is ColumnStackScope -> Modifier
                 .width(spacing.dp)
-            COLUMN -> Modifier
+            is RowStackScope -> Modifier
                 .height(spacing.dp)
         }
 

--- a/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
@@ -19,7 +19,7 @@ import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment.LEADING
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment.TRAILING
 import com.appcues.ui.composables.LocalStackScope
-import com.appcues.ui.composables.StackScope
+import com.appcues.ui.composables.StackScope.ColumnStackScope
 import com.appcues.ui.extensions.getHorizontalAlignment
 import com.appcues.ui.extensions.getTextStyle
 import com.appcues.ui.theme.AppcuesPreviewPrimitive
@@ -32,7 +32,7 @@ internal fun VerticalStackPrimitive.Compose(modifier: Modifier) {
         horizontalAlignment = style.getHorizontalAlignment(),
         verticalArrangement = Arrangement.spacedBy(spacing.dp, Alignment.CenterVertically)
     ) {
-        CompositionLocalProvider(LocalStackScope provides StackScope.COLUMN) {
+        CompositionLocalProvider(LocalStackScope provides ColumnStackScope(style.width, items.size)) {
             ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
                 items.forEach {
                     it.Compose()

--- a/appcues/src/main/java/com/appcues/ui/utils/ComposeConstraintsExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/utils/ComposeConstraintsExt.kt
@@ -1,0 +1,91 @@
+package com.appcues.ui.utils
+
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.isSatisfiedBy
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+import kotlin.math.roundToInt
+
+internal fun Constraints.tryMatchHeightFirst(aspectRatio: Float, widthPixels: Float?, enforceConstraints: Boolean): IntSize? {
+    // tryMaxHeight, if null tryMaxWidth
+    val maxSize = tryMaxHeight(aspectRatio, widthPixels, enforceConstraints) ?: tryMaxWidth(aspectRatio, widthPixels, enforceConstraints)
+    // tryMinHeight, if null tryMinWidth
+    val minSize = tryMinHeight(aspectRatio, enforceConstraints) ?: tryMinWidth(aspectRatio, enforceConstraints)
+    // return maxSize, if null minSize else null
+    return (maxSize ?: minSize)
+}
+
+internal fun Constraints.tryMatchWidthFirst(aspectRatio: Float, widthPixels: Float?, enforceConstraints: Boolean): IntSize? {
+    // tryMaxWidth, if null tryMaxHeight
+    val maxSize = tryMaxWidth(aspectRatio, widthPixels, enforceConstraints) ?: tryMaxHeight(aspectRatio, widthPixels, enforceConstraints)
+    // tryMinWidth, if null tryMinHeight
+    val minSize = tryMinWidth(aspectRatio, enforceConstraints) ?: tryMinHeight(aspectRatio, enforceConstraints)
+    // return maxSize, if null minSize else null
+    return (maxSize ?: minSize)
+}
+
+@OptIn(ExperimentalContracts::class)
+internal fun isPositiveFloat(value: Float?): Boolean {
+    contract {
+        returns(true) implies (value != null)
+    }
+
+    return value != null && value > 0.0
+}
+
+private fun Constraints.tryMaxWidth(aspectRatio: Float, widthPixels: Float?, enforceConstraints: Boolean): IntSize? {
+    val maxWidth = if (isPositiveFloat(widthPixels)) widthPixels else this.maxWidth
+    if (maxWidth != Constraints.Infinity) {
+        val height = (maxWidth.toFloat() / aspectRatio).roundToInt()
+        if (height > 0) {
+            val size = IntSize(maxWidth.toInt(), height)
+            if (widthPixels != null || !enforceConstraints || isSatisfiedBy(size)) {
+                return size
+            }
+        }
+    }
+    return null
+}
+
+private fun Constraints.tryMaxHeight(aspectRatio: Float, widthPixels: Float?, enforceConstraints: Boolean): IntSize? {
+    val maxHeight = this.maxHeight
+    val maxWidth = if (isPositiveFloat(widthPixels)) widthPixels else this.maxWidth.toFloat()
+    val height = (maxWidth / aspectRatio).roundToInt()
+    if (maxHeight != Constraints.Infinity) {
+        val width = (maxHeight * aspectRatio).roundToInt()
+        if (width > 0) {
+            val size = IntSize(width, maxHeight)
+            if (!enforceConstraints || isSatisfiedBy(size)) {
+                return size
+            }
+        }
+    } else if (height > 0) {
+        return IntSize(maxWidth.toInt(), height)
+    }
+    return null
+}
+
+private fun Constraints.tryMinWidth(aspectRatio: Float, enforceConstraints: Boolean = true): IntSize? {
+    val minWidth = this.minWidth
+    val height = (minWidth / aspectRatio).roundToInt()
+    if (height > 0) {
+        val size = IntSize(minWidth, height)
+        if (!enforceConstraints || isSatisfiedBy(size)) {
+            return size
+        }
+    }
+    return null
+}
+
+private fun Constraints.tryMinHeight(aspectRatio: Float, enforceConstraints: Boolean = true): IntSize? {
+    val minHeight = this.minHeight
+    val width = (minHeight * aspectRatio).roundToInt()
+    if (width > 0) {
+        val size = IntSize(width, minHeight)
+        if (!enforceConstraints || isSatisfiedBy(size)) {
+            return size
+        }
+    }
+    return null
+}


### PR DESCRIPTION
Updating the AspecRatio reader logic to fit specs for Side-by-side content.


Before this change aspectRatio was calculated based only on the target primitive, now by knowning [stackScope](https://github.com/appcues/appcues-android-sdk/pull/258/files#diff-ba5fc2a50d116a563e61531b0fc5fb60f4d2538b904a422b789db5cf004a4d56R45) and by each primitive reporting its own size [here](https://github.com/appcues/appcues-android-sdk/pull/258/files#diff-cf90f453a88a858b5ab8c9546f22d74473fff88d732c9875114c33bf846569faR88) we can better define how Constraint.findSize()  works to mirror Web builder and IOS renderings.


updating tests with this change in [this PR](https://github.com/appcues/appcues-mobile-experience-spec/pull/106).