### PR TITLE
♻️ Update Tooltip Trait 

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/step/StepMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/StepMapper.kt
@@ -38,7 +38,6 @@ internal class StepMapper(
         return Step(
             id = from.id,
             content = responseContent.mapPrimitive(),
-            // TODO only one of each type, eg: @appcues/backdrop @appcues/skippable etc
             stepDecoratingTraits = mappedTraits.filterIsInstance(StepDecoratingTrait::class.java),
             backdropDecoratingTraits = mappedTraits.filterIsInstance<BackdropDecoratingTrait>(),
             containerDecoratingTraits = mappedTraits.filterIsInstance<ContainerDecoratingTrait>(),

--- a/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt
+++ b/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt
@@ -3,7 +3,6 @@ package com.appcues.monitor
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import com.appcues.ui.AppcuesActivity
 import java.lang.ref.WeakReference
 
@@ -11,12 +10,12 @@ internal object AppcuesActivityMonitor : Application.ActivityLifecycleCallbacks 
 
     interface ActivityMonitorListener {
 
-        fun onActivityChanged(activity: AppCompatActivity)
+        fun onActivityChanged(activity: Activity)
     }
 
-    private var activityWeakReference: WeakReference<AppCompatActivity>? = null
+    private var activityWeakReference: WeakReference<Activity>? = null
 
-    val activity: AppCompatActivity?
+    val activity: Activity?
         get() = activityWeakReference?.get()
 
     private val activityMonitorListener: HashSet<ActivityMonitorListener> = hashSetOf()
@@ -34,7 +33,7 @@ internal object AppcuesActivityMonitor : Application.ActivityLifecycleCallbacks 
     }
 
     override fun onActivityResumed(activity: Activity) {
-        if (activity !is AppcuesActivity && activity is AppCompatActivity) {
+        if (activity !is AppcuesActivity) {
             if (this.activity != activity) {
                 this.activityWeakReference = WeakReference(activity)
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.AppcuesConfigMap
@@ -97,6 +98,8 @@ internal class BackdropKeyholeTrait(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                // adds a graphic layer to ensure that any BlendModes will work as expected
+                .graphicsLayer(alpha = 0.99F)
                 .drawWithContent {
                     drawContent()
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -1,6 +1,8 @@
 package com.appcues.trait.appcues
 
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,15 +19,27 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.addOutline
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.coerceAtLeast
+import androidx.compose.ui.unit.coerceIn
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.getConfigOrDefault
 import com.appcues.data.model.getConfigStyle
+import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.trait.AppcuesTraitAnimatedVisibility
 import com.appcues.trait.ContentWrappingTrait
 import com.appcues.trait.PresentingTrait
@@ -33,13 +47,17 @@ import com.appcues.trait.appcues.TooltipTrait.PointerPosition.BOTTOM
 import com.appcues.trait.appcues.TooltipTrait.PointerPosition.NONE
 import com.appcues.trait.appcues.TooltipTrait.PointerPosition.TOP
 import com.appcues.ui.AppcuesOverlayViewManager
+import com.appcues.ui.composables.AppcuesStepMetadata
 import com.appcues.ui.composables.LocalAppcuesStepMetadata
 import com.appcues.ui.composables.rememberAppcuesContentVisibility
+import com.appcues.ui.extensions.coloredShadowPath
+import com.appcues.ui.extensions.getColor
 import com.appcues.ui.extensions.styleBackground
 import com.appcues.ui.modal.dialogEnterTransition
 import com.appcues.ui.modal.dialogExitTransition
 import com.appcues.ui.utils.AppcuesWindowInfo
 import com.appcues.ui.utils.rememberAppcuesWindowInfo
+import com.appcues.util.ne
 import org.koin.core.scope.Scope
 
 internal class TooltipTrait(
@@ -51,7 +69,8 @@ internal class TooltipTrait(
 
         const val TYPE = "@appcues/tooltip"
 
-        private val SCREEN_PADDING = 16.dp
+        private val SCREEN_HORIZONTAL_PADDING = 12.dp
+        private val SCREEN_VERTICAL_PADDING = 24.dp
         private val MAX_WIDTH_DP = 350.dp
         private val MAX_HEIGHT_DP = 200.dp
     }
@@ -60,7 +79,25 @@ internal class TooltipTrait(
         TOP, BOTTOM, NONE
     }
 
+    private data class PointerSettings(
+        val hidePointer: Boolean,
+        val pointerPosition: PointerPosition,
+        val pointerBase: Double,
+        val pointerLength: Double
+    ) {
+
+        val pointerOffsetX = mutableStateOf(0.dp)
+    }
+
+    private val tooltipStyleSize = 20.dp
+
     private val style = config.getConfigStyle("style")
+
+    private val preferredPosition = config.getConfigOrDefault("preferredPosition", "center")
+    private val hidePointer = config.getConfigOrDefault("hidePointer", false)
+    private val pointerBase = config.getConfigOrDefault("pointerBase", 12.0)
+    private val pointerLength = config.getConfigOrDefault("pointerLength", 8.0)
+    private val distanceFromTarget = config.getConfigOrDefault("distanceFromTarget", 0.0)
 
     override fun present() {
         AppcuesOverlayViewManager(scope = scope).addView()
@@ -68,97 +105,248 @@ internal class TooltipTrait(
 
     @Composable
     override fun WrapContent(content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit) {
-        val windowInfo = rememberAppcuesWindowInfo()
         val metadata = LocalAppcuesStepMetadata.current
         val density = LocalDensity.current
+        val layoutDirection = LocalLayoutDirection.current
 
-        val actualRect = remember(metadata) {
-            // current target rect or empty
-            (metadata.actual[TargetElementTrait.METADATA_TARGET_RECT] as Rect?)
-        }
+        val windowInfo = rememberAppcuesWindowInfo()
+        val targetRect = remember(metadata) { (metadata.actual[TargetElementTrait.METADATA_TARGET_RECT] as Rect?) }
+        val pointerSettings = rememberPointerSettings(metadata, windowInfo, targetRect)
+        val tooltipSizeDp = remember { mutableStateOf(DpSize(0.dp, 0.dp)) }
+        // TODO change: remember? derivedState?
+        val tooltipPath = tooltipPath(
+            pointerSettings,
+            tooltipSizeDp.value,
+            style,
+            layoutDirection,
+            density,
+        )
 
-        val pointerPosition = remember(metadata) {
-            when {
-                actualRect == null -> PointerPosition.NONE
-                actualRect.center.y.dp < windowInfo.heightDp / 2 -> PointerPosition.TOP
-                else -> PointerPosition.BOTTOM
-            }
-        }
-
-        val tooltipSize = remember { mutableStateOf(DpSize(0.dp, 0.dp)) }
-
-        AppcuesTraitAnimatedVisibility(
-            visibleState = rememberAppcuesContentVisibility(),
-            enter = dialogEnterTransition(),
-            exit = dialogExitTransition(),
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = SCREEN_HORIZONTAL_PADDING, vertical = SCREEN_VERTICAL_PADDING)
         ) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                Column(
-                    modifier = Modifier
-                        .padding(SCREEN_PADDING)
-                        .positionTooltip(actualRect, tooltipSize.value, pointerPosition, windowInfo)
-                ) {
-                    if (pointerPosition == TOP) {
-                        Box(
-                            modifier = Modifier
-                                .padding(start = 32.dp)
-                                .size(20.dp)
-                                .clip(triangleShape)
-                                .styleBackground(style, isSystemInDarkTheme())
-                        )
-                    }
+            AppcuesTraitAnimatedVisibility(
+                visibleState = rememberAppcuesContentVisibility(),
+                enter = dialogEnterTransition(),
+                exit = dialogExitTransition(),
+            ) {
+                // positions both the tip and modal of the tooltip on the screen
+                Column(modifier = Modifier.positionTooltip(targetRect, tooltipSizeDp.value, pointerSettings, windowInfo)) {
                     Box(
                         modifier = Modifier
                             .requiredSizeIn(maxWidth = MAX_WIDTH_DP, maxHeight = MAX_HEIGHT_DP)
-                            .onSizeChanged { with(density) { tooltipSize.value = DpSize(it.width.toDp(), it.height.toDp()) } }
-                            .clip(RoundedCornerShape(8.dp))
+                            .tooltipSize(style)
+                            .onSizeChanged { with(density) { tooltipSizeDp.value = DpSize(it.width.toDp(), it.height.toDp()) } }
+                            .styleShadowPath(style, tooltipPath, isSystemInDarkTheme())
+                            .clipToPath(tooltipPath)
                             .styleBackground(style, isSystemInDarkTheme())
+                            .styleBorderPath(style, tooltipPath, isSystemInDarkTheme())
+                            .tooltipPointerPadding(pointerSettings)
                     ) {
                         content(false, PaddingValues(0.dp))
-                    }
-                    if (pointerPosition == BOTTOM) {
-                        Box(
-                            modifier = Modifier
-                                .padding(start = 32.dp)
-                                .size(20.dp)
-                                .rotate(degrees = 180f)
-                                .clip(triangleShape)
-                                .styleBackground(style, isSystemInDarkTheme())
-                        )
                     }
                 }
             }
         }
     }
 
-    private val triangleShape = GenericShape { size, _ ->
-        moveTo(size.width / 2f, 0f)
-        lineTo(size.width, size.height)
-        lineTo(0f, size.height)
+    @Composable
+    private fun rememberPointerSettings(
+        metadata: AppcuesStepMetadata,
+        windowInfo: AppcuesWindowInfo,
+        targetRect: Rect?
+    ): PointerSettings {
+        return remember(metadata) {
+            val pointerPosition = when {
+                targetRect == null -> NONE
+                targetRect.center.y.dp < windowInfo.heightDp / 2 -> TOP
+                else -> BOTTOM
+            }
+
+            PointerSettings(
+                hidePointer = false,
+                pointerPosition = pointerPosition,
+                pointerBase = pointerBase,
+                pointerLength = pointerLength
+            )
+        }
     }
 
+    @Composable
+    private fun tooltipPath(
+        pointerSettings: PointerSettings,
+        size: DpSize,
+        style: ComponentStyle?,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Path {
+        val containerSizePx = with(density) { Size(size.width.toPx(), size.height.toPx()) }
+        val pointerSizePx = with(density) {
+            Size(width = pointerSettings.pointerBase.dp.toPx(), height = pointerSettings.pointerLength.dp.toPx())
+        }
+
+        val containerOffsetPx = Offset(0f, if (pointerSettings.pointerPosition == TOP) pointerSizePx.height else 0f)
+        val containerSizeWithPointer = containerSizePx.copy(height = containerSizePx.height - pointerSizePx.height)
+        val cornerRadiusPx = with(density) { style?.cornerRadius?.dp?.toPx() ?: 0f }
+
+        return Path().apply {
+            val rect = Path().apply {
+                if (style != null) {
+                    addPath(
+                        Path().apply {
+                            addOutline(
+                                RoundedCornerShape(style.cornerRadius.dp).createOutline(
+                                    containerSizeWithPointer,
+                                    layoutDirection,
+                                    density
+                                )
+                            )
+                        },
+                        containerOffsetPx
+                    )
+                } else {
+                    addRect(Rect(containerOffsetPx, containerSizeWithPointer))
+                }
+            }
+
+            val base = pointerSizePx.width
+            val baseCenter = base / 2
+            val topSizePointer = animateFloatAsState(
+                targetValue = when (pointerSettings.pointerPosition) {
+                    TOP -> -pointerSizePx.height
+                    else -> 0f
+                }
+            )
+            val bottomSizePointer = animateFloatAsState(
+                targetValue = when (pointerSettings.pointerPosition) {
+                    BOTTOM -> cornerRadiusPx + pointerSizePx.height
+                    else -> 0f
+                }
+            )
+            val offsetX = with(density) { (size.width.toPx() / 2) - baseCenter + pointerSettings.pointerOffsetX.value.toPx() }
+            val minPointerOffset = 0f
+            val maxPointerOffset = with(density) { size.width.toPx() - base }
+            // TODO change so this value changes based on how much offset is needed for the pointer to point at target element
+            val pointerOffsetX = if (offsetX < minPointerOffset) {
+                -baseCenter
+            } else if (offsetX > maxPointerOffset) {
+                baseCenter
+            } else 0f
+
+            val offsetXAnimated = animateFloatAsState(
+                targetValue = offsetX.coerceAtLeast(minPointerOffset).coerceAtMost(maxPointerOffset)
+            )
+            val offsetY = animateFloatAsState(
+                targetValue = if (pointerSettings.pointerPosition == BOTTOM)
+                    containerSizeWithPointer.height - cornerRadiusPx else -topSizePointer.value
+            )
+            val pointer = Path().apply {
+                reset()
+
+                if (pointerSettings.pointerPosition == TOP) {
+                    lineTo(x = base / 2 + pointerOffsetX, y = topSizePointer.value)
+                }
+                lineTo(x = base, y = 0f)
+                lineTo(x = base, y = cornerRadiusPx)
+
+                if (pointerSettings.pointerPosition == BOTTOM) {
+                    lineTo(x = base / 2 + pointerOffsetX, y = bottomSizePointer.value)
+                }
+                lineTo(x = 0f, y = cornerRadiusPx)
+                lineTo(x = 0f, y = 0f)
+
+                close()
+
+                translate(Offset(offsetXAnimated.value, offsetY.value))
+            }
+
+            op(pointer, rect, PathOperation.Union)
+        }
+    }
+
+    private fun Modifier.clipToPath(path: Path) = then(
+        Modifier.clip(GenericShape { _, _ -> addPath(path) })
+    )
+
+    private fun Modifier.styleBorderPath(
+        style: ComponentStyle?,
+        path: Path,
+        isDark: Boolean
+    ) = this.then(
+        if (style?.borderWidth != null && style.borderWidth ne 0.0 && style.borderColor != null) {
+            Modifier
+                .border(style.borderWidth.dp, style.borderColor.getColor(isDark), GenericShape { _, _ -> addPath(path) })
+                .padding(style.borderWidth.dp)
+        } else {
+            Modifier
+        }
+    )
+
     private fun Modifier.positionTooltip(
-        actualRect: Rect?,
-        tooltipSize: DpSize,
-        pointerPosition: PointerPosition,
+        targetRect: Rect?,
+        tooltipSizeDp: DpSize,
+        pointerSettings: PointerSettings,
         windowInfo: AppcuesWindowInfo
     ): Modifier = composed {
+
         val tooltipPaddingTop = animateDpAsState(
-            targetValue = when (pointerPosition) {
-                TOP -> max((actualRect?.let { it.bottom.dp } ?: 0.dp), 0.dp)
-                BOTTOM -> max((actualRect?.let { it.top.dp - tooltipSize.height - SCREEN_PADDING - 20.dp } ?: 0.dp), 0.dp)
-                NONE -> windowInfo.heightDp - tooltipSize.height - SCREEN_PADDING
+            targetValue = when (pointerSettings.pointerPosition) {
+                TOP -> max((targetRect?.bottom?.dp ?: 0.dp) - SCREEN_VERTICAL_PADDING, 0.dp)
+                BOTTOM -> max((targetRect?.top?.dp ?: 0.dp) - tooltipSizeDp.height - tooltipStyleSize - SCREEN_VERTICAL_PADDING, 0.dp)
+                NONE -> windowInfo.heightDp - tooltipSizeDp.height - SCREEN_VERTICAL_PADDING
             }
         )
 
         val toolTipPaddingStart = animateDpAsState(
-            targetValue = if (actualRect != null) {
-                max(0.dp, 0.dp)
+            targetValue = if (targetRect != null) {
+                val paddingStartMin = 0.dp
+                val paddingStartMax = windowInfo.widthDp - (SCREEN_HORIZONTAL_PADDING * 2) - tooltipSizeDp.width
+                val paddingStartOnTarget = targetRect.center.x.dp - SCREEN_HORIZONTAL_PADDING - (tooltipSizeDp.width / 2)
+
+                if (paddingStartOnTarget < 0.dp) {
+                    pointerSettings.pointerOffsetX.value = paddingStartOnTarget
+                } else if (paddingStartOnTarget > paddingStartMax) {
+                    pointerSettings.pointerOffsetX.value = paddingStartOnTarget - paddingStartMax
+                }
+                // target value is between min and max
+                paddingStartOnTarget.coerceIn(paddingStartMin, paddingStartMax)
             } else {
-                max((windowInfo.widthDp - (SCREEN_PADDING * 2) - tooltipSize.width) / 2, 0.dp)
+                // When no targetRect is found we align the tooltip at bottomCenter of the screen
+                val paddingStartCentered = (windowInfo.widthDp - tooltipSizeDp.width - (SCREEN_HORIZONTAL_PADDING * 2)) / 2
+                // Min value
+                paddingStartCentered.coerceAtLeast(0.dp)
             }
         )
 
         then(Modifier.padding(start = toolTipPaddingStart.value, top = tooltipPaddingTop.value))
     }
+
+    private fun Modifier.tooltipPointerPadding(pointerSettings: PointerSettings): Modifier {
+        return then(
+            when (pointerSettings.pointerPosition) {
+                TOP -> Modifier.padding(top = pointerSettings.pointerLength.dp)
+                BOTTOM -> Modifier
+                NONE -> Modifier
+            }
+        )
+    }
+
+    private fun Modifier.styleShadowPath(style: ComponentStyle?, path: Path, isDark: Boolean): Modifier {
+        return this.then(
+            if (style?.shadow != null)
+                Modifier.coloredShadowPath(
+                    style.shadow.color.getColor(isDark),
+                    path,
+                    style.shadow.radius.dp,
+                    offsetX = style.shadow.x.dp,
+                    offsetY = style.shadow.y.dp
+                ) else Modifier
+        )
+    }
+
+    private fun Modifier.tooltipSize(style: ComponentStyle?): Modifier = then(
+        Modifier.size(width = style?.width?.dp ?: Dp.Unspecified, height = style?.height?.dp ?: Dp.Unspecified)
+    )
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathOperation
 import androidx.compose.ui.graphics.addOutline
@@ -230,9 +231,9 @@ internal class TooltipTrait(
             val maxPointerOffset = with(density) { size.width.toPx() - base }
             // TODO change so this value changes based on how much offset is needed for the pointer to point at target element
             val pointerOffsetX = if (offsetX < minPointerOffset) {
-                -baseCenter
+                (offsetX - minPointerOffset).coerceAtLeast(-baseCenter)
             } else if (offsetX > maxPointerOffset) {
-                baseCenter
+                (offsetX - maxPointerOffset).coerceAtMost(baseCenter)
             } else 0f
 
             val offsetXAnimated = animateFloatAsState(

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipsPaths.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipsPaths.kt
@@ -114,7 +114,7 @@ private fun getTooltipPointerPath(
 
     // mapping all values to px
     val cornerRadius = with(density) { style?.cornerRadius?.dp?.toPx() ?: 0f }
-    val pointerOffset = with(density) { pointerSettings.pointerOffsetX.value.toPx() } ?: 0f
+    val pointerOffset = with(density) { pointerSettings.pointerOffsetX.value.toPx() }
     val offsetX = (containerDimens.widthPx / 2) - pointerSettings.pointerBaseCenterPx + pointerOffset
 
     // boundaries for the tooltip

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipsPaths.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipsPaths.kt
@@ -1,0 +1,224 @@
+package com.appcues.trait.appcues
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.appcues.data.model.styling.ComponentStyle
+import com.appcues.trait.appcues.TooltipPointerPosition.BOTTOM
+import com.appcues.trait.appcues.TooltipPointerPosition.BOTTOM_END
+import com.appcues.trait.appcues.TooltipPointerPosition.BOTTOM_START
+import com.appcues.trait.appcues.TooltipPointerPosition.NONE
+import com.appcues.trait.appcues.TooltipPointerPosition.TOP
+import com.appcues.trait.appcues.TooltipPointerPosition.TOP_END
+import com.appcues.trait.appcues.TooltipPointerPosition.TOP_START
+import com.appcues.ui.utils.AppcuesWindowInfo
+import com.appcues.util.ne
+
+internal enum class TooltipPointerPosition {
+    TOP, TOP_START, TOP_END, BOTTOM, BOTTOM_START, BOTTOM_END, NONE
+}
+
+internal data class TooltipSettings(
+    val hidePointer: Boolean,
+    val pointerPosition: TooltipPointerPosition,
+    val pointerBaseDp: Dp,
+    val pointerLengthDp: Dp,
+    val pointerBasePx: Float,
+    val pointerLengthPx: Float,
+) {
+
+    val pointerBaseCenterPx = pointerBasePx / 2
+    val pointerOffsetX = mutableStateOf(0.dp)
+}
+
+internal data class TooltipContainerDimens(
+    val widthDp: Dp,
+    val heightDp: Dp,
+    val widthPx: Float,
+    val heightPx: Float
+)
+
+internal fun getTooltipSettings(
+    density: Density,
+    position: TooltipPointerPosition,
+    pointerBaseDp: Dp,
+    pointerLengthDp: Dp,
+): TooltipSettings {
+    return TooltipSettings(
+        hidePointer = false,
+        pointerPosition = position,
+        pointerBaseDp = pointerBaseDp,
+        pointerLengthDp = pointerLengthDp,
+        pointerBasePx = with(density) { pointerBaseDp.toPx() },
+        pointerLengthPx = with(density) { pointerLengthDp.toPx() }
+    )
+}
+
+internal fun getPointerPosition(
+    windowInfo: AppcuesWindowInfo,
+    targetRect: Rect?,
+): TooltipPointerPosition {
+    // Figure out where to position the tooltip
+    return when {
+        targetRect == null -> NONE
+        targetRect.center.y.dp < windowInfo.heightDp / 2 -> TOP
+        else -> BOTTOM
+    }
+}
+
+@Composable
+internal fun tooltipPath(
+    tooltipSettings: TooltipSettings,
+    containerDimens: TooltipContainerDimens?,
+    style: ComponentStyle?,
+    animationSpec: AnimationSpec<Float>,
+): Path {
+    return Path().apply {
+        // if containerDimens is null we don't to path the tooltip yet
+        if (containerDimens == null) return@apply
+
+        // information used by both container path and tooltip pointer path
+        val containerRealSize = Size(containerDimens.widthPx, containerDimens.heightPx - tooltipSettings.pointerLengthPx)
+
+        op(
+            path1 = getTooltipPointerPath(style, containerDimens, tooltipSettings, containerRealSize, animationSpec),
+            path2 = getContainerPath(tooltipSettings, style, containerRealSize),
+            operation = PathOperation.Union
+        )
+    }
+}
+
+@Composable
+private fun getTooltipPointerPath(
+    style: ComponentStyle?,
+    containerDimens: TooltipContainerDimens,
+    pointerSettings: TooltipSettings,
+    containerSize: Size,
+    animationSpec: AnimationSpec<Float>,
+): Path {
+    val density = LocalDensity.current
+
+    // mapping all values to px
+    val cornerRadius = with(density) { style?.cornerRadius?.dp?.toPx() ?: 0f }
+    val pointerOffset = with(density) { pointerSettings.pointerOffsetX.value.toPx() } ?: 0f
+    val offsetX = (containerDimens.widthPx / 2) - pointerSettings.pointerBaseCenterPx + pointerOffset
+
+    // boundaries for the tooltip
+    val minPointerOffset = 0f
+    val minPointerOffsetCornerRadius = minPointerOffset + cornerRadius
+    val maxPointerOffset = (containerDimens.widthPx - pointerSettings.pointerBasePx)
+        .let { return@let if (it < 0) 0f else it }
+    val maxPointerOffsetCornerRadius = maxPointerOffset - cornerRadius
+
+    // vertical pointer implementation, probably in the future make this a separate method and add
+    // another one to generate a horizontal pointer for leading and trailing positions.
+    return Path().apply {
+        val pathOffsetY = animateFloatAsState(
+            targetValue = if (pointerSettings.pointerPosition == BOTTOM)
+                containerSize.height else pointerSettings.pointerLengthPx,
+            animationSpec = animationSpec,
+        )
+
+        val pathOffsetX = animateFloatAsState(
+            targetValue = offsetX.coerceIn(minPointerOffset..maxPointerOffset),
+            animationSpec = animationSpec,
+        )
+
+        val pointerTipOffsetX = animateFloatAsState(
+            targetValue = if (offsetX < minPointerOffsetCornerRadius) {
+                -pointerSettings.pointerBaseCenterPx
+            } else if (offsetX > maxPointerOffsetCornerRadius) {
+                pointerSettings.pointerBaseCenterPx
+            } else 0f,
+            animationSpec = animationSpec,
+        )
+
+        TooltipPointerPath(pointerSettings, pointerTipOffsetX.value)
+
+        // Move path to correct place
+        translate(Offset(pathOffsetX.value, pathOffsetY.value))
+    }
+}
+
+@Composable
+private fun Path.TooltipPointerPath(
+    pointerSettings: TooltipSettings,
+    pointerOffsetX: Float
+) {
+    animateFloatAsState(
+        targetValue = when (pointerSettings.pointerPosition) {
+            TOP, TOP_START, TOP_END -> -pointerSettings.pointerLengthPx
+            BOTTOM, BOTTOM_START, BOTTOM_END -> pointerSettings.pointerLengthPx
+            NONE -> 0f
+        }
+    ).let {
+        reset()
+        lineTo(x = 0f, y = 0f)
+        lineTo(x = pointerSettings.pointerBaseCenterPx + pointerOffsetX, y = it.value)
+        lineTo(x = pointerSettings.pointerBasePx, y = 0f)
+        close()
+    }
+}
+
+@Composable
+private fun getContainerPath(
+    pointerSettings: TooltipSettings,
+    style: ComponentStyle?,
+    containerSizeWithPointer: Size,
+): Path {
+    return Path().apply {
+        val containerOffsetPx =
+            Offset(
+                0f,
+                y = when (pointerSettings.pointerPosition) {
+                    // offset entire content rectangle in case tooltip is at the top
+                    TOP, TOP_START, TOP_END -> pointerSettings.pointerLengthPx
+                    else -> 0f
+                }
+            )
+
+        if (style != null && style.cornerRadius ne 0.0) {
+            val cornerTopStart =
+                animateDpAsState(targetValue = if (pointerSettings.pointerPosition == TOP_START) 0.dp else style.cornerRadius.dp)
+            val cornerTopEnd =
+                animateDpAsState(targetValue = if (pointerSettings.pointerPosition == TOP_END) 0.dp else style.cornerRadius.dp)
+            val cornerBottomStart =
+                animateDpAsState(targetValue = if (pointerSettings.pointerPosition == BOTTOM_START) 0.dp else style.cornerRadius.dp)
+            val cornerBottomEnd =
+                animateDpAsState(targetValue = if (pointerSettings.pointerPosition == BOTTOM_END) 0.dp else style.cornerRadius.dp)
+            addPath(
+                Path().apply {
+                    addOutline(
+                        RoundedCornerShape(
+                            topStart = cornerTopStart.value,
+                            topEnd = cornerTopEnd.value,
+                            bottomEnd = cornerBottomEnd.value,
+                            bottomStart = cornerBottomStart.value
+                        ).createOutline(
+                            containerSizeWithPointer,
+                            LocalLayoutDirection.current,
+                            LocalDensity.current
+                        )
+                    )
+                },
+                containerOffsetPx
+            )
+        } else {
+            addRect(Rect(containerOffsetPx, containerSizeWithPointer))
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
@@ -1,8 +1,9 @@
 package com.appcues.ui
 
+import android.app.Activity
 import android.view.ViewGroup
+import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -32,7 +33,7 @@ class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLifecycleObse
         }
     }
 
-    override fun onActivityChanged(activity: AppCompatActivity) {
+    override fun onActivityChanged(activity: Activity) {
         activity.addView()
     }
 
@@ -66,10 +67,10 @@ class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLifecycleObse
         viewModel?.onFinish()
     }
 
-    private fun AppCompatActivity?.addView() {
+    private fun Activity?.addView() {
         if (this == null) return
 
-        onBackPressedDispatcher.addCallback(handleBackPress)
+        tryRegisterOnBackDispatcher()
 
         val parentView = getParentView()
         parentView.findViewTreeLifecycleOwner()?.lifecycle?.addObserver(this@AppcuesOverlayViewManager)
@@ -103,7 +104,7 @@ class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLifecycleObse
         }
     }
 
-    private fun AppCompatActivity?.removeView() {
+    private fun Activity?.removeView() {
         handleBackPress.remove()
 
         if (this == null) return
@@ -118,8 +119,18 @@ class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLifecycleObse
         }
     }
 
-    private fun AppCompatActivity.getParentView(): ViewGroup {
+    private fun Activity.getParentView(): ViewGroup {
         // if there is any difference in API levels we can handle it here
         return window.decorView.rootView as ViewGroup
+    }
+
+    private fun Activity?.tryRegisterOnBackDispatcher() {
+        // add onBackPressedDispatcher to handle internally native android back press when debugger is expanded
+        if (this is ComponentActivity) {
+            handleBackPress.remove()
+
+            // attach to the new activity
+            onBackPressedDispatcher.addCallback(handleBackPress)
+        }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -2,7 +2,6 @@ package com.appcues.ui.composables
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -56,7 +55,10 @@ internal fun AppcuesComposition(
 
 @Composable
 private fun MainSurface(onCompositionDismissed: () -> Unit) {
-    Box(contentAlignment = Alignment.Center) {
+    Box(
+        modifier = Modifier.consumeAllTouchEvents(),
+        contentAlignment = Alignment.Center
+    ) {
         val viewModel = LocalViewModel.current
         // collect all UIState
         viewModel.uiState.collectAsState().let { state ->
@@ -83,6 +85,13 @@ private fun MainSurface(onCompositionDismissed: () -> Unit) {
         }
     }
 }
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun Modifier.consumeAllTouchEvents(): Modifier = then(
+    Modifier
+        .fillMaxSize()
+        .pointerInteropFilter { false }
+)
 
 @Composable
 private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
@@ -164,16 +173,8 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun BoxScope.ApplyBackgroundDecoratingTraits(list: List<BackdropDecoratingTrait>) {
-    // adds a layer behind all Backdrop decorating traits to prevent touch events to
-    Spacer(
-        modifier = Modifier
-            .fillMaxSize()
-            .pointerInteropFilter { false }
-    )
-
     // get last trait if its not null compose it and drop last calling it again recursively
     val item = list.lastOrNull()
     if (item != null) {

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -112,6 +112,7 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
             // apply backdrop traits
             ApplyBackgroundDecoratingTraits(backdropDecoratingTraits.value)
 
+            // TODO contentPadding + stepDecoratingPadding into one? to fix tooltip padding issue
             // create wrapper
             contentWrappingTrait.WrapContent { hasFixedHeight, contentPadding ->
                 Box(contentAlignment = Alignment.TopCenter) {

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -2,6 +2,8 @@ package com.appcues.ui.composables
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -9,6 +11,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInteropFilter
 import androidx.compose.ui.platform.LocalDensity
 import com.appcues.logging.Logcues
 import com.appcues.trait.BackdropDecoratingTrait
@@ -159,8 +164,16 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun BoxScope.ApplyBackgroundDecoratingTraits(list: List<BackdropDecoratingTrait>) {
+    // adds a layer behind all Backdrop decorating traits to prevent touch events to
+    Spacer(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInteropFilter { false }
+    )
+
     // get last trait if its not null compose it and drop last calling it again recursively
     val item = list.lastOrNull()
     if (item != null) {

--- a/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.Role
@@ -114,10 +115,10 @@ private fun Modifier.styleBackgroundGradient(style: ComponentStyle, isDark: Bool
 )
 
 internal fun Modifier.styleBorder(
-    style: ComponentStyle,
+    style: ComponentStyle?,
     isDark: Boolean
 ) = this.then(
-    if (style.borderWidth != null && style.borderWidth ne 0.0 && style.borderColor != null) {
+    if (style?.borderWidth != null && style.borderWidth ne 0.0 && style.borderColor != null) {
         Modifier
             .border(style.borderWidth.dp, style.borderColor.getColor(isDark), RoundedCornerShape(style.cornerRadius.dp))
             .padding(style.borderWidth.dp)
@@ -172,7 +173,7 @@ internal fun Modifier.styleCorner(style: ComponentStyle) = this.then(
 
 internal fun Modifier.styleShadow(style: ComponentStyle?, isDark: Boolean): Modifier {
     return this.then(
-        if (style?.shadow != null) Modifier.coloredShadow(
+        if (style?.shadow != null) Modifier.coloredShadowRect(
             color = style.shadow.color.getColor(isDark),
             radius = style.shadow.radius.dp,
             cornerRadius = style.cornerRadius.dp,
@@ -183,7 +184,7 @@ internal fun Modifier.styleShadow(style: ComponentStyle?, isDark: Boolean): Modi
     )
 }
 
-internal fun Modifier.coloredShadow(
+internal fun Modifier.coloredShadowRect(
     color: Color,
     radius: Dp = 0.dp,
     cornerRadius: Dp = 0.dp,
@@ -215,6 +216,33 @@ internal fun Modifier.coloredShadow(
             cornerRadius.toPx(),
             paint
         )
+    }
+}
+
+internal fun Modifier.coloredShadowPath(
+    color: Color,
+    path: Path,
+    radius: Dp = 0.dp,
+    offsetX: Dp = 0.dp,
+    offsetY: Dp = 0.dp
+) = drawBehind {
+
+    val shadowColor = color.toArgb()
+    val transparent = color.copy(alpha = 0.0f).toArgb()
+
+    drawIntoCanvas {
+        val paint = Paint()
+        val frameworkPaint = paint.asFrameworkPaint()
+        frameworkPaint.color = transparent
+
+        frameworkPaint.setShadowLayer(
+            radius.toPx(),
+            offsetX.toPx(),
+            offsetY.toPx(),
+            shadowColor
+        )
+
+        it.drawPath(path, paint)
     }
 }
 


### PR DESCRIPTION
This pass on tooltip trait comes with some changes.

* AppcuesActivityMonitor and AppcuesOverlay changed to support "subscribing" to the existing activity, I changed to this approach as a way to  re-add our view in case the activity gets destroyed and restored for any reason (orientation changes, layout inspector, etc)
* BackdropKeyHoleTrait now applies, a graphicLayer with 0.99F Alpha to add a new layer that enables BlendMondes to work as [expected](https://stackoverflow.com/questions/73313025/jetpack-compose-canvas-blendmode-not-working-as-expected) 
* Various changes to TooltipTrait files to add support for better positioning the pointer (at the top or bottom of the content). Plus adding in all animation to the animation trait.
* Minor change to AppcuesComposition to add an Spacer fillMaxSize to intercept all events (for now at least) and block user of unwanted interaction.



https://user-images.githubusercontent.com/5244805/220458781-6b57da89-ef36-4545-ae51-de4c29a2289f.mov



Remaining work:

* implement distanceFromTarget option
* implement preferredPosition (top/bottom)
* implement pointer handling for edge positions
* Adjust safe content area for tooltips
* Change Debugger to ensure its always the view on top