### PR TITLE
Update dependencies for 1.1 SDK release

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -14,8 +14,9 @@ ext.room_version = '2.4.3'
 ext.compose_version = '1.3.0'
 ext.compose_compiler_version = '1.3.2'
 ext.accompanist_version = '0.27.0'
-ext.koin_version = '3.1.6'
-ext.coil_version = '2.2.0'
+ext.koin_version = '3.2.2'
+ext.coil_version = '2.2.2'
+ext.moshi_version = '1.14.0'
 
 android {
     compileSdk 33
@@ -66,10 +67,10 @@ android {
 
 dependencies {
     // Androidx
-    implementation "androidx.core:core-ktx:1.8.0"
-    implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation "androidx.core:core-ktx:1.9.0"
+    implementation 'androidx.activity:activity-compose:1.6.1'
     implementation "androidx.browser:browser:1.4.0"
-    implementation "androidx.navigation:navigation-compose:2.5.1"
+    implementation "androidx.navigation:navigation-compose:2.5.3"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
@@ -77,10 +78,10 @@ dependencies {
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
     // Workaround for an issue that will be fixed by google some day.
     // https://issuetracker.google.com/issues/227767363
-    debugImplementation "androidx.customview:customview:1.2.0-alpha01"
+    debugImplementation "androidx.customview:customview:1.2.0-alpha02"
     debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0"
     // ----
-    implementation "com.google.android.material:material:1.6.1"
+    implementation "com.google.android.material:material:1.7.0"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
@@ -93,10 +94,10 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
     implementation "com.squareup.okhttp3:logging-interceptor:4.9.0"
-    implementation 'com.squareup.moshi:moshi:1.13.0'
-    implementation 'com.squareup.moshi:moshi-adapters:1.13.0'
-    implementation 'com.squareup.moshi:moshi-kotlin:1.13.0'
-    kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.13.0'
+    implementation "com.squareup.moshi:moshi:$moshi_version"
+    implementation "com.squareup.moshi:moshi-adapters:$moshi_version"
+    implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
     // Dependency Injection
     implementation "io.insert-koin:koin-core:$koin_version"
     implementation "io.insert-koin:koin-android:$koin_version"


### PR DESCRIPTION
Several minor version updates to internal dependencies, to pick up fixes for our 1.1 SDK release: Jetpack libs, Material, Koin, Coil, Moshi