### PR TITLE
Rework experiment analytics to support new requested properties

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -6,6 +6,7 @@ import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.Interactio
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.statemachine.Error
+import com.appcues.util.appcuesFormatted
 import com.appcues.util.toSlug
 
 internal sealed class ExperienceLifecycleEvent(
@@ -77,7 +78,7 @@ internal sealed class ExperienceLifecycleEvent(
 
     val properties: Map<String, Any>
         get() = hashMapOf<String, Any?>(
-            "experienceId" to experience.id.toString().lowercase(),
+            "experienceId" to experience.id.appcuesFormatted(),
             "experienceName" to experience.name,
             "experienceType" to experience.type,
             "version" to experience.publishedAt,
@@ -88,7 +89,7 @@ internal sealed class ExperienceLifecycleEvent(
         ).apply {
             flatStepIndex?.let {
                 val step = experience.flatSteps[it]
-                this["stepId"] = step.id.toString()
+                this["stepId"] = step.id.appcuesFormatted()
                 // this is required by SDK debugger to know which step and group is currently showing
                 this["stepIndex"] = "${experience.groupLookup[it] ?: 0},${experience.stepIndexLookup[it] ?: 0}"
                 this["stepType"] = step.type
@@ -98,7 +99,7 @@ internal sealed class ExperienceLifecycleEvent(
             }
             error?.let {
                 this["message"] = it.message
-                this["errorId"] = it.id.toString()
+                this["errorId"] = it.id.appcuesFormatted()
             }
         }.filterValues { it != null }.mapValues { it.value as Any }
 

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -93,6 +93,12 @@ internal class ExperienceMapper(
 
     private fun List<ExperimentResponse>.getExperiment(experienceId: UUID) =
         this.firstOrNull { it.experienceId == experienceId }?.let { experimentResponse ->
-            Experiment(experimentResponse.experimentId, experimentResponse.group)
+            Experiment(
+                id = experimentResponse.experimentId,
+                group = experimentResponse.group,
+                experienceId = experimentResponse.experienceId,
+                goalId = experimentResponse.goalId,
+                contentType = experimentResponse.contentType
+            )
         }
 }

--- a/appcues/src/main/java/com/appcues/data/model/Experiment.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experiment.kt
@@ -5,4 +5,7 @@ import java.util.UUID
 internal data class Experiment(
     val id: UUID,
     val group: String,
+    val experienceId: UUID,
+    val goalId: String,
+    val contentType: String,
 )

--- a/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/ExperimentResponse.kt
@@ -11,4 +11,8 @@ internal data class ExperimentResponse(
     val experimentId: UUID,
     @Json(name = "experience_id")
     val experienceId: UUID,
+    @Json(name = "goal_id")
+    val goalId: String,
+    @Json(name = "content_type")
+    val contentType: String,
 )

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -18,6 +18,7 @@ import com.appcues.statemachine.StateMachine
 import com.appcues.util.ResultOf
 import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
+import com.appcues.util.appcuesFormatted
 import org.koin.core.component.KoinScopeComponent
 import org.koin.core.component.inject
 import org.koin.core.scope.Scope
@@ -128,8 +129,11 @@ internal class ExperienceRenderer(
         analyticsTracker.track(
             event = AnalyticsEvent.ExperimentEntered,
             properties = mapOf(
-                "experimentId" to id.toString().lowercase(),
-                "group" to group
+                "experimentId" to id.appcuesFormatted(),
+                "experimentGroup" to group,
+                "experimentExperienceId" to experienceId.appcuesFormatted(),
+                "experimentGoalId" to goalId,
+                "experimentContentType" to contentType,
             ),
             interactive = false
         )

--- a/appcues/src/main/java/com/appcues/util/UuidExt.kt
+++ b/appcues/src/main/java/com/appcues/util/UuidExt.kt
@@ -1,0 +1,5 @@
+package com.appcues.util
+
+import java.util.UUID
+
+fun UUID.appcuesFormatted() = toString().lowercase()

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -75,7 +75,13 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD NOT show experience WHEN an experiment is active AND group is control`() = runTest {
         // GIVEN
-        val experiment = Experiment(UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"), "control")
+        val experiment = Experiment(
+            id = UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"),
+            group = "control",
+            experienceId = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
+            goalId = "my-goal",
+            contentType = "my-content-type"
+        )
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -95,7 +101,13 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD show experience WHEN an experiment is active AND group is exposed`() = runTest {
         // GIVEN
-        val experiment = Experiment(UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"), "exposed")
+        val experiment = Experiment(
+            id = UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"),
+            group = "exposed",
+            experienceId = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
+            goalId = "my-goal",
+            contentType = "my-content-type"
+        )
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -116,7 +128,13 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD track experiment_entered with group=control WHEN an experiment is active AND group is control`() = runTest {
         // GIVEN
-        val experiment = Experiment(UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"), "control")
+        val experiment = Experiment(
+            id = UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"),
+            group = "control",
+            experienceId = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
+            goalId = "my-goal",
+            contentType = "my-content-type"
+        )
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -133,7 +151,13 @@ class ExperienceRendererTest {
         verify {
             analyticsTracker.track(
                 AnalyticsEvent.ExperimentEntered,
-                mapOf("experimentId" to "06f9bf87-1921-4919-be55-429b278bf578", "group" to "control"),
+                mapOf(
+                    "experimentId" to "06f9bf87-1921-4919-be55-429b278bf578",
+                    "experimentGroup" to "control",
+                    "experimentExperienceId" to "d84c9d01-aa27-4cbb-b832-ee03720e04fc",
+                    "experimentGoalId" to "my-goal",
+                    "experimentContentType" to "my-content-type",
+                ),
                 false
             )
         }
@@ -142,7 +166,13 @@ class ExperienceRendererTest {
     @Test
     fun `show SHOULD track experiment_entered with group=exposed WHEN an experiment is active AND group is exposed`() = runTest {
         // GIVEN
-        val experiment = Experiment(UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"), "exposed")
+        val experiment = Experiment(
+            id = UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"),
+            group = "exposed",
+            experienceId = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
+            goalId = "my-goal",
+            contentType = "my-content-type"
+        )
         val experience = mockExperienceExperiment(experiment)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
             every { this@mockk.state } answers { Idling }
@@ -159,7 +189,13 @@ class ExperienceRendererTest {
         verify {
             analyticsTracker.track(
                 AnalyticsEvent.ExperimentEntered,
-                mapOf("experimentId" to "06f9bf87-1921-4919-be55-429b278bf578", "group" to "exposed"),
+                mapOf(
+                    "experimentId" to "06f9bf87-1921-4919-be55-429b278bf578",
+                    "experimentGroup" to "exposed",
+                    "experimentExperienceId" to "d84c9d01-aa27-4cbb-b832-ee03720e04fc",
+                    "experimentGoalId" to "my-goal",
+                    "experimentContentType" to "my-content-type",
+                ),
                 false)
         }
     }


### PR DESCRIPTION
NOTE: targeting new `release/1.2` branch (branched off 1.1.1 tag)

* capture 2 new properties from the response for experiments
* update the experience_entered analytic to output 3 additional properties and rename another

Also added extension on UUID for analytics string formatting logic shared in a few places

