### PR TITLE
Prevent multiple traits of the same type at the same level of an Experience

### DIFF
--- a/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
+++ b/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
@@ -4,6 +4,7 @@ import com.appcues.data.remote.adapters.DateAdapter
 import com.appcues.data.remote.adapters.ExperienceStepFormStateAdapter
 import com.appcues.data.remote.adapters.LossyExperienceResponseAdapterFactory
 import com.appcues.data.remote.adapters.StepContainerAdapter
+import com.appcues.data.remote.adapters.TraitResponseAdapterFactory
 import com.appcues.data.remote.adapters.UUIDAdapter
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.BlockPrimitiveResponse
@@ -57,6 +58,7 @@ internal object MoshiConfiguration {
         .add(StepContainerAdapter())
         .add(ExperienceStepFormStateAdapter())
         .add(LossyExperienceResponseAdapterFactory())
+        .add(TraitResponseAdapterFactory())
         .addLast(KotlinJsonAdapterFactory())
         .build()
 

--- a/appcues/src/main/java/com/appcues/data/remote/adapters/TraitResponseAdapterFactory.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/adapters/TraitResponseAdapterFactory.kt
@@ -1,0 +1,66 @@
+package com.appcues.data.remote.adapters
+
+import com.appcues.data.remote.response.trait.TraitResponse
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import java.lang.reflect.Type
+
+class TraitResponseAdapterFactory : JsonAdapter.Factory {
+
+    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+        return if (
+            Types.getRawType(type) == List::class.java &&
+            Types.collectionElementType(type, List::class.java) == TraitResponse::class.java
+        ) {
+            val delegate = moshi.adapter(TraitResponse::class.java)
+            TraitResponseAdapter(delegate)
+        } else {
+            null
+        }
+    }
+
+    private class TraitResponseAdapter(
+        private val delegate: JsonAdapter<TraitResponse>,
+    ) : JsonAdapter<List<TraitResponse>>() {
+
+        override fun fromJson(reader: JsonReader): List<TraitResponse> {
+            val traits = mutableListOf<TraitResponse>()
+            val traitTypes = mutableSetOf<String>()
+            val duplicates = mutableSetOf<String>()
+
+            reader.beginArray()
+
+            while (reader.hasNext()) {
+                val value = reader.readJsonValue()
+                delegate.fromJsonValue(value)?.let {
+                    if (!traitTypes.add(it.type)) {
+                        // If adding the type to the existing set returns false, this means it
+                        // was already in the set, and this is a duplicate type in this collection.
+                        // Duplicates are collected and used in a decoding error.
+                        duplicates.add(it.type)
+                    } else {
+                        // Normal case, capture the decoded trait for our resulting list
+                        traits.add(it)
+                    }
+                }
+            }
+
+            if (duplicates.isNotEmpty()) {
+                val message = "multiple traits of same type are not supported: ${duplicates.joinToString(",")}. " +
+                    "Found at path ${reader.path}"
+                throw JsonDataException(message)
+            }
+
+            reader.endArray()
+            return traits
+        }
+
+        override fun toJson(writer: JsonWriter, value: List<TraitResponse>?) {
+            throw UnsupportedOperationException("trait responses only support deserialization")
+        }
+    }
+}

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/AppcuesServiceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/AppcuesServiceTest.kt
@@ -5,13 +5,16 @@ import com.appcues.data.remote.response.experience.FailedExperienceResponse
 import com.appcues.data.remote.retrofit.stubs.contentModalOneStubs
 import com.appcues.util.appcuesFormatted
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
+import com.squareup.moshi.JsonDataException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Test
 import java.util.UUID
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AppcuesServiceTest {
 
     private val mockWebServer = MockWebServer()
@@ -25,21 +28,17 @@ class AppcuesServiceTest {
     }
 
     @Test
-    fun `content SHOULD fetch Experience correctly from specific path`() {
+    fun `content SHOULD fetch Experience correctly from specific path`() = runTest {
         // Given
-        mockWebServer.dispatchResponses(
-            responses = hashMapOf(
-                "/v1/accounts/1234/users/TestUser/experience_content/5678" to "content/content_modal_one.json"
-            )
-        )
+        val accountId = "account-id"
+        val userId = "user-id"
+        val experienceId = "experience-id"
+        val mock = "content_modal_one"
+        mockWebServer.mockExperienceContent(accountId, userId, experienceId, mock)
+
         // When
-        val result = runBlocking {
-            api.experienceContent(
-                account = "1234",
-                user = "TestUser",
-                experienceId = "5678",
-            )
-        }
+        val result = api.experienceContent(accountId, userId, experienceId)
+
         // Then
         with(result) {
             assertThat(this).isEqualTo(contentModalOneStubs)
@@ -47,23 +46,15 @@ class AppcuesServiceTest {
     }
 
     @Test
-    fun `qualify SHOULD lossy decode Experiences from specific path`() {
+    fun `qualify SHOULD lossy decode Experiences from specific path`() = runTest {
         // Given
-        mockWebServer.dispatchResponses(
-            responses = hashMapOf(
-                "/v1/accounts/1234/users/TestUser/qualify" to "content/content_lossy_decoding.json"
-            )
-        )
+        val accountId = "account-id"
+        val userId = "user-id"
+        val mock = "content_lossy_decoding"
+        mockWebServer.mockQualify(accountId, userId, mock)
 
         // When
-        val result = runBlocking {
-            api.qualify(
-                account = "1234",
-                user = "TestUser",
-                requestId = UUID.randomUUID(),
-                activity = "".toRequestBody(),
-            )
-        }
+        val result = api.qualify(accountId, userId, UUID.randomUUID(), "".toRequestBody())
 
         // Then
         //
@@ -113,9 +104,96 @@ class AppcuesServiceTest {
             with(experiences[5] as FailedExperienceResponse) {
                 assertThat(this.id.appcuesFormatted()).isEqualTo("c9c11671-f418-451e-9b4a-33d54ed5299f")
                 assertThat(this.error)
-                    .isEqualTo("Error parsing Experience JSON data: Expected STRING but was true, a java.lang.Boolean," +
-                        " at path \$.steps[0].children[0].content.id")
+                    .isEqualTo(
+                        "Error parsing Experience JSON data: Expected STRING but was true, a java.lang.Boolean," +
+                            " at path \$.steps[0].children[0].content.id"
+                    )
             }
         }
     }
+
+    @Test
+    fun `trait decoding SHOULD fail WHEN multiple traits of same type declared at step level`() = runTest {
+        // Given
+        var error: String? = null
+        val accountId = "account-id"
+        val userId = "user-id"
+        val experienceId = "experience-id"
+        val mock = "content_duplicate_traits_step"
+        mockWebServer.mockExperienceContent(accountId, userId, experienceId, mock)
+
+        // When
+        try {
+            api.experienceContent(accountId, userId, experienceId)
+        } catch (exception: JsonDataException) {
+            error = exception.message
+        }
+
+        // Then
+        assertThat(error).isEqualTo(
+            "multiple traits of same type are not supported: step-trait. Found at path $.steps[0].children[0].traits[2]"
+        )
+    }
+
+    @Test
+    fun `trait decoding SHOULD fail WHEN multiple traits of same type declared at group level`() = runTest {
+        // Given
+        var error: String? = null
+        val accountId = "account-id"
+        val userId = "user-id"
+        val experienceId = "experience-id"
+        val mock = "content_duplicate_traits_group"
+        mockWebServer.mockExperienceContent(accountId, userId, experienceId, mock)
+
+        // When
+        try {
+            api.experienceContent(accountId, userId, experienceId)
+        } catch (exception: JsonDataException) {
+            error = exception.message
+        }
+
+        // Then
+        assertThat(error).isEqualTo(
+            "multiple traits of same type are not supported: group-trait. Found at path $.steps[0].traits[2]"
+        )
+    }
+
+    @Test
+    fun `trait decoding SHOULD fail WHEN multiple traits of same type declared at experience level`() = runTest {
+        // Given
+        var error: String? = null
+        val accountId = "account-id"
+        val userId = "user-id"
+        val experienceId = "experience-id"
+        val mock = "content_duplicate_traits_experience"
+        mockWebServer.mockExperienceContent(accountId, userId, experienceId, mock)
+
+        // When
+        try {
+            api.experienceContent(accountId, userId, experienceId)
+        } catch (exception: JsonDataException) {
+            error = exception.message
+        }
+
+        // Then
+        assertThat(error).isEqualTo(
+            "multiple traits of same type are not supported: experience-trait. Found at path \$.traits[2]"
+        )
+    }
+}
+
+private fun MockWebServer.mockExperienceContent(accountId: String, userId: String, experienceId: String, mock: String) {
+    this.dispatchResponses(
+        responses = hashMapOf(
+            "/v1/accounts/$accountId/users/$userId/experience_content/$experienceId" to "content/$mock.json"
+        )
+    )
+}
+
+private fun MockWebServer.mockQualify(accountId: String, userId: String, mock: String) {
+    this.dispatchResponses(
+        responses = hashMapOf(
+            "/v1/accounts/$accountId/users/$userId/qualify" to "content/$mock.json"
+        )
+    )
 }

--- a/appcues/src/test/resources/content/content_duplicate_traits_experience.json
+++ b/appcues/src/test/resources/content/content_duplicate_traits_experience.json
@@ -1,0 +1,41 @@
+{
+  "id": "05e78601-d7d8-449f-a074-fe3ae1144366",
+  "name": "duplicate experience trait",
+  "type": "mobile",
+  "traits": [
+    {
+      "type": "experience-trait"
+    },
+    {
+      "type": "experience-trait"
+    }
+  ],
+  "steps": [
+    {
+      "id": "f7edb07c-5f96-4440-9b70-3bdd0b7675b0",
+      "type": "group",
+      "actions": {},
+      "traits": [
+        {
+          "type": "group-trait"
+        }
+      ],
+      "children": [
+        {
+          "id": "68bb5cc4-99b4-4f5c-a787-930ba921fc05",
+          "type": "modal",
+          "content": {
+            "type": "spacer",
+            "id": "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4"
+          },
+          "traits": [
+            {
+              "type": "step-trait"
+            }
+          ],
+          "actions": {}
+        }
+      ]
+    }
+  ]
+}

--- a/appcues/src/test/resources/content/content_duplicate_traits_group.json
+++ b/appcues/src/test/resources/content/content_duplicate_traits_group.json
@@ -1,0 +1,41 @@
+{
+  "id": "05e78601-d7d8-449f-a074-fe3ae1144366",
+  "name": "duplicate step trait",
+  "type": "mobile",
+  "traits": [
+    {
+      "type": "experience-trait"
+    }
+  ],
+  "steps": [
+    {
+      "id": "f7edb07c-5f96-4440-9b70-3bdd0b7675b0",
+      "type": "group",
+      "actions": {},
+      "traits": [
+        {
+          "type": "group-trait"
+        },
+        {
+          "type": "group-trait"
+        }
+      ],
+      "children": [
+        {
+          "id": "68bb5cc4-99b4-4f5c-a787-930ba921fc05",
+          "type": "modal",
+          "content": {
+            "type": "spacer",
+            "id": "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4"
+          },
+          "traits": [
+            {
+              "type": "step-trait"
+            }
+          ],
+          "actions": {}
+        }
+      ]
+    }
+  ]
+}

--- a/appcues/src/test/resources/content/content_duplicate_traits_step.json
+++ b/appcues/src/test/resources/content/content_duplicate_traits_step.json
@@ -1,0 +1,41 @@
+{
+  "id": "05e78601-d7d8-449f-a074-fe3ae1144366",
+  "name": "duplicate step trait",
+  "type": "mobile",
+  "traits": [
+    {
+      "type": "experience-trait"
+    }
+  ],
+  "steps": [
+    {
+      "id": "f7edb07c-5f96-4440-9b70-3bdd0b7675b0",
+      "type": "group",
+      "actions": {},
+      "traits": [
+        {
+          "type": "group-trait"
+        }
+      ],
+      "children": [
+        {
+          "id": "68bb5cc4-99b4-4f5c-a787-930ba921fc05",
+          "type": "modal",
+          "content": {
+            "type": "spacer",
+            "id": "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4"
+          },
+          "traits": [
+            {
+              "type": "step-trait"
+            },
+            {
+              "type": "step-trait"
+            }
+          ],
+          "actions": {}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A custom Moshi factory/adapter to allow use to detect malformed experiences and report errors, per 2.0 trait design discussions.

Analogous to the iOS changes in https://github.com/appcues/appcues-ios-sdk/pull/295