### PR TITLE
✨ Added spans property to TextPrimitive

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/TextPrimitiveMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/TextPrimitiveMapper.kt
@@ -13,7 +13,7 @@ internal fun TextPrimitiveResponse.mapTextPrimitive(): TextPrimitive {
     val processedSpans = when {
         // when text is not null and spans is null or empty we use the raw text as a single span item
         text != null && spans.isNullOrEmpty() -> text.toTextSpanPrimitiveList(style)
-        // else when span is not null we nao to Primitive
+        // else when span is not null we map to Primitive
         spans != null -> spans.toTextSpanPrimitive()
         // else an empty list
         else -> arrayListOf()
@@ -27,7 +27,6 @@ internal fun TextPrimitiveResponse.mapTextPrimitive(): TextPrimitive {
     return TextPrimitive(
         id = id,
         style = style.mapComponentStyle(),
-        text = processedSpans.joinToString { it.text },
         spans = processedSpans
     )
 }

--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/TextPrimitiveMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/TextPrimitiveMapper.kt
@@ -1,11 +1,41 @@
 package com.appcues.data.mapper.step.primitives
 
+import com.appcues.data.mapper.AppcuesMappingException
 import com.appcues.data.mapper.styling.mapComponentStyle
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.TextPrimitiveResponse
+import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.TextSpanResponse
+import com.appcues.data.remote.response.styling.StyleResponse
 
-internal fun TextPrimitiveResponse.mapTextPrimitive() = TextPrimitive(
-    id = id,
-    text = text,
-    style = style.mapComponentStyle(),
-)
+internal fun TextPrimitiveResponse.mapTextPrimitive(): TextPrimitive {
+
+    val processedSpans = when {
+        // when text is not null and spans is null or empty we use the raw text as a single span item
+        text != null && spans.isNullOrEmpty() -> text.toTextSpanPrimitiveList(style)
+        // else when span is not null we nao to Primitive
+        spans != null -> spans.toTextSpanPrimitive()
+        // else an empty list
+        else -> arrayListOf()
+    }
+
+    // check if this TextPrimitive is valid (contains text in form of spans)
+    if (processedSpans.isEmpty()) {
+        throw AppcuesMappingException("text($id) has no text or spans defined.")
+    }
+
+    return TextPrimitive(
+        id = id,
+        style = style.mapComponentStyle(),
+        text = processedSpans.joinToString { it.text },
+        spans = processedSpans
+    )
+}
+
+private fun String.toTextSpanPrimitiveList(style: StyleResponse?): List<TextSpanPrimitive> {
+    return listOf(TextSpanPrimitive(text = this, style = style.mapComponentStyle()))
+}
+
+private fun List<TextSpanResponse>.toTextSpanPrimitive(): List<TextSpanPrimitive> {
+    return map { TextSpanPrimitive(text = it.text, style = it.style.mapComponentStyle()) }
+}

--- a/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
@@ -30,11 +30,10 @@ internal sealed class ExperiencePrimitive(
     data class TextPrimitive(
         override val id: UUID,
         override val style: ComponentStyle = ComponentStyle(),
-        val text: String,
         val spans: List<TextSpanPrimitive>,
     ) : ExperiencePrimitive(id, style) {
 
-        override val textDescription: String = text
+        override val textDescription: String = spans.joinToString(separator = String()) { it.text }
     }
 
     data class TextSpanPrimitive(

--- a/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
@@ -31,10 +31,16 @@ internal sealed class ExperiencePrimitive(
         override val id: UUID,
         override val style: ComponentStyle = ComponentStyle(),
         val text: String,
+        val spans: List<TextSpanPrimitive>,
     ) : ExperiencePrimitive(id, style) {
 
         override val textDescription: String = text
     }
+
+    data class TextSpanPrimitive(
+        val text: String,
+        val style: ComponentStyle = ComponentStyle()
+    )
 
     data class ButtonPrimitive(
         override val id: UUID,

--- a/appcues/src/main/java/com/appcues/data/model/ExperienceStepFormState.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperienceStepFormState.kt
@@ -127,7 +127,7 @@ internal sealed class ExperienceStepFormItemState(
         index = index,
         id = primitive.id,
         type = "textInput",
-        label = primitive.label.text,
+        label = primitive.label.textDescription,
         isRequired = primitive.required,
         attributeName = primitive.attributeName,
         isTextFocusable = true,
@@ -147,7 +147,7 @@ internal sealed class ExperienceStepFormItemState(
         index = index,
         id = primitive.id,
         type = "optionSelect",
-        label = primitive.label.text,
+        label = primitive.label.textDescription,
         isRequired = primitive.minSelections > 0u,
         attributeName = primitive.attributeName,
     ) {

--- a/appcues/src/main/java/com/appcues/data/remote/response/step/primitive/PrimitiveResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/response/step/primitive/PrimitiveResponse.kt
@@ -55,8 +55,14 @@ internal sealed class PrimitiveResponse(
     internal data class TextPrimitiveResponse(
         val id: UUID,
         val style: StyleResponse? = null,
-        val text: String,
+        val text: String? = null,
+        val spans: List<TextSpanResponse>? = arrayListOf(),
     ) : PrimitiveResponse(TEXT)
+
+    internal data class TextSpanResponse(
+        val text: String,
+        val style: StyleResponse? = null,
+    )
 
     internal data class ButtonPrimitiveResponse(
         val id: UUID,

--- a/appcues/src/main/java/com/appcues/ui/extensions/TextStyleExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/TextStyleExt.kt
@@ -1,8 +1,15 @@
 package com.appcues.ui.extensions
 
 import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentStyle
 
 internal fun TextStyle.applyStyle(style: ComponentStyle, context: Context, isDark: Boolean): TextStyle {
@@ -14,5 +21,25 @@ internal fun TextStyle.applyStyle(style: ComponentStyle, context: Context, isDar
         fontFamily = style.getFontFamily(context) ?: fontFamily,
         letterSpacing = style.letterSpacing?.sp ?: letterSpacing,
         fontWeight = style.getFontWeight() ?: fontWeight,
+    )
+}
+
+internal fun List<TextSpanPrimitive>.toAnnotatedString(context: Context, isDark: Boolean): AnnotatedString {
+    return buildAnnotatedString {
+        forEach {
+            withStyle(style = it.style.toSpanStyle(context, isDark)) {
+                append(it.text)
+            }
+        }
+    }
+}
+
+private fun ComponentStyle.toSpanStyle(context: Context, isDark: Boolean): SpanStyle {
+    return SpanStyle(
+        color = foregroundColor.getColor(isDark) ?: Color.Unspecified,
+        fontSize = fontSize?.sp ?: TextUnit.Unspecified,
+        fontFamily = getFontFamily(context),
+        letterSpacing = letterSpacing?.sp ?: TextUnit.Unspecified,
+        fontWeight = getFontWeight(),
     )
 }

--- a/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
@@ -35,14 +35,12 @@ internal fun BoxPrimitive.Compose(modifier: Modifier) {
 private val items = arrayListOf(
     TextPrimitive(
         id = UUID.randomUUID(),
-        text = "\uD83D\uDC4B Welcome!",
         spans = arrayListOf(TextSpanPrimitive("\uD83D\uDC4B Welcome!"))
     ),
     ButtonPrimitive(
         id = UUID.randomUUID(),
         content = TextPrimitive(
             id = UUID.randomUUID(),
-            text = "Button 1",
             style = ComponentStyle(
                 fontSize = 17.0,
                 foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
@@ -71,7 +69,6 @@ private val items = arrayListOf(
     ),
     TextPrimitive(
         id = UUID.randomUUID(),
-        text = "BYE! \uD83E\uDD96",
         spans = arrayListOf(TextSpanPrimitive("BYE! \uD83E\uDD96"))
     )
 )

--- a/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.appcues.data.model.ExperiencePrimitive.BoxPrimitive
 import com.appcues.data.model.ExperiencePrimitive.ButtonPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentColor
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment
@@ -35,6 +36,7 @@ private val items = arrayListOf(
     TextPrimitive(
         id = UUID.randomUUID(),
         text = "\uD83D\uDC4B Welcome!",
+        spans = arrayListOf(TextSpanPrimitive("\uD83D\uDC4B Welcome!"))
     ),
     ButtonPrimitive(
         id = UUID.randomUUID(),
@@ -44,6 +46,15 @@ private val items = arrayListOf(
             style = ComponentStyle(
                 fontSize = 17.0,
                 foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
+            ),
+            spans = arrayListOf(
+                TextSpanPrimitive(
+                    text = "Button 1",
+                    style = ComponentStyle(
+                        fontSize = 17.0,
+                        foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
+                    )
+                )
             )
         ),
         style = ComponentStyle(
@@ -61,6 +72,7 @@ private val items = arrayListOf(
     TextPrimitive(
         id = UUID.randomUUID(),
         text = "BYE! \uD83E\uDD96",
+        spans = arrayListOf(TextSpanPrimitive("BYE! \uD83E\uDD96"))
     )
 )
 

--- a/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.appcues.data.model.ExperiencePrimitive.ButtonPrimitive
 import com.appcues.data.model.ExperiencePrimitive.HorizontalStackPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentColor
 import com.appcues.data.model.styling.ComponentShadow
 import com.appcues.data.model.styling.ComponentStyle
@@ -56,6 +57,14 @@ internal fun PreviewButtonBorder() {
                 text = "My Fancy Button",
                 style = ComponentStyle(
                     foregroundColor = ComponentColor(light = 0xFF5C5CFF, dark = 0xFF5C5CFF)
+                ),
+                spans = arrayListOf(
+                    TextSpanPrimitive(
+                        text = "My Fancy Button",
+                        style = ComponentStyle(
+                            foregroundColor = ComponentColor(light = 0xFF5C5CFF, dark = 0xFF5C5CFF)
+                        )
+                    )
                 )
             ),
             style = ComponentStyle(
@@ -87,11 +96,17 @@ internal fun PreviewButtonComplexContents() {
                 items = arrayListOf(
                     TextPrimitive(
                         id = UUID.randomUUID(),
-                        text = "\uD83E\uDDEA"
+                        text = "\uD83E\uDDEA",
+                        spans = arrayListOf(
+                            TextSpanPrimitive("\uD83E\uDDEA")
+                        )
                     ),
                     TextPrimitive(
                         id = UUID.randomUUID(),
-                        text = "My Fancy Button"
+                        text = "My Fancy Button",
+                        spans = arrayListOf(
+                            TextSpanPrimitive("My Fancy Button")
+                        )
                     )
                 )
             ),
@@ -118,6 +133,9 @@ internal fun PreviewButtonDefault() {
             content = TextPrimitive(
                 id = UUID.randomUUID(),
                 text = "My Button",
+                spans = arrayListOf(
+                    TextSpanPrimitive("My Button")
+                )
             ),
         )
     }
@@ -135,6 +153,15 @@ internal fun PreviewButtonGeneral() {
                 style = ComponentStyle(
                     fontSize = 17.0,
                     foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
+                ),
+                spans = arrayListOf(
+                    TextSpanPrimitive(
+                        text = "Button 1",
+                        style = ComponentStyle(
+                            fontSize = 17.0,
+                            foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
+                        )
+                    )
                 )
             ),
             style = ComponentStyle(

--- a/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
@@ -54,7 +54,6 @@ internal fun PreviewButtonBorder() {
             id = UUID.randomUUID(),
             content = TextPrimitive(
                 id = UUID.randomUUID(),
-                text = "My Fancy Button",
                 style = ComponentStyle(
                     foregroundColor = ComponentColor(light = 0xFF5C5CFF, dark = 0xFF5C5CFF)
                 ),
@@ -96,14 +95,12 @@ internal fun PreviewButtonComplexContents() {
                 items = arrayListOf(
                     TextPrimitive(
                         id = UUID.randomUUID(),
-                        text = "\uD83E\uDDEA",
                         spans = arrayListOf(
                             TextSpanPrimitive("\uD83E\uDDEA")
                         )
                     ),
                     TextPrimitive(
                         id = UUID.randomUUID(),
-                        text = "My Fancy Button",
                         spans = arrayListOf(
                             TextSpanPrimitive("My Fancy Button")
                         )
@@ -132,7 +129,6 @@ internal fun PreviewButtonDefault() {
             id = UUID.randomUUID(),
             content = TextPrimitive(
                 id = UUID.randomUUID(),
-                text = "My Button",
                 spans = arrayListOf(
                     TextSpanPrimitive("My Button")
                 )
@@ -149,7 +145,6 @@ internal fun PreviewButtonGeneral() {
             id = UUID.randomUUID(),
             content = TextPrimitive(
                 id = UUID.randomUUID(),
-                text = "Button 1",
                 style = ComponentStyle(
                     fontSize = 17.0,
                     foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)

--- a/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
@@ -96,7 +96,6 @@ private fun ComponentStyle.getBoxAlignment(): Alignment {
 private val items = arrayListOf(
     TextPrimitive(
         id = UUID.randomUUID(),
-        text = "\uD83D\uDC4B Welcome!",
         style = ComponentStyle(
             verticalAlignment = ComponentVerticalAlignment.BOTTOM,
             horizontalAlignment = ComponentHorizontalAlignment.LEADING,
@@ -115,7 +114,6 @@ private val items = arrayListOf(
         id = UUID.randomUUID(),
         content = TextPrimitive(
             id = UUID.randomUUID(),
-            text = "Button 1",
             style = ComponentStyle(
                 fontSize = 17.0,
                 foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
@@ -144,7 +142,6 @@ private val items = arrayListOf(
     ),
     TextPrimitive(
         id = UUID.randomUUID(),
-        text = "BYE! \uD83E\uDD96",
         style = ComponentStyle(
             verticalAlignment = ComponentVerticalAlignment.TOP,
             horizontalAlignment = ComponentHorizontalAlignment.TRAILING,

--- a/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
@@ -19,6 +19,7 @@ import com.appcues.data.model.ExperiencePrimitive.ButtonPrimitive
 import com.appcues.data.model.ExperiencePrimitive.HorizontalStackPrimitive
 import com.appcues.data.model.ExperiencePrimitive.SpacerPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentColor
 import com.appcues.data.model.styling.ComponentDistribution
 import com.appcues.data.model.styling.ComponentStyle
@@ -99,6 +100,15 @@ private val items = arrayListOf(
         style = ComponentStyle(
             verticalAlignment = ComponentVerticalAlignment.BOTTOM,
             horizontalAlignment = ComponentHorizontalAlignment.LEADING,
+        ),
+        spans = arrayListOf(
+            TextSpanPrimitive(
+                text = "\uD83D\uDC4B Welcome!",
+                style = ComponentStyle(
+                    verticalAlignment = ComponentVerticalAlignment.BOTTOM,
+                    horizontalAlignment = ComponentHorizontalAlignment.LEADING,
+                )
+            )
         )
     ),
     ButtonPrimitive(
@@ -109,6 +119,15 @@ private val items = arrayListOf(
             style = ComponentStyle(
                 fontSize = 17.0,
                 foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
+            ),
+            spans = arrayListOf(
+                TextSpanPrimitive(
+                    text = "Button 1",
+                    style = ComponentStyle(
+                        fontSize = 17.0,
+                        foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
+                    )
+                )
             )
         ),
         style = ComponentStyle(
@@ -129,6 +148,15 @@ private val items = arrayListOf(
         style = ComponentStyle(
             verticalAlignment = ComponentVerticalAlignment.TOP,
             horizontalAlignment = ComponentHorizontalAlignment.TRAILING,
+        ),
+        spans = arrayListOf(
+            TextSpanPrimitive(
+                text = "BYE! \uD83E\uDD96",
+                style = ComponentStyle(
+                    verticalAlignment = ComponentVerticalAlignment.TOP,
+                    horizontalAlignment = ComponentHorizontalAlignment.TRAILING,
+                )
+            )
         )
     )
 )

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isUnspecified
 import com.appcues.data.model.ExperiencePrimitive.TextInputPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentColor
 import com.appcues.data.model.styling.ComponentDataType
 import com.appcues.data.model.styling.ComponentDataType.ADDRESS
@@ -241,6 +242,9 @@ private fun mapKeyboardType(value: ComponentDataType): KeyboardType = when (valu
 private val textPrimitive = TextPrimitive(
     id = UUID.randomUUID(),
     text = "Enter a value",
+    spans = arrayListOf(
+        TextSpanPrimitive("Enter a value")
+    )
 )
 
 private val textInputPrimitive = TextInputPrimitive(

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -241,7 +241,6 @@ private fun mapKeyboardType(value: ComponentDataType): KeyboardType = when (valu
 
 private val textPrimitive = TextPrimitive(
     id = UUID.randomUUID(),
-    text = "Enter a value",
     spans = arrayListOf(
         TextSpanPrimitive("Enter a value")
     )

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
@@ -60,7 +60,6 @@ internal fun TextPrimitive.Compose(modifier: Modifier) {
 
 private val textPrimitive = TextPrimitive(
     id = UUID.randomUUID(),
-    text = "\uD83D\uDC4B Welcome! If you’re looking for Appcues’\nbrand guidelines, you’ve come to the right place.",
     spans = arrayListOf(
         TextSpanPrimitive("\uD83D\uDC4B Welcome! If you’re looking for Appcues’\nbrand guidelines, you’ve come to the right place.")
     )

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
@@ -16,9 +16,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentColor
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment.TRAILING
 import com.appcues.ui.extensions.applyStyle
+import com.appcues.ui.extensions.toAnnotatedString
 import com.appcues.ui.theme.AppcuesPreviewPrimitive
 import java.util.UUID
 
@@ -26,18 +28,18 @@ private const val TEXT_SCALE_REDUCTION_INTERVAL = 0.9f
 
 @Composable
 internal fun TextPrimitive.Compose(modifier: Modifier) {
-    val style = LocalTextStyle.current.applyStyle(
-        style = style,
-        context = LocalContext.current,
-        isDark = isSystemInDarkTheme(),
-    )
+    val isDark = isSystemInDarkTheme()
+    val context = LocalContext.current
+    val style = LocalTextStyle.current.applyStyle(style, context, isDark)
 
     var resizedStyle by remember(style) { mutableStateOf(style) }
     var readyToDraw by remember(style) { mutableStateOf(false) }
 
     Text(
-        modifier = modifier.clipToBounds().drawWithContent { if (readyToDraw) drawContent() },
-        text = text,
+        modifier = modifier
+            .clipToBounds()
+            .drawWithContent { if (readyToDraw) drawContent() },
+        text = spans.toAnnotatedString(context, isDark),
         style = resizedStyle,
         overflow = TextOverflow.Ellipsis,
         onTextLayout = { textLayoutResult ->
@@ -59,6 +61,9 @@ internal fun TextPrimitive.Compose(modifier: Modifier) {
 private val textPrimitive = TextPrimitive(
     id = UUID.randomUUID(),
     text = "\uD83D\uDC4B Welcome! If you’re looking for Appcues’\nbrand guidelines, you’ve come to the right place.",
+    spans = arrayListOf(
+        TextSpanPrimitive("\uD83D\uDC4B Welcome! If you’re looking for Appcues’\nbrand guidelines, you’ve come to the right place.")
+    )
 )
 
 @Composable

--- a/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
@@ -46,7 +46,6 @@ internal fun VerticalStackPrimitive.Compose(modifier: Modifier) {
 private val items = arrayListOf(
     TextPrimitive(
         id = UUID.randomUUID(),
-        text = "\uD83D\uDC4B Welcome!",
         spans = arrayListOf(
             TextSpanPrimitive("\uD83D\uDC4B Welcome!")
         )
@@ -55,7 +54,6 @@ private val items = arrayListOf(
         id = UUID.randomUUID(),
         content = TextPrimitive(
             id = UUID.randomUUID(),
-            text = "Button 1",
             style = ComponentStyle(
                 fontSize = 17.0,
                 foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
@@ -84,7 +82,6 @@ private val items = arrayListOf(
     ),
     TextPrimitive(
         id = UUID.randomUUID(),
-        text = "BYE! \uD83E\uDD96",
         spans = arrayListOf(
             TextSpanPrimitive("BYE! \uD83E\uDD96")
         )

--- a/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.ExperiencePrimitive.ButtonPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.ExperiencePrimitive.VerticalStackPrimitive
 import com.appcues.data.model.styling.ComponentColor
 import com.appcues.data.model.styling.ComponentStyle
@@ -46,6 +47,9 @@ private val items = arrayListOf(
     TextPrimitive(
         id = UUID.randomUUID(),
         text = "\uD83D\uDC4B Welcome!",
+        spans = arrayListOf(
+            TextSpanPrimitive("\uD83D\uDC4B Welcome!")
+        )
     ),
     ButtonPrimitive(
         id = UUID.randomUUID(),
@@ -55,6 +59,15 @@ private val items = arrayListOf(
             style = ComponentStyle(
                 fontSize = 17.0,
                 foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
+            ),
+            spans = arrayListOf(
+                TextSpanPrimitive(
+                    text = "Button 1",
+                    style = ComponentStyle(
+                        fontSize = 17.0,
+                        foregroundColor = ComponentColor(light = 0xFFFFFFFF, dark = 0xFFFFFFFF)
+                    )
+                )
             )
         ),
         style = ComponentStyle(
@@ -72,6 +85,9 @@ private val items = arrayListOf(
     TextPrimitive(
         id = UUID.randomUUID(),
         text = "BYE! \uD83E\uDD96",
+        spans = arrayListOf(
+            TextSpanPrimitive("BYE! \uD83E\uDD96")
+        )
     )
 )
 

--- a/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
@@ -79,7 +79,7 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         // GIVEN
         val textInput = TextInputPrimitive(
             id = UUID.randomUUID(),
-            label = TextPrimitive(id = UUID.randomUUID(), text = "label"),
+            label = TextPrimitive(id = UUID.randomUUID(), text = "label", spans = listOf()),
             required = true,
             attributeName = "myCustomAttribute"
         )
@@ -240,17 +240,17 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
     private fun optionSelect(count: Int = 3, minSelections: Int = 1) =
         OptionSelectPrimitive(
             id = UUID.randomUUID(),
-            label = TextPrimitive(id = UUID.randomUUID(), text = "select an option"),
+            label = TextPrimitive(id = UUID.randomUUID(), text = "select an option", spans = listOf()),
             minSelections = minSelections.toUInt(),
             selectMode = MULTIPLE,
             options = (0..count).map {
-                OptionItem("$it", TextPrimitive(UUID.randomUUID(), text = "$it"))
+                OptionItem("$it", TextPrimitive(UUID.randomUUID(), text = "$it", spans = listOf()))
             }
         )
 
     private fun textInput() = TextInputPrimitive(
         id = UUID.randomUUID(),
-        label = TextPrimitive(id = UUID.randomUUID(), text = "label"),
+        label = TextPrimitive(id = UUID.randomUUID(), text = "label", spans = listOf()),
         required = true
     )
 

--- a/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
@@ -12,6 +12,7 @@ import com.appcues.data.model.ExperiencePrimitive.OptionSelectPrimitive
 import com.appcues.data.model.ExperiencePrimitive.OptionSelectPrimitive.OptionItem
 import com.appcues.data.model.ExperiencePrimitive.TextInputPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.data.model.ExperienceTrigger
@@ -79,7 +80,7 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         // GIVEN
         val textInput = TextInputPrimitive(
             id = UUID.randomUUID(),
-            label = TextPrimitive(id = UUID.randomUUID(), text = "label", spans = listOf()),
+            label = TextPrimitive(id = UUID.randomUUID(), spans = listOf(TextSpanPrimitive("label"))),
             required = true,
             attributeName = "myCustomAttribute"
         )
@@ -240,17 +241,17 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
     private fun optionSelect(count: Int = 3, minSelections: Int = 1) =
         OptionSelectPrimitive(
             id = UUID.randomUUID(),
-            label = TextPrimitive(id = UUID.randomUUID(), text = "select an option", spans = listOf()),
+            label = TextPrimitive(id = UUID.randomUUID(), spans = listOf(TextSpanPrimitive("select an option"))),
             minSelections = minSelections.toUInt(),
             selectMode = MULTIPLE,
             options = (0..count).map {
-                OptionItem("$it", TextPrimitive(UUID.randomUUID(), text = "$it", spans = listOf()))
+                OptionItem("$it", TextPrimitive(UUID.randomUUID(), spans = listOf(TextSpanPrimitive("$it"))))
             }
         )
 
     private fun textInput() = TextInputPrimitive(
         id = UUID.randomUUID(),
-        label = TextPrimitive(id = UUID.randomUUID(), text = "label", spans = listOf()),
+        label = TextPrimitive(id = UUID.randomUUID(), spans = listOf(TextSpanPrimitive("label"))),
         required = true
     )
 

--- a/appcues/src/test/java/com/appcues/data/mapper/step/primitives/TextPrimitiveMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/primitives/TextPrimitiveMapperTest.kt
@@ -1,0 +1,57 @@
+package com.appcues.data.mapper.step.primitives
+
+import com.appcues.data.mapper.AppcuesMappingException
+import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.TextPrimitiveResponse
+import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.TextSpanResponse
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.UUID
+
+class TextPrimitiveMapperTest {
+
+    @Test
+    fun `text primitive mapping SHOULD map all spans properly and also concatenate to the text label`() {
+        // GIVEN
+        val textPrimitiveResponse = TextPrimitiveResponse(
+            UUID.randomUUID(), null, null,
+            spans = arrayListOf(
+                TextSpanResponse("1"), TextSpanResponse("2"), TextSpanResponse("3")
+            )
+        )
+
+        // WHEN
+        val textPrimitive = textPrimitiveResponse.mapTextPrimitive()
+
+        // THEN
+        assertThat(textPrimitive.spans).hasSize(3)
+        assertThat(textPrimitive.spans[0].text).isEqualTo("1")
+        assertThat(textPrimitive.spans[1].text).isEqualTo("2")
+        assertThat(textPrimitive.spans[2].text).isEqualTo("3")
+        assertThat(textPrimitive.textDescription).isEqualTo("123")
+    }
+
+    @Test
+    fun `text primitive mapping SHOULD be compatible with older versions of the textResponse`() {
+        // GIVEN
+        val textPrimitiveResponse = TextPrimitiveResponse(
+            UUID.randomUUID(), null, "old text",
+        )
+
+        // WHEN
+        val textPrimitive = textPrimitiveResponse.mapTextPrimitive()
+
+        // THEN
+        assertThat(textPrimitive.spans).hasSize(1)
+        assertThat(textPrimitive.spans[0].text).isEqualTo("old text")
+        assertThat(textPrimitive.textDescription).isEqualTo("old text")
+    }
+
+    @Test(expected = AppcuesMappingException::class)
+    fun `text primitive mapping SHOULD throw error if no text or spans are provided`() {
+        // GIVEN
+        val textPrimitiveResponse = TextPrimitiveResponse(UUID.randomUUID(), null, null)
+        // WHEN
+        textPrimitiveResponse.mapTextPrimitive()
+        // Then text will capture exception
+    }
+}

--- a/appcues/src/test/java/com/appcues/data/model/ExperienceStepFormStateTest.kt
+++ b/appcues/src/test/java/com/appcues/data/model/ExperienceStepFormStateTest.kt
@@ -4,6 +4,7 @@ import com.appcues.data.model.ExperiencePrimitive.OptionSelectPrimitive
 import com.appcues.data.model.ExperiencePrimitive.OptionSelectPrimitive.OptionItem
 import com.appcues.data.model.ExperiencePrimitive.TextInputPrimitive
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.ExperienceStepFormItemState.OptionSelectFormItemState
 import com.appcues.data.model.ExperienceStepFormItemState.TextInputFormItemState
 import com.appcues.data.model.styling.ComponentSelectMode.MULTIPLE
@@ -14,7 +15,7 @@ import java.util.UUID
 
 class ExperienceStepFormStateTest {
 
-    private val label = TextPrimitive(id = UUID.randomUUID(), text = "label", spans = listOf())
+    private val label = TextPrimitive(id = UUID.randomUUID(), spans = listOf(TextSpanPrimitive("label")))
 
     @Test
     fun `form state SHOULD be valid by default`() {
@@ -363,6 +364,6 @@ class ExperienceStepFormStateTest {
     }
 
     private fun optionItems(count: Int) = (0..count).map {
-        OptionItem("$it", TextPrimitive(UUID.randomUUID(), text = "$it", spans = listOf()))
+        OptionItem("$it", TextPrimitive(UUID.randomUUID(), spans = listOf(TextSpanPrimitive("$it"))))
     }
 }

--- a/appcues/src/test/java/com/appcues/data/model/ExperienceStepFormStateTest.kt
+++ b/appcues/src/test/java/com/appcues/data/model/ExperienceStepFormStateTest.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 
 class ExperienceStepFormStateTest {
 
-    private val label = TextPrimitive(id = UUID.randomUUID(), text = "label")
+    private val label = TextPrimitive(id = UUID.randomUUID(), text = "label", spans = listOf())
 
     @Test
     fun `form state SHOULD be valid by default`() {
@@ -363,6 +363,6 @@ class ExperienceStepFormStateTest {
     }
 
     private fun optionItems(count: Int) = (0..count).map {
-        OptionItem("$it", TextPrimitive(UUID.randomUUID(), text = "$it"))
+        OptionItem("$it", TextPrimitive(UUID.randomUUID(), text = "$it", spans = listOf()))
     }
 }

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -65,7 +65,6 @@ internal fun mockStep(id: UUID) =
         id = id,
         content = TextPrimitive(
             id = UUID.fromString("df3bbe3e-8bdb-417a-b644-5e23862786b2"),
-            text = "",
             spans = listOf()
         ),
         stepDecoratingTraits = listOf(),

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -65,7 +65,8 @@ internal fun mockStep(id: UUID) =
         id = id,
         content = TextPrimitive(
             id = UUID.fromString("df3bbe3e-8bdb-417a-b644-5e23862786b2"),
-            text = ""
+            text = "",
+            spans = listOf()
         ),
         stepDecoratingTraits = listOf(),
         actions = mapOf(),


### PR DESCRIPTION
`targeting release/1.3.0`

adds spans as a TextPrimitive property and handles it so whenever we have spans we basically ignore the content sent in "text" and override it with the combined values of all spans.

also when we have only text we map to a single span item so its straight forward way to handle all texts (as span elements).

<img width="409" alt="image" src="https://user-images.githubusercontent.com/5244805/213811793-97b032d7-30b2-4aa5-a1b9-8ad492ebfbbe.png">
