### PR TITLE
⏪ Revert Koin back to 3.1.6 from 3.2.2 for Expo compatibility

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -14,7 +14,7 @@ ext.room_version = '2.4.3'
 ext.compose_version = '1.3.0'
 ext.compose_compiler_version = '1.3.2'
 ext.accompanist_version = '0.27.0'
-ext.koin_version = '3.2.2'
+ext.koin_version = '3.1.6'
 ext.coil_version = '2.2.2'
 ext.moshi_version = '1.14.0'
 


### PR DESCRIPTION
note: targeting `release/1.1.2`

This change reverts the Koin version back to `3.1.6` instead of `3.2.2` that was used in the SDK 1.1 release. 

The prior change was [here](https://github.com/appcues/appcues-android-sdk/pull/262/files#diff-dc19bb0e566daa0f4286c73260cb0d2b2e3b5a303a2323ff0a01e0fdc17347b9L17), and done to keep current and adopt any internal fixes in Koin. However, we've since learned that this version of Koin conflicts with what is used in Expo development builds, specifically in [expo-dev-launcher](https://github.com/expo/expo/blob/main/packages/expo-dev-launcher/android/build.gradle#L154) where 3.1.2 is used. We cannot move to 3.1.2 due to other issues, but 3.1.6 seems to be compatible in testing.

The 3.2.x issue may be related to what others have reported [here](https://github.com/InsertKoinIO/koin/issues/1369).

For now, we have no compelling reason to move beyond 3.1.6 that I'm aware of, and it will enable our React Native Expo customers to better adopt our products, so I propose sticking with 3.1.6.