### PR TITLE
Add initial layout capture model and populate from current Activity

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/screencapture/Capture.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/Capture.kt
@@ -1,0 +1,79 @@
+package com.appcues.debugger.screencapture
+
+import android.os.Build.VERSION
+import android.util.Log
+import com.appcues.BuildConfig
+import com.appcues.R
+import com.appcues.data.MoshiConfiguration
+import com.appcues.ui.ElementSelector
+import com.appcues.util.ContextResources
+import com.squareup.moshi.JsonClass
+import java.util.Date
+import java.util.UUID
+
+@JsonClass(generateAdapter = true)
+internal data class Capture(
+    val id: UUID = UUID.randomUUID(),
+    val appId: String,
+    var displayName: String,
+    val screenshotImageUrl: String?,
+    val layout: View,
+    val metadata: Metadata,
+    val timestamp: Date,
+) {
+    @JsonClass(generateAdapter = true)
+    internal data class View(
+        val id: UUID = UUID.randomUUID(),
+        val x: Float,
+        val y: Float,
+        val width: Float,
+        val height: Float,
+        val type: String,
+        val selector: ElementSelector?,
+        val children: List<View>?,
+    )
+
+    @JsonClass(generateAdapter = true)
+    internal data class Metadata(
+        val appName: String,
+        val appBuild: String,
+        val appVersion: String,
+        val deviceModel: String,
+        val deviceWidth: String,
+        val deviceHeight: String,
+        val deviceOrientation: String,
+        val deviceType: String,
+        val bundlePackageId: String,
+        val sdkVersion: String,
+        val sdkName: String,
+        val osName: String,
+        val osVersion: String,
+    )
+}
+
+internal fun ContextResources.generateCaptureMetadata(): Capture.Metadata {
+    val width = displayMetrics.widthPixels / displayMetrics.density
+    val height = displayMetrics.heightPixels / displayMetrics.density
+
+    return Capture.Metadata(
+        appName = getAppName(),
+        appBuild = getAppBuild().toString(),
+        appVersion = getAppVersion(),
+        deviceModel = getDeviceName(),
+        deviceWidth = width.toString(),
+        deviceHeight = height.toString(),
+        deviceOrientation = orientation,
+        deviceType = getString(R.string.appcues_device_type),
+        bundlePackageId = getPackageName(),
+        sdkVersion = BuildConfig.SDK_VERSION,
+        sdkName = "appcues-android",
+        osName = "android",
+        osVersion = "${VERSION.SDK_INT}",
+    )
+}
+
+// TESTING - will be removed but output layout info to log for now
+internal fun Capture.prettyPrint() {
+    val json = MoshiConfiguration.moshi.adapter(Capture::class.java).indent("    ").toJson(this)
+    Log.i("Appcues", json)
+}

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/ViewExt.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/ViewExt.kt
@@ -1,0 +1,77 @@
+package com.appcues.debugger.screencapture
+
+import android.graphics.Rect
+import android.text.format.DateFormat
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.children
+import com.appcues.R
+import com.appcues.monitor.AppcuesActivityMonitor
+import com.appcues.ui.ElementSelector
+import java.util.Date
+
+internal fun View.screenCaptureDisplayName(timestamp: Date): String {
+    var name = ""
+    val activity = AppcuesActivityMonitor.activity
+    if (activity != null) {
+        name = activity.javaClass.simpleName
+        if (name != "Activity") {
+            name = name.replace("Activity", "")
+        }
+    } else {
+        name = this.javaClass.simpleName
+    }
+    return "$name (${DateFormat.format("yyyy-MM-dd_HH:mm:ss", timestamp)})"
+}
+
+internal fun View.asCaptureView(): Capture.View? {
+    val displayMetrics = context.resources.displayMetrics
+    val density = displayMetrics.density
+
+    // this is the position of the view relative to the entire screen
+    val actualPosition = Rect()
+    getGlobalVisibleRect(actualPosition)
+
+    // the bounds of the screen
+    val screenRect = Rect(0, 0, displayMetrics.widthPixels, displayMetrics.heightPixels)
+
+    // if the view is not currently in the screenshot image (scrolled away), ignore
+    if (!actualPosition.intersect(screenRect)) {
+        return null
+    }
+
+    // ignore the Appcues SDK content that has been injected into the view hierarchy
+    if (this.id == R.id.appcues_debugger_view) {
+        return null
+    }
+
+    var children = (this as? ViewGroup)?.children?.mapNotNull {
+        if (!it.isShown) {
+            // discard hidden views and subviews within
+            null
+        } else {
+            it.asCaptureView()
+        }
+    }?.toList()
+
+    if (children?.isEmpty() == true) {
+        children = null
+    }
+
+    val selector = ElementSelector(
+        id = null, // for manual tagging
+        accessibilityIdentifier = null, // not valid on android
+        description = this.contentDescription?.toString(),
+        tag = tag?.toString()
+    )
+
+    return Capture.View(
+        x = actualPosition.left / density,
+        y = actualPosition.top / density,
+        width = actualPosition.width() / density,
+        height = actualPosition.height() / density,
+        selector = if (selector.isValid) selector else null,
+        type = this.javaClass.name,
+        children = children,
+    )
+}

--- a/appcues/src/main/java/com/appcues/ui/ElementSelector.kt
+++ b/appcues/src/main/java/com/appcues/ui/ElementSelector.kt
@@ -1,0 +1,14 @@
+package com.appcues.ui
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class ElementSelector(
+    val accessibilityIdentifier: String? = null,
+    val description: String? = null,
+    val tag: String? = null,
+    val id: String? = null,
+) {
+    val isValid: Boolean
+        get() = accessibilityIdentifier != null || description != null || tag != null || id != null
+}

--- a/appcues/src/main/java/com/appcues/util/ContextResources.kt
+++ b/appcues/src/main/java/com/appcues/util/ContextResources.kt
@@ -1,9 +1,11 @@
 package com.appcues.util
 
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
+import android.util.DisplayMetrics
 import android.webkit.WebView
 import androidx.annotation.StringRes
 import kotlinx.coroutines.Dispatchers
@@ -14,6 +16,12 @@ import java.util.Locale
 // supposed to be tied to android context, this is helpful to keep
 // any class clean of Android references, which makes it easier to unit test later
 internal class ContextResources(private val context: Context) {
+
+    val displayMetrics: DisplayMetrics
+        get() = context.resources.displayMetrics
+
+    val orientation: String
+        get() = if (context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) "landscape" else "portrait"
 
     fun getString(@StringRes id: Int): String {
         return context.getString(id)


### PR DESCRIPTION
The only thing using this right now is the FAB tap action from the deep link to /sdk/capture_screen. This matches the model used on the iOS side and defined in the spec for platform. Initially just filling out the Android View hierarchy and device metadata and printing to the log for review.

Next steps will be to handle the screenshot portion, the confirmation dialog, and eventually the integration with the API.

Also want to take another pass and look into the Compose hierarchy capture capabilities, specifically researching how it is done in https://github.com/google/talkback.