### PR TITLE
Fix text style updates not being applied on recomposition

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
@@ -44,8 +44,10 @@ import com.appcues.ui.extensions.toImageAsyncContentScale
 import com.appcues.ui.utils.rememberBlurHashDecoded
 import java.util.UUID
 
+// the given `modifier` is chained onto the end of the new composable, allowing a capability to apply
+// additional behaviors to those specified in the primitive configuration.
 @Composable
-internal fun ExperiencePrimitive.Compose(matchParentBox: BoxScope? = null) {
+internal fun ExperiencePrimitive.Compose(matchParentBox: BoxScope? = null, modifier: Modifier = Modifier) {
     val stackScope = LocalStackScope.current
     Box(
         modifier = Modifier
@@ -62,24 +64,25 @@ internal fun ExperiencePrimitive.Compose(matchParentBox: BoxScope? = null) {
                 isDark = isSystemInDarkTheme(),
                 matchParentBox = matchParentBox,
             )
-            .updateStackScope(stackScope, id),
+            .updateStackScope(stackScope, id)
+            .then(modifier),
         contentAlignment = Alignment.Center
     ) {
         BackgroundImage(style)
 
         with(this@Compose) {
-            val modifier = Modifier.innerPrimitiveStyle(this)
+            val innerModifier = Modifier.innerPrimitiveStyle(this)
             when (this) {
-                is BoxPrimitive -> Compose(modifier)
-                is ButtonPrimitive -> Compose(modifier)
-                is EmbedHtmlPrimitive -> Compose(modifier)
-                is HorizontalStackPrimitive -> Compose(modifier)
-                is ImagePrimitive -> Compose(modifier, matchParentBox)
-                is TextPrimitive -> Compose(modifier)
-                is VerticalStackPrimitive -> Compose(modifier)
-                is TextInputPrimitive -> Compose(modifier)
-                is OptionSelectPrimitive -> Compose(modifier)
-                is SpacerPrimitive -> Compose(modifier)
+                is BoxPrimitive -> Compose(innerModifier)
+                is ButtonPrimitive -> Compose(innerModifier)
+                is EmbedHtmlPrimitive -> Compose(innerModifier)
+                is HorizontalStackPrimitive -> Compose(innerModifier)
+                is ImagePrimitive -> Compose(innerModifier, matchParentBox)
+                is TextPrimitive -> Compose(innerModifier)
+                is VerticalStackPrimitive -> Compose(innerModifier)
+                is TextInputPrimitive -> Compose(innerModifier)
+                is OptionSelectPrimitive -> Compose(innerModifier)
+                is SpacerPrimitive -> Compose(innerModifier)
             }
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -185,8 +185,8 @@ private fun List<OptionSelectPrimitive.OptionItem>.ComposeSelections(
                 contentView.Compose()
                 selectMode.Compose(isSelected, optionSelectPrimitive, errorTint) { itemSelected(option.value) }
             }
-            HIDDEN -> Box(modifier = Modifier.clickable { itemSelected(option.value) }) {
-                contentView.Compose()
+            HIDDEN -> {
+                contentView.Compose(modifier = Modifier.clickable { itemSelected(option.value) })
             }
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
@@ -31,8 +31,9 @@ internal fun TextPrimitive.Compose(modifier: Modifier) {
         context = LocalContext.current,
         isDark = isSystemInDarkTheme(),
     )
-    var resizedStyle by remember { mutableStateOf(style) }
-    var readyToDraw by remember { mutableStateOf(false) }
+
+    var resizedStyle by remember(style) { mutableStateOf(style) }
+    var readyToDraw by remember(style) { mutableStateOf(false) }
 
     Text(
         modifier = modifier.clipToBounds().drawWithContent { if (readyToDraw) drawContent() },


### PR DESCRIPTION
note: targeting `release/1.2`

Fixes the issue observed with our `optionSelect` implementation - where the option `content` was replaced with `selectedContent`, but did not actually apply the updated text style due to the `remember` in place on the style object. This `remember` is updated to be based on the style as the key, so it is updated when `style` updates.

The other change in `ExperiencePrimitive.Compose` is to allow us to more effectively apply the click handler _after_ the content styling is completed - so that the shape of the tap gesture feedback matches the selection element.