### PR TITLE
✨ Added property blurRadius for keyhole trait

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
@@ -1,5 +1,6 @@
 package com.appcues.trait.appcues
 
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.EaseIn
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.EaseOut
@@ -10,23 +11,22 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.ClipOp
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.addOutline
-import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfig
-import com.appcues.data.model.getConfigInt
 import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.appcues.BackdropKeyholeTrait.ConfigShape.CIRCLE
 import com.appcues.trait.appcues.BackdropKeyholeTrait.ConfigShape.RECTANGLE
@@ -59,83 +59,89 @@ internal class BackdropKeyholeTrait(
 
     private val shape = when (config.getConfig<String>("shape")) {
         "circle" -> CIRCLE
+        "rectangle" -> RECTANGLE
         else -> RECTANGLE
     }
 
-    private val configCornerRadius = config.getConfigInt("cornerRadius") ?: 0
+    private val configCornerRadius = config.getConfig<Double>("cornerRadius") ?: 0.0
 
-    private val spreadRadius = config.getConfigInt("spreadRadius") ?: 0
+    private val configSpreadRadius = config.getConfig<Double>("spreadRadius") ?: 0.0
 
-    private val blurRadius = config.getConfigInt("blurRadius") ?: 0
+    private val configBlurRadius = config.getConfig<Double>("blurRadius") ?: 0.0
 
     @Composable
     override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
         val density = LocalDensity.current
         val metadata = LocalAppcuesStepMetadata.current
 
-        val actualRect = rememberMetadataRect(metadata)
-        //        val actualBackground = rememberBackgroundColor(metadata)
-        val animation = rememberMetadataAnimation(metadata)
+        val shapeBlurRadius = if (shape == CIRCLE) configBlurRadius.toFloat() else 0.0f
+        val rect = rememberMetadataRect(metadata, configSpreadRadius.toFloat())
+        val floatAnimation = rememberMetadataFloatAnimation(metadata)
+        val encompassesDiameter = getRectEncompassesRadius(rect.width, rect.height, shapeBlurRadius) * 2
 
-        val rectEncompassRadius = getRectEncompassesRadius(actualRect.width, actualRect.height)
-        val circleSize = (rectEncompassRadius + blurRadius) * 2
-        val circleEncompassXOffset = (circleSize - actualRect.width) / 2
-        val circleEncompassYOffset = (circleSize - actualRect.height) / 2
-        val xPosition = animateFloatAsState(
-            targetValue = if (shape == RECTANGLE) actualRect.left else actualRect.left - circleEncompassXOffset,
-            animationSpec = animation
-        )
-        val yPosition = animateFloatAsState(
-            targetValue = if (shape == RECTANGLE) actualRect.top else actualRect.top - circleEncompassYOffset,
-            animationSpec = animation
-        )
-        val width = animateFloatAsState(if (shape == RECTANGLE) actualRect.width else circleSize, animationSpec = animation)
-        val height = animateFloatAsState(if (shape == RECTANGLE) actualRect.height else circleSize, animationSpec = animation)
-        val cornerRadius =
-            animateFloatAsState(getCornerRadius(actualRect.width, actualRect.height, blurRadius.toFloat()), animationSpec = animation)
+        // animated values
+        val xPosition = animateXPositionAsState(rect, encompassesDiameter, floatAnimation)
+        val yPosition = animateYPositionAsState(rect, encompassesDiameter, floatAnimation)
+        val width = animateFloatAsState(if (shape == RECTANGLE) rect.width else encompassesDiameter, floatAnimation)
+        val height = animateFloatAsState(if (shape == RECTANGLE) rect.height else encompassesDiameter, floatAnimation)
+        val cornerRadius = animateFloatAsState(getCornerRadius(rect.width, rect.height, shapeBlurRadius), floatAnimation)
+        val blurRadius = animateFloatAsState(shapeBlurRadius, floatAnimation)
+        val encompassesRadiusPx = animateFloatAsState(with(density) { encompassesDiameter.dp.toPx() / 2 }, floatAnimation)
+
+        // pixel values
+        val sizePx = with(density) { Size(width.value.dp.toPx(), height.value.dp.toPx()) }
+        val positionPx = with(density) { Offset(xPosition.value.dp.toPx(), yPosition.value.dp.toPx()) }
+        val blurRadiusPx = with(density) { blurRadius.value.dp.toPx() }
+        val rectCornerRadius = with(density) { CornerRadius(cornerRadius.value.dp.toPx()) }
 
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                // draw the desired shape as a clipPath
                 .drawWithContent {
-                    val size = with(density) { Size(width.value.dp.toPx(), height.value.dp.toPx()) }
-                    val position = with(density) { Offset(xPosition.value.dp.toPx(), yPosition.value.dp.toPx()) }
-                    clipPath(
-                        path = Path().apply {
-                            addOutline(
-                                RoundedCornerShape(cornerRadius.value.dp)
-                                    .createOutline(size, layoutDirection, density)
-                            )
-                            translate(position)
-                        },
-                        clipOp = ClipOp.Difference,
-                    ) {
-                        this@drawWithContent.drawContent()
-                    }
+                    drawContent()
 
-                    //                    if (shape == CIRCLE && blurRadius > 0) {
-                    //                        // TODO work on blurRadius .
-                    //                        drawOval(
-                    //                            brush = Brush.radialGradient(
-                    //                                center = Offset(position.x + size.width / 2, position.y + size.height / 2),
-                    //                                radius = size.width / 2,
-                    //                                colors = listOf(Color(0x00000000), actualBackground),
-                    //                                tileMode = TileMode.Decal
-                    //                            ),
-                    //                            topLeft = position,
-                    //                            size = size
-                    //                        )
-                    //                    }
+                    val shapeCenter = Offset(positionPx.x + sizePx.width / 2, positionPx.y + sizePx.height / 2)
+                    val blurStartPoint = ((sizePx.width / 2) - blurRadiusPx) / (sizePx.width / 2)
+
+                    drawRoundRect(
+                        topLeft = positionPx,
+                        brush = Brush.radialGradient(
+                            colorStops = arrayOf(blurStartPoint to Color.Transparent, 1.0f to Color.Black),
+                            center = shapeCenter,
+                            radius = encompassesRadiusPx.value
+                        ),
+                        size = sizePx,
+                        cornerRadius = rectCornerRadius,
+                        blendMode = BlendMode.DstIn
+                    )
                 }
-
         ) {
             content()
         }
     }
 
     @Composable
-    private fun rememberMetadataRect(metadata: AppcuesStepMetadata): Rect {
+    private fun animateXPositionAsState(rect: Rect, encompassesDiameter: Float, animationSpec: AnimationSpec<Float>): State<Float> {
+        val circleXOffset = (encompassesDiameter - rect.width) / 2
+
+        return animateFloatAsState(
+            targetValue = if (shape == RECTANGLE) rect.left else rect.left - circleXOffset,
+            animationSpec = animationSpec
+        )
+    }
+
+    @Composable
+    private fun animateYPositionAsState(rect: Rect, encompassesDiameter: Float, animationSpec: AnimationSpec<Float>): State<Float> {
+        val circleYOffset = (encompassesDiameter - rect.height) / 2
+
+        return animateFloatAsState(
+            targetValue = if (shape == RECTANGLE) rect.top else rect.top - circleYOffset,
+            animationSpec = animationSpec
+        )
+    }
+
+    @Composable
+    private fun rememberMetadataRect(metadata: AppcuesStepMetadata, spreadRadius: Float): Rect {
         val windowInfo = rememberAppcuesWindowInfo()
         return remember(metadata) {
             val rectInfo = (metadata.actual[TARGET_RECTANGLE_METADATA] as TargetRectangleInfo?) ?: TargetRectangleInfo()
@@ -155,21 +161,9 @@ internal class BackdropKeyholeTrait(
         }
     }
 
-    //    @Composable
-    //    private fun rememberBackgroundColor(metadata: AppcuesStepMetadata): Color {
-    //        val isDark = isSystemInDarkTheme()
-    //
-    //        val componentColor = (metadata.actual[BackdropTrait.METADATA_BACKGROUND_COLOR] as ComponentColor?)
-    //
-    //        return animateColorAsState(
-    //            targetValue = componentColor.getColor(isDark) ?: Color.Transparent,
-    //            animationSpec = tween(2000)
-    //        ).value
-    //    }
-
     @Composable
-    private fun rememberMetadataAnimation(metadata: AppcuesStepMetadata): TweenSpec<Float> {
-        val animation = remember<TweenSpec<Float>>(metadata) {
+    private fun rememberMetadataFloatAnimation(metadata: AppcuesStepMetadata): TweenSpec<Float> {
+        return remember(metadata) {
             val duration = (metadata.actual[StepAnimationTrait.METADATA_ANIMATION_DURATION] as Int?) ?: StepAnimationTrait.DEFAULT_ANIMATION
             when ((metadata.actual[StepAnimationTrait.METADATA_ANIMATION_EASING] as StepAnimationEasing?)) {
                 LINEAR -> tween(durationMillis = duration, easing = LinearEasing)
@@ -180,21 +174,18 @@ internal class BackdropKeyholeTrait(
                 null -> tween(durationMillis = 0, easing = LinearEasing)
             }
         }
-        return animation
     }
 
     private fun getCornerRadius(width: Float, height: Float, blurRadius: Float): Float {
         return when (shape) {
             RECTANGLE -> configCornerRadius.toFloat()
-            CIRCLE -> {
-                (getRectEncompassesRadius(width, height) + blurRadius)
-                    // calculate Radius that encompasses the rect
-                    .let { ((it * Math.PI) / 2).toFloat() }
-            }
+            CIRCLE -> (getRectEncompassesRadius(width, height, blurRadius))
+                // calculate Radius that encompasses the rect
+                .let { ((it * Math.PI) / 2).toFloat() }
         }
     }
 
-    private fun getRectEncompassesRadius(width: Float, height: Float): Float {
-        return max((sqrt(width.pow(2) + height.pow(2)) / 2), 0f)
+    private fun getRectEncompassesRadius(width: Float, height: Float, blurRadius: Float): Float {
+        return max((sqrt(width.pow(2) + height.pow(2)) / 2) + blurRadius, 0f)
     }
 }


### PR DESCRIPTION
Added support for blurRadius to keyhole trait.

Refactored some of backdrop trait too since both use similar code, wanted both traits to look as close as possible.
The current approach is move advanced now using BlenderModes instead of clipping the shape and adding the radius on top of it. 


https://user-images.githubusercontent.com/5244805/217609963-b33a39ab-2c05-499d-beda-7b2fc7704faf.mov

