### PR TITLE
A couple of cherry picks for release/1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Initializing the SDK requires you to provide two values: `APPCUES_ACCOUNT_ID` an
 
 #### Supporting Debugging and Experience Previewing
 
-Supporting debugging and experience previewing is not required for the Appcues Android SDK to function, but it is necessary for the optimal Appcues builder experience. Refer to the [Debug Guide](https://github.com/appcues/appcues-android-sdk/blob/main/docs/Debugging.md) for details.
+During installation, follow the steps outlined in [Configuring the Appcues URL Scheme](https://github.com/appcues/appcues-android-sdk/blob/main/docs/URLSchemeConfiguring.md). This is necessary for the optimal Appcues builder experience, to support debugging and experience preview. Refer to the [Debug Guide](https://github.com/appcues/appcues-android-sdk/blob/main/docs/Debugging.md) for details about using the Appcues debugger.
 
 ### Identifying Users
 

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
NOTE: targeting new `release/1.2 branch`

Now that we have a `1.2.0` release branch going, cherry picking a couple of minor updates from `main` that were after `1.1.1` but not related to any of the longer term trait 2.0 work. 

This is really just to keep things in clean state, branch hygiene - one readme doc update and one update to the sample app build minification.