### PR TITLE
🐛 Fix bug with virtualkeyboard on scrollable content

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -52,6 +52,7 @@ android {
 
     buildFeatures {
         compose true
+        viewBinding true
     }
 
     composeOptions {

--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         <activity
             android:name=".ui.AppcuesActivity"
             android:exported="false"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Appcues.AppcuesActivityTheme" />
     </application>
 

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -3,10 +3,10 @@ package com.appcues.ui
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
+import com.appcues.databinding.AppcuesActivityLayoutBinding
 import com.appcues.di.AppcuesKoinContext
 import com.appcues.logging.Logcues
 import com.appcues.ui.composables.AppcuesComposition
@@ -29,6 +29,8 @@ internal class AppcuesActivity : AppCompatActivity() {
             }
     }
 
+    private val binding by lazy { AppcuesActivityLayoutBinding.inflate(layoutInflater) }
+
     private val scope: Scope by lazy { AppcuesKoinContext.koin.getScope(intent.getStringExtra(EXTRA_SCOPE_ID)!!) }
 
     private val viewModel: AppcuesViewModel by viewModels { AppcuesViewModelFactory(scope) }
@@ -41,13 +43,13 @@ internal class AppcuesActivity : AppCompatActivity() {
         // remove enter animation from this activity
         overridePendingTransition(0, 0)
         super.onCreate(savedInstanceState)
+        setContentView(binding.root)
 
-        setContent {
+        binding.appcuesActivityComposeView.setContent {
             AppcuesComposition(
                 viewModel = viewModel,
                 shakeGestureListener = shakeGestureListener,
                 logcues = logcues,
-                applySystemMargins = true,
                 onCompositionDismissed = ::finish
             )
         }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -5,13 +5,9 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.platform.LocalDensity
 import com.appcues.logging.Logcues
 import com.appcues.trait.ContentHolderTrait.ContainerPages
@@ -21,14 +17,12 @@ import com.appcues.ui.AppcuesViewModel.UIState.Dismissing
 import com.appcues.ui.AppcuesViewModel.UIState.Rendering
 import com.appcues.ui.ShakeGestureListener
 import com.appcues.ui.theme.AppcuesTheme
-import com.appcues.ui.utils.margin
 
 @Composable
 internal fun AppcuesComposition(
     viewModel: AppcuesViewModel,
     shakeGestureListener: ShakeGestureListener,
     logcues: Logcues,
-    applySystemMargins: Boolean,
     onCompositionDismissed: () -> Unit,
 ) {
     // ensure to change some colors to match appropriate design for custom primitive blocks
@@ -42,7 +36,6 @@ internal fun AppcuesComposition(
             LocalAppcuesPaginationDelegate provides AppcuesPagination { viewModel.onPageChanged(it) },
         ) {
             MainSurface(
-                applySystemMargins = rememberUpdatedState(applySystemMargins),
                 onCompositionDismissed = onCompositionDismissed
             )
         }
@@ -50,14 +43,8 @@ internal fun AppcuesComposition(
 }
 
 @Composable
-private fun MainSurface(
-    applySystemMargins: State<Boolean>,
-    onCompositionDismissed: () -> Unit,
-) {
-    Box(
-        modifier = Modifier.applySystemMargins(applySystemMargins),
-        contentAlignment = Alignment.Center,
-    ) {
+private fun MainSurface(onCompositionDismissed: () -> Unit) {
+    Box(contentAlignment = Alignment.Center) {
         val viewModel = LocalViewModel.current
         // collect all UIState
         viewModel.uiState.collectAsState().let { state ->
@@ -83,14 +70,6 @@ private fun MainSurface(
             }
         }
     }
-}
-
-private fun Modifier.applySystemMargins(shouldApply: State<Boolean>): Modifier = composed {
-    then(
-        if (shouldApply.value) {
-            Modifier.margin(rememberSystemMarginsState().value)
-        } else Modifier
-    )
 }
 
 @Composable

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
@@ -1,19 +1,12 @@
 package com.appcues.ui.composables
 
 import androidx.compose.animation.core.MutableTransitionState
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import com.appcues.ui.AppcuesViewModel.UIState
 import com.appcues.ui.AppcuesViewModel.UIState.Rendering
-import com.appcues.util.getNavigationBarHeight
-import com.appcues.util.getStatusBarHeight
 
 @Composable
 internal fun rememberLastRenderingState(state: State<UIState>) = remember { mutableStateOf<Rendering?>(null) }
@@ -87,13 +80,3 @@ internal fun rememberAppcuesContentVisibility() = remember { isContentVisible }
 
 @Composable
 internal fun rememberAppcuesBackdropVisibility() = remember { isBackdropVisible }
-
-@Composable
-internal fun rememberSystemMarginsState(): State<PaddingValues> {
-    val density = LocalDensity.current
-    val topMargin = rememberUpdatedState(newValue = with(density) { LocalContext.current.getStatusBarHeight().toDp() })
-    val bottomMargin = rememberUpdatedState(newValue = with(density) { LocalContext.current.getNavigationBarHeight().toDp() })
-    // will calculate status bar height and navigation bar height and return it in PaddingValues
-    // this is derived state to handle possible changes to values in top and bottom margin
-    return remember { derivedStateOf { PaddingValues(top = topMargin.value, bottom = bottomMargin.value) } }
-}

--- a/appcues/src/main/res/layout/appcues_activity_layout.xml
+++ b/appcues/src/main/res/layout/appcues_activity_layout.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/appcues_activity_compose_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
working around a previous issue from delivery-hero (customer) we now have a appcues_activity_layout.xml containing the container for our composition, then we can set fitsSystemWindow to true without introducing unwanted behavior from activity customization. updated UI [tests PR](https://github.com/appcues/appcues-mobile-experience-spec/pull/114) 