### PR TITLE
Update optionSelect and textInput components to handle label horizontalAlignment

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -164,12 +164,12 @@ internal fun ComponentStyle.getVerticalAlignment(default: Alignment.Vertical): A
     }
 }
 
-internal fun ComponentStyle.getHorizontalAlignment(): Alignment.Horizontal {
+internal fun ComponentStyle.getHorizontalAlignment(default: Alignment.Horizontal): Alignment.Horizontal {
     return when (horizontalAlignment) {
         ComponentHorizontalAlignment.LEADING -> Alignment.Start
         ComponentHorizontalAlignment.CENTER -> Alignment.CenterHorizontally
         ComponentHorizontalAlignment.TRAILING -> Alignment.End
-        null -> Alignment.CenterHorizontally
+        null -> default
     }
 }
 

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -67,17 +67,23 @@ internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
     }
 
     Column(
-        modifier = modifier,
-        horizontalAlignment = style.getHorizontalAlignment(),
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = style.getHorizontalAlignment(Alignment.CenterHorizontally),
     ) {
 
         // the form item label / question
-        updatedLabel.Compose()
+        Column(modifier = modifier.fillMaxWidth(), horizontalAlignment = updatedLabel.style.getHorizontalAlignment(Alignment.Start)) {
+            updatedLabel.Compose()
+        }
 
-        ComposeOptions(formState, showError)
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            ComposeOptions(formState, showError)
+        }
 
-        if (showError) {
-            errorLabel?.Compose()
+        if (showError && errorLabel != null) {
+            Column(modifier = modifier.fillMaxWidth(), horizontalAlignment = errorLabel.style.getHorizontalAlignment(Alignment.Start)) {
+                errorLabel.Compose()
+            }
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -99,7 +100,7 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
 
     Column(
         modifier = modifier.fillMaxWidth(),
-        horizontalAlignment = style.getHorizontalAlignment(),
+        horizontalAlignment = style.getHorizontalAlignment(Alignment.CenterHorizontally),
     ) {
         val focusManager = LocalFocusManager.current
         val keyboardController = LocalSoftwareKeyboardController.current
@@ -107,7 +108,9 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
         val lastItemId = rememberUpdatedState(newValue = formState.lastTextFocusableItem)
         val isLastInputItem = remember { derivedStateOf { lastItemId.value?.let { it.id == id } ?: false } }
 
-        updatedLabel.Compose()
+        Column(modifier = modifier.fillMaxWidth(), horizontalAlignment = updatedLabel.style.getHorizontalAlignment(Alignment.Start)) {
+            updatedLabel.Compose()
+        }
 
         // Several styling customization options for TextField noted here https://stackoverflow.com/a/68592613
         TextField(
@@ -130,18 +133,16 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
             shape = RoundedCornerShape(8.dp),
             maxLines = numberOfLines,
             singleLine = numberOfLines == 1,
-            placeholder = placeholder?.let {
-                {
-                    it.Compose()
-                }
-            },
+            placeholder = placeholder?.let { { it.Compose() } },
             keyboardOptions = getKeyboardOptions(isLastInputItem),
             keyboardActions = getKeyboardActions(layoutDirection, focusManager, keyboardController),
             colors = getColors(isDark),
         )
 
-        if (showError) {
-            errorLabel?.Compose()
+        if (showError && errorLabel != null) {
+            Column(modifier = modifier.fillMaxWidth(), horizontalAlignment = errorLabel.style.getHorizontalAlignment(Alignment.Start)) {
+                errorLabel.Compose()
+            }
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
@@ -29,7 +29,7 @@ import java.util.UUID
 internal fun VerticalStackPrimitive.Compose(modifier: Modifier) {
     Column(
         modifier = modifier,
-        horizontalAlignment = style.getHorizontalAlignment(),
+        horizontalAlignment = style.getHorizontalAlignment(Alignment.CenterHorizontally),
         verticalArrangement = Arrangement.spacedBy(spacing.dp, Alignment.CenterVertically)
     ) {
         CompositionLocalProvider(LocalStackScope provides ColumnStackScope(style.width, items.size)) {


### PR DESCRIPTION
note: targeting `release/1.2`

similar to the update on iOS https://github.com/appcues/appcues-ios-sdk/pull/306

This updates the `textInput` and `optionSelect` components to allow their `label` and `errorLabel` primitives within to apply their own `style.horizontalAlignment` properties, and position the text as desired, relative to the survey options/controls.

This allows for the common case of having a `leading` aligned label/error, and `center` aligned ratings content

![Screenshot 2023-01-03 at 2 25 50 PM](https://user-images.githubusercontent.com/19266448/210427236-9e8a3f95-1826-4f47-b5a3-d5b3e2f9ab44.png)
