### PR TITLE
✨ Include Source and Javadoc with library .aar

### DIFF
--- a/appcues/artifacts-android.gradle
+++ b/appcues/artifacts-android.gradle
@@ -1,0 +1,25 @@
+task sourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
+task javadoc(type: Javadoc) {
+    configurations.implementation.setCanBeResolved(true)
+
+    failOnError false
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.implementation
+}
+
+// build a jar with javadoc
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+}
+
+// Attach Javadocs and Sources jar
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
+apply from: 'artifacts-android.gradle'
 apply from: 'publish-maven.gradle'
 apply from: 'copy-dependencies.gradle'
 apply from: 'codecov.gradle'

--- a/appcues/publish-maven.gradle
+++ b/appcues/publish-maven.gradle
@@ -49,6 +49,9 @@ afterEvaluate {
                 artifactId = appcuesProperties.getProperty("ARTIFACT_ID")
                 version = versionName
 
+                artifact sourcesJar
+                artifact javadocJar
+
                 pom {
                     name = appcuesProperties.getProperty("NAME")
                     description = appcuesProperties.getProperty("DESCRIPTION")


### PR DESCRIPTION
`targeting release 1.3.0`
With this change customers can access the source and javadoc through the Android Studio.