### PR TITLE
Allow navigate actions on first step for non-qualifying experience triggers

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -7,6 +7,7 @@ import com.appcues.action.ActionRegistry
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ActivityScreenTracking
 import com.appcues.analytics.AnalyticsTracker
+import com.appcues.data.model.ExperienceTrigger
 import com.appcues.debugger.AppcuesDebuggerManager
 import com.appcues.di.AppcuesKoinContext
 import com.appcues.logging.Logcues
@@ -179,7 +180,7 @@ class Appcues internal constructor(koinScope: Scope) {
      * @return True if experience content was able to be shown, false if not.
      */
     suspend fun show(experienceId: String): Boolean {
-        return experienceRenderer.show(experienceId)
+        return experienceRenderer.show(experienceId, ExperienceTrigger.ShowCall)
     }
 
     /**

--- a/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
@@ -3,6 +3,7 @@ package com.appcues
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import com.appcues.data.model.ExperienceTrigger
 import com.appcues.debugger.AppcuesDebuggerManager
 import com.appcues.ui.ExperienceRenderer
 import kotlinx.coroutines.launch
@@ -35,7 +36,7 @@ internal class DeepLinkHandler(
                 }
                 segments.count() == 2 && segments[0] == "experience_content" -> {
                     appcuesCoroutineScope.launch {
-                        experienceRenderer.show(segments[1])
+                        experienceRenderer.show(segments[1], ExperienceTrigger.DeepLink)
                     }
                     handled = true
                 }

--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -47,6 +47,8 @@ internal object ActionKoin : KoinScopePlugin {
         factory { params ->
             LaunchExperienceAction(
                 config = params.getOrNull(),
+                stateMachine = get(),
+                experienceRenderer = get(),
             )
         }
 

--- a/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
@@ -4,22 +4,40 @@ import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.action.MetadataSettingsAction
 import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.ExperienceTrigger
 import com.appcues.data.model.getConfig
+import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer
+import java.util.UUID
 
 internal class LaunchExperienceAction(
     override val config: AppcuesConfigMap,
+    private val stateMachine: StateMachine,
+    private val experienceRenderer: ExperienceRenderer,
 ) : ExperienceAction, MetadataSettingsAction {
 
-    constructor(experienceId: String) : this(
-        hashMapOf<String, Any>("experienceID" to experienceId)
+    // this constructor is called to create an instance of this action from the post-flow-completion
+    // actions that are defined in flow settings, that execute after the flow (not a button action)
+    constructor(
+        completedExperienceId: String,
+        launchExperienceId: String,
+        stateMachine: StateMachine,
+        experienceRenderer: ExperienceRenderer,
+    ) : this(
+        config = hashMapOf<String, Any>(
+            "completedExperienceID" to completedExperienceId,
+            "experienceID" to launchExperienceId,
+        ),
+        stateMachine = stateMachine,
+        experienceRenderer = experienceRenderer
     )
 
     companion object {
-
         const val TYPE = "@appcues/launch-experience"
     }
 
     private val experienceId: String? = config.getConfig("experienceID")
+    private val completedExperienceId: String? = config.getConfig("completedExperienceID")
 
     override val category = "internal"
 
@@ -27,7 +45,21 @@ internal class LaunchExperienceAction(
 
     override suspend fun execute(appcues: Appcues) {
         if (experienceId != null) {
-            appcues.show(experienceId)
+            experienceRenderer.show(experienceId, getTrigger())
         }
     }
+
+    private fun getTrigger() =
+        if (completedExperienceId != null) {
+            // if a completed experience ID was provided - this means the action originated as a post-flow
+            // completion action, so this should be supplied as the trigger type
+            ExperienceTrigger.ExperienceCompletionAction(UUID.fromString(completedExperienceId))
+        } else {
+            // more typical case - the action was a button action within a flow that is launching another
+            // flow - capture the current experience from the state machine as the experience that is launching the new flow.
+            // note: it's possible that the current experience was closed out before this triggered, in which case this
+            // fromExperience ID value would be null.
+            val fromExperience = stateMachine.state.currentExperience
+            ExperienceTrigger.LaunchExperienceAction(fromExperience?.id)
+        }
 }

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -13,6 +13,7 @@ internal data class Experience(
     val publishedAt: Long?,
     val experiment: Experiment?,
     val completionActions: List<ExperienceAction>,
+    val trigger: ExperienceTrigger,
     val requestId: UUID? = null,
     val error: String? = null,
 ) {

--- a/appcues/src/main/java/com/appcues/data/model/ExperienceTrigger.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperienceTrigger.kt
@@ -1,0 +1,12 @@
+package com.appcues.data.model
+
+import java.util.UUID
+
+internal sealed class ExperienceTrigger {
+    data class Qualification(val reason: String?) : ExperienceTrigger()
+    data class ExperienceCompletionAction(val fromExperienceId: UUID?) : ExperienceTrigger()
+    data class LaunchExperienceAction(val fromExperienceId: UUID?) : ExperienceTrigger()
+    object ShowCall : ExperienceTrigger()
+    object DeepLink : ExperienceTrigger()
+    object Preview : ExperienceTrigger()
+}

--- a/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
@@ -5,6 +5,7 @@ package com.appcues.statemachine
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.Action.Trigger.NAVIGATE
 import com.appcues.data.model.Experience
+import com.appcues.data.model.ExperienceTrigger.Qualification
 import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.Action.RenderStep
 import com.appcues.statemachine.Action.Reset
@@ -60,13 +61,19 @@ internal interface Transitions {
             }
         }
 
+        // for pre-step navigation actions - only allow these to execute if this experience is being launched for some
+        // other reason that Qualification (i.e. deep links, preview, manual show). For any qualified experience, the initial
+        // starting state of the experience is determined solely by flow settings determining the trigger
+        // (i.e. trigger on certain screen).
+        val actions = if (experience.trigger is Qualification) emptyList() else experience.getNavigationActions(0)
+
         return Transition(
             state = BeginningStep(experience, 0, true) {
                 coroutineScope.launch {
                     completion.complete(continuation())
                 }
             },
-            sideEffect = PresentContainerEffect(experience, 0, completion, emptyList())
+            sideEffect = PresentContainerEffect(experience, 0, completion, actions)
         )
     }
 

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -7,6 +7,7 @@ import com.appcues.analytics.AnalyticsTracker
 import com.appcues.data.AppcuesRepository
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePriority.NORMAL
+import com.appcues.data.model.ExperienceTrigger
 import com.appcues.data.model.Experiment
 import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.Action.StartExperience
@@ -96,10 +97,10 @@ internal class ExperienceRenderer(
         return success
     }
 
-    suspend fun show(experienceId: String): Boolean {
+    suspend fun show(experienceId: String, trigger: ExperienceTrigger): Boolean {
         if (!sessionMonitor.checkSession("cannot show Experience $experienceId")) return false
 
-        repository.getExperienceContent(experienceId)?.let {
+        repository.getExperienceContent(experienceId, trigger)?.let {
             return show(it)
         }
 

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -6,6 +6,7 @@ import com.appcues.action.ActionRegistry
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ActivityScreenTracking
 import com.appcues.analytics.AnalyticsTracker
+import com.appcues.data.model.ExperienceTrigger
 import com.appcues.debugger.AppcuesDebuggerManager
 import com.appcues.rules.KoinScopeRule
 import com.appcues.rules.MainDispatcherRule
@@ -204,7 +205,7 @@ internal class AppcuesTest : AppcuesScopeTest {
         appcues.show(experienceId)
 
         // THEN
-        coVerify { experienceRenderer.show(experienceId) }
+        coVerify { experienceRenderer.show(experienceId, ExperienceTrigger.ShowCall) }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
@@ -2,10 +2,17 @@ package com.appcues.action.appcues
 
 import com.appcues.Appcues
 import com.appcues.AppcuesScopeTest
+import com.appcues.data.model.ExperienceTrigger
+import com.appcues.mocks.mockExperience
 import com.appcues.rules.KoinScopeRule
+import com.appcues.statemachine.State.RenderingStep
+import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer
 import com.google.common.truth.Truth
 import io.mockk.Called
 import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -25,29 +32,38 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
     }
 
     @Test
-    fun `launch experience SHOULD trigger Appcues show with experience ID`() = runTest {
+    fun `launch experience SHOULD call ExperienceRenderer show with experience ID`() = runTest {
         // GIVEN
-        val experienceId: String = UUID.randomUUID().toString()
+        val experienceId = UUID.randomUUID()
+        val experienceIdString = experienceId.toString()
         val appcues: Appcues = get()
-        val action = LaunchExperienceAction(mapOf("experienceID" to experienceId))
+        val experienceRenderer: ExperienceRenderer = get()
+        val currentExperience = mockExperience()
+        val stateMachine = mockk<StateMachine>(relaxed = true) {
+            // this is so we can validate the launch trigger matches the fromExperienceID for the current experience
+            // that executed the action
+            every { this@mockk.state } returns RenderingStep(currentExperience, 0, true)
+        }
+        val action = LaunchExperienceAction(mapOf("experienceID" to experienceIdString), stateMachine, get())
 
         // WHEN
         action.execute(appcues)
 
         // THEN
-        coVerify { appcues.show(experienceId) }
+        coVerify { experienceRenderer.show(experienceIdString, ExperienceTrigger.LaunchExperienceAction(currentExperience.id)) }
     }
 
     @Test
-    fun `launch experience SHOULD NOT trigger Appcues show WHEN no experience ID is in config`() = runTest {
+    fun `launch experience SHOULD NOT call ExperienceRenderer show WHEN no experience ID is in config`() = runTest {
         // GIVEN
         val appcues: Appcues = get()
-        val action = LaunchExperienceAction(mapOf())
+        val experienceRenderer: ExperienceRenderer = get()
+        val action = LaunchExperienceAction(mapOf(), get(), get())
 
         // WHEN
         action.execute(appcues)
 
         // THEN
-        coVerify { appcues wasNot Called }
+        coVerify { experienceRenderer wasNot Called }
     }
 }

--- a/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
@@ -14,6 +14,7 @@ import com.appcues.data.model.ExperiencePrimitive.TextInputPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceStepFormState
+import com.appcues.data.model.ExperienceTrigger
 import com.appcues.data.model.Step
 import com.appcues.data.model.StepContainer
 import com.appcues.data.model.styling.ComponentSelectMode.MULTIPLE
@@ -286,6 +287,7 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         type = "mobile",
         publishedAt = Date().time,
         completionActions = listOf(),
+        trigger = ExperienceTrigger.ShowCall,
         experiment = null,
     )
 }

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -1,11 +1,11 @@
 package com.appcues.mocks
 
-import com.appcues.action.appcues.LaunchExperienceAction
 import com.appcues.action.appcues.TrackEventAction
 import com.appcues.data.model.Action
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
 import com.appcues.data.model.ExperiencePriority.NORMAL
+import com.appcues.data.model.ExperienceTrigger
 import com.appcues.data.model.Experiment
 import com.appcues.data.model.Step
 import com.appcues.data.model.StepContainer
@@ -56,7 +56,8 @@ internal fun mockExperience(onPresent: (() -> Unit)? = null) =
         priority = NORMAL,
         publishedAt = 1652895835000,
         experiment = null,
-        completionActions = arrayListOf(LaunchExperienceAction("1234"), TrackEventAction(hashMapOf()))
+        completionActions = arrayListOf(TrackEventAction(hashMapOf())),
+        trigger = ExperienceTrigger.ShowCall,
     )
 
 internal fun mockStep(id: UUID) =
@@ -94,13 +95,14 @@ internal fun mockExperienceExperiment(experiment: Experiment) =
         priority = NORMAL,
         publishedAt = 1652895835000,
         experiment = experiment,
-        completionActions = emptyList()
+        completionActions = emptyList(),
+        trigger = ExperienceTrigger.ShowCall,
     )
 
-// An experience with two step containers, each with one step. The given list of actions are applied to the
-// second step container, to test pre-step navigation actions. The given PresentingTrait is applied to both
+// An experience with two step containers, each with one step. The given list of actions are applied to both
+// step containers, to test pre-step navigation actions. The given PresentingTrait is applied to both
 // step containers, to verify the order of actions prior to presentation.
-internal fun mockExperienceNavigateActions(actions: List<Action>, presentingTrait: PresentingTrait) =
+internal fun mockExperienceNavigateActions(actions: List<Action>, presentingTrait: PresentingTrait, trigger: ExperienceTrigger) =
     Experience(
         id = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
         name = "Mock Experience with Experiment",
@@ -116,7 +118,7 @@ internal fun mockExperienceNavigateActions(actions: List<Action>, presentingTrai
                 contentWrappingTrait = mockk(relaxed = true),
                 backdropDecoratingTraits = listOf(),
                 containerDecoratingTraits = listOf(),
-                actions = emptyMap(),
+                actions = mapOf(UUID.fromString("60b49c12-c49b-47ac-8ed3-ba4e9a55e694") to actions),
             ),
             StepContainer(
                 id = UUID.fromString("71614c07-3f37-4f04-a853-f55424160321"),
@@ -135,5 +137,6 @@ internal fun mockExperienceNavigateActions(actions: List<Action>, presentingTrai
         priority = NORMAL,
         publishedAt = 1652895835000,
         experiment = null,
-        completionActions = emptyList()
+        completionActions = emptyList(),
+        trigger = trigger,
     )

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -7,6 +7,8 @@ import com.appcues.action.ExperienceAction
 import com.appcues.data.model.Action.Trigger.NAVIGATE
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePriority.NORMAL
+import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.model.ExperienceTrigger.Qualification
 import com.appcues.mocks.mockExperience
 import com.appcues.mocks.mockExperienceNavigateActions
 import com.appcues.rules.KoinScopeRule
@@ -39,6 +41,7 @@ import io.mockk.Called
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitAll
@@ -258,7 +261,7 @@ class StateMachineTest : AppcuesScopeTest {
 
     @Test
     fun `StartStep SHOULD execute navigation actions sequentially WHEN moving to a new group`() = runTest {
-        // Test that an experience with "navigate" actions on a group at index > 0 has those actions executed and
+        // Test that a qualified experience with "navigate" actions on a group at index > 0 has those actions executed and
         // completed prior to presenting the container for the next group
 
         // GIVEN
@@ -269,7 +272,7 @@ class StateMachineTest : AppcuesScopeTest {
             com.appcues.data.model.Action(NAVIGATE, experienceAction1),
             com.appcues.data.model.Action(NAVIGATE, experienceAction2),
         )
-        val experience = mockExperienceNavigateActions(navigationActions, presentingTrait)
+        val experience = mockExperienceNavigateActions(navigationActions, presentingTrait, Qualification("screen_view"))
         val initialState = RenderingStep(experience, 0, true)
         val stateMachine = initMachine(initialState)
         val action = StartStep(StepOffset(1))
@@ -282,6 +285,70 @@ class StateMachineTest : AppcuesScopeTest {
         // THEN
         assertThat(result.successValue()).isEqualTo(targetState)
         assertThat(stateMachine.state).isEqualTo(targetState)
+        coVerifyOrder {
+            actionProcessor.process(listOf(experienceAction1, experienceAction2))
+            presentingTrait.present()
+        }
+    }
+
+    @Test
+    fun `StartExperience SHOULD NOT execute navigation actions WHEN trigger is Qualification`() = runTest {
+        // Test that a qualified experience with "navigate" actions on a group at index 0 has those actions ignored
+        // when presenting the first step - since flow settings for qualify determine its location
+
+        // GIVEN
+        val experienceAction1 = mockk<ExperienceAction>(relaxed = true)
+        val experienceAction2 = mockk<ExperienceAction>(relaxed = true)
+        val presentingTrait = mockk<PresentingTrait>(relaxed = true)
+        val navigationActions = listOf(
+            com.appcues.data.model.Action(NAVIGATE, experienceAction1),
+            com.appcues.data.model.Action(NAVIGATE, experienceAction2),
+        )
+        val experience = mockExperienceNavigateActions(navigationActions, presentingTrait, Qualification("screen_view"))
+        val initialState = Idling
+        val stateMachine = initMachine(initialState)
+        val action = StartExperience(experience)
+        val targetState = RenderingStep(experience, 0, true)
+        val actionProcessor: ActionProcessor = get()
+
+        // WHEN
+        val result = stateMachine.handleAction(action)
+
+        // THEN
+        assertThat(result.successValue()).isEqualTo(targetState)
+        assertThat(stateMachine.state).isEqualTo(targetState)
+        coVerify(exactly = 0) { actionProcessor.process(listOf(experienceAction1, experienceAction2)) }
+        coVerify { presentingTrait.present() }
+    }
+
+    @Test
+    fun `StartExperience SHOULD execute navigation actions WHEN trigger is NOT Qualification`() = runTest {
+        // Test that a manually triggered experience with "navigate" actions on a group at index 0 has those actions executed
+        // when presenting the first step
+
+        // GIVEN
+        val experienceAction1 = mockk<ExperienceAction>(relaxed = true)
+        val experienceAction2 = mockk<ExperienceAction>(relaxed = true)
+        val presentingTrait = mockk<PresentingTrait>(relaxed = true)
+        val navigationActions = listOf(
+            com.appcues.data.model.Action(NAVIGATE, experienceAction1),
+            com.appcues.data.model.Action(NAVIGATE, experienceAction2),
+        )
+        val experience = mockExperienceNavigateActions(navigationActions, presentingTrait, ExperienceTrigger.Preview)
+        val initialState = Idling
+        val stateMachine = initMachine(initialState)
+        val action = StartExperience(experience)
+        val targetState = RenderingStep(experience, 0, true)
+        val actionProcessor: ActionProcessor = get()
+
+        // WHEN
+        val result = stateMachine.handleAction(action)
+
+        // THEN
+        assertThat(result.successValue()).isEqualTo(targetState)
+        assertThat(stateMachine.state).isEqualTo(targetState)
+        verify { experienceAction1 wasNot Called }
+        verify { experienceAction2 wasNot Called }
         coVerifyOrder {
             actionProcessor.process(listOf(experienceAction1, experienceAction2))
             presentingTrait.present()
@@ -303,6 +370,7 @@ class StateMachineTest : AppcuesScopeTest {
             publishedAt = 1652895835000,
             completionActions = arrayListOf(),
             experiment = null,
+            trigger = ExperienceTrigger.ShowCall,
         )
         val initialState = Idling
         val stateMachine = initMachine(initialState)
@@ -329,7 +397,8 @@ class StateMachineTest : AppcuesScopeTest {
             publishedAt = 1652895835000,
             completionActions = arrayListOf(),
             experiment = null,
-            error = "Failed decode"
+            error = "Failed decode",
+            trigger = ExperienceTrigger.ShowCall,
         )
         val initialState = Idling
         val stateMachine = initMachine(initialState)


### PR DESCRIPTION
note: targeting `release/1.2`

This PR introduces the concept of `ExperienceTrigger`, which defines the currently six ways an Experience can be triggered: 
* builder preview
* qualification
* deep link
* show function call
* launch experience action
* post-flow completion action

This context is now stored on the `Experience` object via passing through at call sites as appropriate. This allows us to detect when an Experience is being launched from a method other than the standard qualification flow, and enable pre-step navigation actions to occur if so. Qualified flows are unchanged - as the location in the app they trigger upon is based entirely on the flow settings defined in Studio, and no redirection is done on launch in those cases.

This will enable use cases like redirecting to the right page prior to showing the experience, when using the builder preview, or a deep link to a flow.

The only part that was a little more complicated was in `LaunchExperienceAction` - which is dual purpose for the launch experience button actions AND the post-flow completion actions. A bit more logic in there allows it to be able to distinguish those and report the proper trigger info in each case.

Here is an example where the app is on the Events tab, and a deep link to preview a flow with the first step targeting the Profile tab results in the app switching to the correct tab and showing the flow.

https://user-images.githubusercontent.com/19266448/206293693-bec233e5-3b13-4e87-ae39-d9ea34764a55.mov

