### PR TITLE
Fix embed video expansion to full screen

### DIFF
--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
             android:name=".ui.AppcuesActivity"
             android:exported="false"
             android:windowSoftInputMode="adjustResize"
+            android:configChanges="orientation|screenSize|screenLayout"
             android:theme="@style/Appcues.AppcuesActivityTheme" />
     </application>
 

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -10,6 +10,7 @@ import com.appcues.databinding.AppcuesActivityLayoutBinding
 import com.appcues.di.AppcuesKoinContext
 import com.appcues.logging.Logcues
 import com.appcues.ui.composables.AppcuesComposition
+import com.appcues.ui.primitive.EmbedChromeClient
 import org.koin.core.scope.Scope
 
 internal class AppcuesActivity : AppCompatActivity() {
@@ -50,6 +51,7 @@ internal class AppcuesActivity : AppCompatActivity() {
                 viewModel = viewModel,
                 shakeGestureListener = shakeGestureListener,
                 logcues = logcues,
+                chromeClient = EmbedChromeClient(binding.appcuesCustomViewContainer),
                 onCompositionDismissed = ::finish
             )
         }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -17,12 +17,14 @@ import com.appcues.ui.AppcuesViewModel.UIState.Dismissing
 import com.appcues.ui.AppcuesViewModel.UIState.Rendering
 import com.appcues.ui.ShakeGestureListener
 import com.appcues.ui.theme.AppcuesTheme
+import com.google.accompanist.web.AccompanistWebChromeClient
 
 @Composable
 internal fun AppcuesComposition(
     viewModel: AppcuesViewModel,
     shakeGestureListener: ShakeGestureListener,
     logcues: Logcues,
+    chromeClient: AccompanistWebChromeClient,
     onCompositionDismissed: () -> Unit,
 ) {
     // ensure to change some colors to match appropriate design for custom primitive blocks
@@ -32,6 +34,7 @@ internal fun AppcuesComposition(
             LocalViewModel provides viewModel,
             LocalShakeGestureListener provides shakeGestureListener,
             LocalLogcues provides logcues,
+            LocalChromeClient provides chromeClient,
             LocalAppcuesActionDelegate provides DefaultAppcuesActionsDelegate(viewModel),
             LocalAppcuesPaginationDelegate provides AppcuesPagination { viewModel.onPageChanged(it) },
         ) {

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -13,6 +13,7 @@ import com.appcues.logging.Logcues
 import com.appcues.ui.AppcuesViewModel
 import com.appcues.ui.ShakeGestureListener
 import com.appcues.ui.composables.StackScope.ColumnStackScope
+import com.google.accompanist.web.AccompanistWebChromeClient
 import java.util.UUID
 
 // used to register callback for all Actions triggered from primitives
@@ -57,6 +58,8 @@ internal val LocalLogcues = staticCompositionLocalOf<Logcues> { noLocalProvidedF
 internal val LocalExperienceStepFormStateDelegate = compositionLocalOf { ExperienceStepFormState() }
 
 internal val LocalStackScope = compositionLocalOf<StackScope> { ColumnStackScope(null, 0) }
+
+internal val LocalChromeClient = compositionLocalOf { AccompanistWebChromeClient() }
 
 internal sealed class StackScope(private val childrenCount: Int) {
 

--- a/appcues/src/main/res/layout/appcues_activity_layout.xml
+++ b/appcues/src/main/res/layout/appcues_activity_layout.xml
@@ -13,4 +13,14 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <FrameLayout
+        android:id="@+id/appcues_custom_view_container"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
To support a fullscreen button on an embedded video inside of a WebView, we need to implement a custom `AccompanistWebChromeClient` and override the `onShowCustomView` and `onHideCustomView` functions. These calls get invoked to pass a `View` that should be shown/hidden respectively, when the user toggles that button. The general concept for hooking into the Accompanist WebView chrome client was modeled after ideas in https://github.com/google/accompanist/pull/1113. Some of the other implementation details were inspired by https://github.com/akhgupta/WebviewVideo/blob/master/src/com/example/webview/MyActivity.java#L99.

This implementation shows the new custom view by using an empty, hidden `FrameLayout` in the root activity layout, which is then used as a custom view container, conditionally, for this purpose. A CompositionLocal is used to pass this custom chrome client down through the composition, since it needs to be implemented at the host Activity layer for access to the top level layout references.

The `android:configChanges` is an approach to enable rotation to landscape for the fullscreen video, without restarting the AppcuesActivity, and thus stopping the video.


https://user-images.githubusercontent.com/19266448/201178607-7a8ac48d-9baf-4447-9ae3-28335938fcfa.mov

