### PR TITLE
Update handling of sticky content for single primitive case

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/step/StepMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/StepMapper.kt
@@ -43,10 +43,14 @@ internal class StepMapper(
     }
 }
 
-// if one or more sticky content items exist, wrap them in a vertical stack that will then be applied as overlay content
+// if a single sticky item, return as-is
+// if multiple sticky items, wrap them in a vertical stack
 private fun List<PrimitiveResponse>.toWrappedStickyContent(): ExperiencePrimitive? {
-    if (isEmpty()) return null
-    return VerticalStackPrimitive(UUID.randomUUID(), items = this.map { it.mapPrimitive() })
+    return when {
+        this.count() == 1 -> this.first().mapPrimitive()
+        this.count() > 1 -> VerticalStackPrimitive(UUID.randomUUID(), items = this.map { it.mapPrimitive() })
+        else -> null
+    }
 }
 
 // This function recursively walks through the content and extracts any items that were meant to be sticky content - pinned

--- a/appcues/src/test/java/com/appcues/data/mapper/step/StepMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/StepMapperTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import com.appcues.data.mapper.LeveledTraitResponse
 import com.appcues.data.mapper.trait.TraitsMapper
+import com.appcues.data.model.ExperiencePrimitive.HorizontalStackPrimitive
 import com.appcues.data.model.ExperiencePrimitive.VerticalStackPrimitive
 import com.appcues.data.remote.response.step.StepResponse
 import com.appcues.data.remote.response.step.primitive.PrimitiveResponse.BoxPrimitiveResponse
@@ -42,13 +43,15 @@ class StepMapperTest {
         with(step) {
             assertThat(topStickyContent).isNotNull()
             assertThat(bottomStickyContent).isNotNull()
+            // this one is vstack since it had multiple items that get combined
             assertThat(topStickyContent).isInstanceOf(VerticalStackPrimitive::class.java)
-            assertThat(bottomStickyContent).isInstanceOf(VerticalStackPrimitive::class.java)
+            // this one is hstack since it was a single item pulled out directly
+            assertThat(bottomStickyContent).isInstanceOf(HorizontalStackPrimitive::class.java)
             val topStack = topStickyContent as VerticalStackPrimitive
-            val bottomStack = bottomStickyContent as VerticalStackPrimitive
+            val bottomStack = bottomStickyContent as HorizontalStackPrimitive
             assertThat(topStack.items[0].id).isEqualTo(topItem1)
             assertThat(topStack.items[1].id).isEqualTo(topItem2)
-            assertThat(bottomStack.items[0].id).isEqualTo(bottomItem1)
+            assertThat(bottomStack.id).isEqualTo(bottomItem1)
         }
     }
 


### PR DESCRIPTION
targeting `release/1.3.0`

This is a minor update to match the iOS logic as discussed here https://github.com/appcues/appcues-ios-sdk/pull/334#discussion_r1100164652

If the sticky content is a single item (typically a single horizontal stack), then we do not need to wrap that in another vertical stack - just position that horizontal stack directly as the sticky content.  If there are more than one sticky items defined for an edge, then wrap them in the vertical stack as we had before.