### PR TITLE
🐛 Fix bug where corner Radius and border width was not properly applied

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
@@ -314,7 +314,7 @@ internal fun Modifier.imageAspectRatio(
 
 private fun ComponentStyle.getImageWidthPixels(density: Density) = with(density) {
     // get true image width by subtracting current width with existing
-    // padding (leading and trialing) and borderWidth times 2 (as it applies on both sides)
+    // padding (leading and trailing) and borderWidth times 2 (as it applies on both sides)
     width?.let { (it - (paddingLeading + paddingTrailing + (borderWidth ?: 0.0) * 2)).dp.toPx() }
 }
 

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -52,6 +52,7 @@ internal fun BottomSheetModal(
         val height = heightDerivedOf(appcuesWindowInfo)
         val enterAnimation = enterTransitionDerivedOf(appcuesWindowInfo)
         val exitAnimation = exitTransitionDerivedOf(appcuesWindowInfo)
+        val isDark = isSystemInDarkTheme()
 
         Box(
             modifier = Modifier
@@ -70,11 +71,7 @@ internal fun BottomSheetModal(
                         .fillMaxWidth(width.value)
                         .fillMaxHeight(height.value)
                         // default modal style modifiers
-                        .modalStyle(
-                            style = style,
-                            isDark = isSystemInDarkTheme(),
-                            modifier = Modifier.sheetModifier(appcuesWindowInfo, style),
-                        ),
+                        .modalStyle(style, isDark) { Modifier.sheetModifier(appcuesWindowInfo, isDark, it) },
                     content = { content(true, style?.getPaddings()) },
                 )
             }

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -57,11 +57,7 @@ internal fun DialogModal(
                 // container padding based on screen size
                 .padding(horizontal = dialogHorizontalMargin, vertical = dialogVerticalMargin)
                 // default modal style modifiers
-                .modalStyle(
-                    style = style,
-                    isDark = isDark,
-                    modifier = Modifier.dialogModifier(style, isDark),
-                ),
+                .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) },
             content = { content(false, style?.getPaddings()) },
         )
     }

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -50,6 +50,7 @@ internal fun ExpandedBottomSheetModal(
         val height = heightDerivedOf(windowInfo)
         val enterAnimation = enterTransitionDerivedOf(windowInfo)
         val exitAnimation = exitTransitionDerivedOf(windowInfo)
+        val isDark = isSystemInDarkTheme()
 
         Box(
             modifier = Modifier.fillMaxSize(),
@@ -66,11 +67,7 @@ internal fun ExpandedBottomSheetModal(
                         .fillMaxWidth(width.value)
                         .fillMaxHeight(height.value)
                         // default modal style modifiers
-                        .modalStyle(
-                            style = style,
-                            isDark = isSystemInDarkTheme(),
-                            modifier = Modifier.sheetModifier(windowInfo, style),
-                        ),
+                        .modalStyle(style, isDark) { Modifier.sheetModifier(windowInfo, isDark, it) },
                     content = { content(true, style?.getPaddings()) },
                 )
             }

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -53,6 +53,7 @@ internal fun FullScreenModal(
         val fullHeight = heightDerivedOf(windowInfo)
         val enterAnimation = enterTransitionDerivedOf(windowInfo)
         val exitAnimation = exitTransitionDerivedOf(windowInfo)
+        val isDark = isSystemInDarkTheme()
 
         Box(
             modifier = Modifier.fillMaxSize(),
@@ -69,11 +70,7 @@ internal fun FullScreenModal(
                         .fillMaxWidth(fullWidth.value)
                         .fillMaxHeight(fullHeight.value)
                         // default modal style modifiers
-                        .modalStyle(
-                            style = style,
-                            isDark = isSystemInDarkTheme(),
-                            modifier = Modifier.fullModifier(windowInfo),
-                        ),
+                        .modalStyle(style, isDark) { Modifier.fullModifier(windowInfo, isDark, it) },
                     content = { content(true, style?.getPaddings()) },
                 )
             }

--- a/appcues/src/main/java/com/appcues/ui/modal/SharedModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/SharedModal.kt
@@ -10,11 +10,9 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
-import com.appcues.ui.extensions.coloredShadow
-import com.appcues.ui.extensions.styleBorder
+import com.appcues.ui.extensions.styleCorner
 import com.appcues.ui.extensions.styleShadow
 import com.appcues.ui.utils.AppcuesWindowInfo
 import com.appcues.ui.utils.AppcuesWindowInfo.DeviceType.MOBILE
@@ -33,42 +31,32 @@ internal fun dialogExitTransition(): ExitTransition {
     return fadeOut(tween(durationMillis = 100))
 }
 
-internal fun Modifier.dialogModifier(style: ComponentStyle?, isDark: Boolean) =
-    then(Modifier.styleShadow(style, isDark))
-        .then(
-            if (style?.cornerRadius != null && style.cornerRadius ne 0.0)
-                Modifier
-                    .clip(RoundedCornerShape(style.cornerRadius.dp))
-                    .styleBorder(style, isDark)
-            else
-                Modifier
-        )
+internal fun Modifier.dialogModifier(style: ComponentStyle, isDark: Boolean) =
+    then(
+        Modifier
+            .styleShadow(style, isDark)
+            .styleCorner(style)
+    )
 
-internal fun Modifier.sheetModifier(windowInfo: AppcuesWindowInfo, style: ComponentStyle?) = then(
+internal fun Modifier.sheetModifier(windowInfo: AppcuesWindowInfo, isDark: Boolean, style: ComponentStyle) = then(
     when (windowInfo.deviceType) {
-        MOBILE -> if (windowInfo.orientation == PORTRAIT && style?.cornerRadius != null && style.cornerRadius ne 0.0)
+        MOBILE -> if (windowInfo.orientation == PORTRAIT && style.cornerRadius ne 0.0)
             Modifier.clip(RoundedCornerShape(topStart = style.cornerRadius.dp, topEnd = style.cornerRadius.dp))
         else
             Modifier
         TABLET ->
             Modifier
-                .coloredShadow(
-                    color = Color(color = 0xEE777777),
-                    radius = 12.dp
-                )
-                .clip(RoundedCornerShape(12.dp))
+                .styleShadow(style, isDark)
+                .styleCorner(style)
     }
 )
 
-internal fun Modifier.fullModifier(windowInfo: AppcuesWindowInfo) = then(
+internal fun Modifier.fullModifier(windowInfo: AppcuesWindowInfo, isDark: Boolean, style: ComponentStyle) = then(
     when (windowInfo.deviceType) {
         MOBILE -> Modifier
         TABLET ->
             Modifier
-                .coloredShadow(
-                    color = Color(color = 0xEE777777),
-                    radius = 12.dp
-                )
-                .clip(RoundedCornerShape(12.dp))
+                .styleShadow(style, isDark)
+                .styleCorner(style)
     }
 )


### PR DESCRIPTION
Changing some of the UI behavior to consider and fit properly in order the cornerRadius + BorderWidth, taking into consideration possible background. reflected UI tests is [here](https://github.com/appcues/appcues-mobile-experience-spec/pull/109).

the only difference between builder and Android is the clipping of the primitive based on cornerRadius + padding, this is unusual behavior for Compose and will lead to unwanted clipping for things like negative margin and shadows

![image](https://user-images.githubusercontent.com/5244805/199312187-8f19f1cb-d0ce-492b-a432-81e643f78dda.png)

