### PR TITLE
♻️  Update backdrop trait behavior inside composition to enable keyhoole trait

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/BackdropDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/BackdropDecoratingTrait.kt
@@ -6,5 +6,5 @@ import androidx.compose.runtime.Composable
 interface BackdropDecoratingTrait : ExperienceTrait {
 
     @Composable
-    fun BoxScope.Backdrop()
+    fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit)
 }

--- a/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
@@ -4,6 +4,7 @@ import com.appcues.di.KoinScopePlugin
 import com.appcues.trait.appcues.BackdropTrait
 import com.appcues.trait.appcues.BackgroundContentTrait
 import com.appcues.trait.appcues.CarouselTrait
+import com.appcues.trait.appcues.KeyholeTrait
 import com.appcues.trait.appcues.ModalTrait
 import com.appcues.trait.appcues.PagingDotsTrait
 import com.appcues.trait.appcues.SkippableTrait
@@ -22,6 +23,12 @@ internal object TraitKoin : KoinScopePlugin {
 
         factory { params ->
             BackdropTrait(
+                config = params.getOrNull(),
+            )
+        }
+
+        factory { params ->
+            KeyholeTrait(
                 config = params.getOrNull(),
             )
         }

--- a/appcues/src/main/java/com/appcues/trait/TraitRegistry.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitRegistry.kt
@@ -5,6 +5,7 @@ import com.appcues.logging.Logcues
 import com.appcues.trait.appcues.BackdropTrait
 import com.appcues.trait.appcues.BackgroundContentTrait
 import com.appcues.trait.appcues.CarouselTrait
+import com.appcues.trait.appcues.KeyholeTrait
 import com.appcues.trait.appcues.ModalTrait
 import com.appcues.trait.appcues.PagingDotsTrait
 import com.appcues.trait.appcues.SkippableTrait
@@ -26,6 +27,7 @@ internal class TraitRegistry(
 
     init {
         register(BackdropTrait.TYPE) { config, _ -> get<BackdropTrait> { parametersOf(config) } }
+        register(KeyholeTrait.TYPE) { config, _ -> get<KeyholeTrait> { parametersOf(config) } }
         register(ModalTrait.TYPE) { config, _ -> get<ModalTrait> { parametersOf(config) } }
         register(SkippableTrait.TYPE) { config, _ -> get<SkippableTrait> { parametersOf(config) } }
         register(CarouselTrait.TYPE) { config, _ -> get<CarouselTrait> { parametersOf(config) } }

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropTrait.kt
@@ -32,7 +32,7 @@ internal class BackdropTrait(
     private val backgroundColor = config.getConfigColor("backgroundColor")
 
     @Composable
-    override fun BoxScope.Backdrop() {
+    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
         AppcuesTraitAnimatedVisibility(
             visibleState = rememberAppcuesBackdropVisibility(),
             enter = enterTransition(),
@@ -45,6 +45,8 @@ internal class BackdropTrait(
                     .background(backgroundColor, isSystemInDarkTheme())
             )
         }
+
+        content()
     }
 
     private fun Modifier.background(color: ComponentColor?, isDark: Boolean) = this.then(

--- a/appcues/src/main/java/com/appcues/trait/appcues/KeyholeTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/KeyholeTrait.kt
@@ -1,0 +1,66 @@
+package com.appcues.trait.appcues
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ClipOp
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.platform.LocalDensity
+import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.trait.BackdropDecoratingTrait
+
+internal class KeyholeTrait(
+    override val config: AppcuesConfigMap,
+) : BackdropDecoratingTrait {
+
+    companion object {
+
+        const val TYPE = "@appcues/keyhole"
+    }
+
+    @Composable
+    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
+        // temporary block of code before we understand how to style keyhole
+        val density = LocalDensity.current
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                // set background color
+                .drawWithContent {
+                    val outline =
+                        RoundedCornerShape(percent = 100).createOutline(Size(width = 400f, height = 400f), layoutDirection, density)
+                    clipPath(
+                        path = Path().apply {
+                            addOutline(outline)
+                            translate(Offset(x = 200f, y = 80f))
+                        },
+                        clipOp = ClipOp.Difference,
+                    ) {
+                        this@drawWithContent.drawContent()
+                    }
+
+                    //                    drawOval(
+                    //                        brush = Brush.radialGradient(
+                    //                            center = Offset(400f, 280f),
+                    //                            radius = 205f,
+                    //                            colors = listOf(Color(0x00000000), Color(0x00000000), Color(0x00000000), Color(0xFFFF5050)),
+                    //                            tileMode = TileMode.Clamp
+                    //                        ),
+                    //                        topLeft = Offset(200f, 80f),
+                    //                        size = Size(400f, 400f)
+                    //                    )
+                }
+
+        ) {
+            content()
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -60,7 +60,7 @@ internal class SkippableTrait(
     }
 
     @Composable
-    override fun BoxScope.Backdrop() {
+    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
         Spacer(
             modifier = Modifier
                 .matchParentSize()
@@ -73,5 +73,7 @@ internal class SkippableTrait(
                     }
                 },
         )
+
+        content()
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalDensity
 import com.appcues.logging.Logcues
+import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.ContentHolderTrait.ContainerPages
 import com.appcues.trait.StepDecoratingPadding
 import com.appcues.ui.AppcuesViewModel
@@ -91,9 +92,8 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
 
     with(state.stepContainer) {
         // apply backdrop traits
-        backdropDecoratingTraits.forEach {
-            with(it) { Backdrop() }
-        }
+        ApplyBackgroundDecoratingTraits(list = backdropDecoratingTraits.toMutableList())
+
         // create wrapper
         contentWrappingTrait.WrapContent { hasFixedHeight, contentPadding ->
             Box(contentAlignment = Alignment.TopCenter) {
@@ -131,5 +131,14 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
                 ApplyOverlayContainerTraits(this)
             }
         }
+    }
+}
+
+@Composable
+private fun BoxScope.ApplyBackgroundDecoratingTraits(list: List<BackdropDecoratingTrait>) {
+    // get last trait if its not null compose it and drop last calling it again recursively
+    val item = list.lastOrNull()
+    if (item != null) {
+        with(item) { BackdropDecorate { ApplyBackgroundDecoratingTraits(list.dropLast(1)) } }
     }
 }


### PR DESCRIPTION
Before this change, backroptraits were rendering one on top of the other, as totally different compositions, now its all in the same end composition, in a way that you can (if desired) alter the composition coming from the ApplyBackdropTrait chain. an example of this is found on KeyholeTrait, which is not accepting any styling options for now but works as a proof of concept and will be updated later.