### PR TITLE
Add leadingFill option for rating components

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapper.kt
@@ -40,6 +40,7 @@ internal fun OptionSelectPrimitiveResponse.mapOptionSelectPrimitive(): OptionSel
         unselectedColor = unselectedColor?.mapComponentColor(),
         accentColor = accentColor?.mapComponentColor(),
         attributeName = attributeName,
+        leadingFill = leadingFill ?: false
     )
 }
 

--- a/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
@@ -144,6 +144,7 @@ internal sealed class ExperiencePrimitive(
         val unselectedColor: ComponentColor? = null,
         val accentColor: ComponentColor? = null,
         val attributeName: String? = null,
+        val leadingFill: Boolean = false,
     ) : ExperiencePrimitive(id, style) {
 
         data class OptionItem(

--- a/appcues/src/main/java/com/appcues/data/remote/response/step/primitive/PrimitiveResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/step/primitive/PrimitiveResponse.kt
@@ -104,6 +104,7 @@ internal sealed class PrimitiveResponse(
         val unselectedColor: StyleColorResponse?,
         val accentColor: StyleColorResponse?,
         val attributeName: String?,
+        val leadingFill: Boolean?
     ) : PrimitiveResponse(OPTION_SELECT) {
 
         data class OptionItem(

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -115,6 +115,7 @@ private fun OptionSelectPrimitive.ComposeOptions(
                     controlPosition = controlPosition,
                     optionSelectPrimitive = this@ComposeOptions,
                     errorTint = errorTint,
+                    leadingFill = leadingFill,
                 ) {
                     formState.setValue(this@ComposeOptions, it)
                 }
@@ -128,6 +129,7 @@ private fun OptionSelectPrimitive.ComposeOptions(
                     controlPosition = controlPosition,
                     optionSelectPrimitive = this@ComposeOptions,
                     errorTint = errorTint,
+                    leadingFill = leadingFill,
                 ) {
                     formState.setValue(this@ComposeOptions, it)
                 }
@@ -157,14 +159,27 @@ private fun List<OptionSelectPrimitive.OptionItem>.ComposeSelections(
     controlPosition: ComponentControlPosition,
     optionSelectPrimitive: OptionSelectPrimitive,
     errorTint: Color?,
+    leadingFill: Boolean,
     itemSelected: (String) -> Unit,
 ) {
+    // allow a leading fill only if requested, and in single select mode, and something is selected, and no checkbox or radio
+    // i.e. the ratings use case
+    var leadingFillOverride = leadingFill && selectMode == SINGLE && selectedValues.any() && controlPosition == HIDDEN
+
     forEach { option ->
 
         val isSelected = selectedValues.contains(option.value)
-        val contentView by remember(isSelected) {
+
+        if (isSelected) {
+            // no more leading fill after this item
+            leadingFillOverride = false
+        }
+
+        val styleSelected = isSelected || leadingFillOverride
+
+        val contentView by remember(styleSelected) {
             derivedStateOf {
-                option.selectedContent?.let { if (isSelected) it else option.content } ?: option.content
+                option.selectedContent?.let { if (styleSelected) it else option.content } ?: option.content
             }
         }
 

--- a/appcues/src/test/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapperTest.kt
@@ -34,6 +34,7 @@ class OptionSelectPrimitiveMapperTest {
             unselectedColor = null,
             accentColor = null,
             attributeName = null,
+            leadingFill = null,
         )
 
         // WHEN
@@ -69,6 +70,7 @@ class OptionSelectPrimitiveMapperTest {
             unselectedColor = null,
             accentColor = null,
             attributeName = null,
+            leadingFill = null,
         )
 
         // WHEN


### PR DESCRIPTION
note: targeting `release/1.2`

This is the Android implementation of the [proposed spec change](https://github.com/appcues/appcues-mobile-experience-spec/pull/121/files#diff-b4d74ced281deda59b98f155a0fd068ac0bcaa79d3c9fb67cf91023a80f664f4R457-R460) to add `leadingFill` on the `optionSelect` component.

It is only supported for single select components, with `hidden` controlPosition (ratings use cases)

This would apply in cases like the star rating block being built now.

![Screenshot 2022-12-14 at 12 42 22 PM](https://user-images.githubusercontent.com/19266448/207668481-2c1b9e22-6a4c-454b-9560-0a370a928dde.png)

