### PR TITLE
Add support for Authorization header on API requests

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -30,6 +30,12 @@ android {
         testApplicationId = "com.appcues.test"
 
         consumerProguardFiles "consumer-rules.pro"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
+            }
+        }
     }
 
     resourcePrefix 'appcues_'

--- a/appcues/schemas/com.appcues.data.local.room.AppcuesDatabase/1.json
+++ b/appcues/schemas/com.appcues.data.local.room.AppcuesDatabase/1.json
@@ -1,0 +1,58 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "a0ebeca2cdf828c99a581c5c93d36fd6",
+    "entities": [
+      {
+        "tableName": "ActivityStorage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`requestId` BLOB NOT NULL, `accountId` TEXT NOT NULL, `userId` TEXT NOT NULL, `data` TEXT NOT NULL, `created` INTEGER NOT NULL, PRIMARY KEY(`requestId`))",
+        "fields": [
+          {
+            "fieldPath": "requestId",
+            "columnName": "requestId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "requestId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a0ebeca2cdf828c99a581c5c93d36fd6')"
+    ]
+  }
+}

--- a/appcues/schemas/com.appcues.data.local.room.AppcuesDatabase/2.json
+++ b/appcues/schemas/com.appcues.data.local.room.AppcuesDatabase/2.json
@@ -1,0 +1,64 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "d786b056672ba83833f4961141f367fc",
+    "entities": [
+      {
+        "tableName": "ActivityStorage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`requestId` BLOB NOT NULL, `accountId` TEXT NOT NULL, `userId` TEXT NOT NULL, `data` TEXT NOT NULL, `userSignature` TEXT, `created` INTEGER NOT NULL, PRIMARY KEY(`requestId`))",
+        "fields": [
+          {
+            "fieldPath": "requestId",
+            "columnName": "requestId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSignature",
+            "columnName": "userSignature",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "requestId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd786b056672ba83833f4961141f367fc')"
+    ]
+  }
+}

--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -148,6 +148,7 @@ class Appcues internal constructor(koinScope: Scope) {
     fun reset() {
         sessionMonitor.reset()
         storage.userId = ""
+        storage.userSignature = null
         storage.isAnonymous = true
         storage.groupId = null
     }
@@ -259,9 +260,11 @@ class Appcues internal constructor(koinScope: Scope) {
             return
         }
 
+        val mutableProperties = properties?.toMutableMap()
         val userChanged = storage.userId != userId
         storage.userId = userId
         storage.isAnonymous = isAnonymous
+        storage.userSignature = mutableProperties?.remove("appcues:user_id_signature") as? String
         if (userChanged) {
             // when the identified user changes from last known value, we must start a new session
             sessionMonitor.start()
@@ -270,6 +273,6 @@ class Appcues internal constructor(koinScope: Scope) {
             storage.groupId = null
         }
 
-        analyticsTracker.identify(properties)
+        analyticsTracker.identify(mutableProperties)
     }
 }

--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -106,6 +106,9 @@ class Appcues internal constructor(koinScope: Scope) {
     /**
      * Identify the user and determine if they should see Appcues content.
      *
+     * To authenticate requests for this user, provide the Base64 encoded signature
+     * for this user as a `String` value for key "appcues:user_id_signature", in the `properties` provided.
+     *
      * @param userId Unique value identifying the user.
      * @param properties Optional properties that provide additional context about the user.
      */

--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -37,7 +37,8 @@ internal object AppcuesKoin : KoinScopePlugin {
                 appcuesLocalSource = get(),
                 experienceMapper = get(),
                 config = get(),
-                logcues = get()
+                logcues = get(),
+                storage = get(),
             )
         }
         scoped { LinkOpener(get()) }

--- a/appcues/src/main/java/com/appcues/Storage.kt
+++ b/appcues/src/main/java/com/appcues/Storage.kt
@@ -16,7 +16,8 @@ internal class Storage(
         UserId("appcues.userId"),
         GroupId("appcues.groupId"),
         IsAnonymous("appcues.isAnonymous"),
-        LastContentShownAt("appcues.lastContentShownAt")
+        LastContentShownAt("appcues.lastContentShownAt"),
+        UserSignature("appcues.userSignature"),
     }
 
     private val sharedPreferences: SharedPreferences = allowReads {
@@ -49,6 +50,10 @@ internal class Storage(
             null -> sharedPreferences.edit().remove(Constants.LastContentShownAt.rawVal).apply()
             else -> sharedPreferences.edit().putLong(Constants.LastContentShownAt.rawVal, value.time).apply()
         }
+
+    var userSignature: String?
+        get() = allowReads { sharedPreferences.getString(Constants.UserSignature.rawVal, null) }
+        set(value) = sharedPreferences.edit().putString(Constants.UserSignature.rawVal, value).apply()
 
     init {
         if (deviceId.isEmpty()) {

--- a/appcues/src/main/java/com/appcues/analytics/ActivityRequestBuilder.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ActivityRequestBuilder.kt
@@ -22,7 +22,8 @@ internal class ActivityRequestBuilder(
             userId = storage.userId,
             accountId = config.accountId,
             groupId = storage.groupId,
-            profileUpdate = properties?.toMutableMap()
+            profileUpdate = properties?.toMutableMap(),
+            userSignature = storage.userSignature,
         )
     )
 
@@ -30,7 +31,8 @@ internal class ActivityRequestBuilder(
         userId = storage.userId,
         accountId = config.accountId,
         groupId = storage.groupId,
-        groupUpdate = properties // no auto-properties on group calls
+        groupUpdate = properties, // no auto-properties on group calls
+        userSignature = storage.userSignature,
     )
 
     fun track(name: String, properties: Map<String, Any>? = null): ActivityRequest {
@@ -45,7 +47,8 @@ internal class ActivityRequestBuilder(
             profileUpdate = decorator.autoProperties.toMutableMap(),
             accountId = config.accountId,
             groupId = storage.groupId,
-            events = listOf(trackEvent)
+            events = listOf(trackEvent),
+            userSignature = storage.userSignature,
         )
     }
 
@@ -66,7 +69,8 @@ internal class ActivityRequestBuilder(
             profileUpdate = decorator.autoProperties.toMutableMap(),
             accountId = config.accountId,
             groupId = storage.groupId,
-            events = listOf(screenEvent)
+            events = listOf(screenEvent),
+            userSignature = storage.userSignature,
         )
     }
 }

--- a/appcues/src/main/java/com/appcues/data/local/model/ActivityStorage.kt
+++ b/appcues/src/main/java/com/appcues/data/local/model/ActivityStorage.kt
@@ -11,5 +11,6 @@ internal data class ActivityStorage(
     val accountId: String,
     val userId: String,
     val data: String,
+    val userSignature: String?,
     val created: Date = Date(),
 )

--- a/appcues/src/main/java/com/appcues/data/local/room/AppcuesDatabase.kt
+++ b/appcues/src/main/java/com/appcues/data/local/room/AppcuesDatabase.kt
@@ -1,11 +1,18 @@
 package com.appcues.data.local.room
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.appcues.data.local.model.ActivityStorage
 
-@Database(entities = [ActivityStorage::class], version = 1, exportSchema = false)
+@Database(
+    entities = [ActivityStorage::class],
+    version = 2,
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2)
+    ]
+)
 @TypeConverters(DateConverter::class)
 internal abstract class AppcuesDatabase : RoomDatabase() {
     abstract fun activityStorageDao(): ActivityStorageDao

--- a/appcues/src/main/java/com/appcues/data/remote/AppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/AppcuesRemoteSource.kt
@@ -7,9 +7,28 @@ import com.appcues.util.ResultOf
 import java.util.UUID
 
 internal interface AppcuesRemoteSource {
-    suspend fun getExperienceContent(experienceId: String): ResultOf<ExperienceResponse, RemoteError>
-    suspend fun getExperiencePreview(experienceId: String): ResultOf<ExperienceResponse, RemoteError>
-    suspend fun postActivity(userId: String, activityJson: String): ResultOf<ActivityResponse, RemoteError>
-    suspend fun qualify(userId: String, requestId: UUID, activityJson: String): ResultOf<QualifyResponse, RemoteError>
+    suspend fun getExperienceContent(
+        experienceId: String,
+        userSignature: String?,
+    ): ResultOf<ExperienceResponse, RemoteError>
+
+    suspend fun getExperiencePreview(
+        experienceId: String,
+        userSignature: String?
+    ): ResultOf<ExperienceResponse, RemoteError>
+
+    suspend fun postActivity(
+        userId: String,
+        userSignature: String?,
+        activityJson: String
+    ): ResultOf<ActivityResponse, RemoteError>
+
+    suspend fun qualify(
+        userId: String,
+        userSignature: String?,
+        requestId: UUID,
+        activityJson: String,
+    ): ResultOf<QualifyResponse, RemoteError>
+
     suspend fun checkAppcuesConnection(): Boolean
 }

--- a/appcues/src/main/java/com/appcues/data/remote/request/ActivityRequest.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/request/ActivityRequest.kt
@@ -24,4 +24,6 @@ internal data class ActivityRequest(
     val groupUpdate: Map<String, Any>? = null,
     @Json(ignore = true)
     val timestamp: Date = Date(),
+    @Transient
+    val userSignature: String? = null,
 )

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/AppcuesService.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/AppcuesService.kt
@@ -51,7 +51,6 @@ internal interface AppcuesService {
     suspend fun experiencePreview(
         @Path("account") account: String,
         @Path("experienceId") experienceId: String,
-        @Header("Authorization") authorization: String?,
     ): ExperienceResponse
 
     @GET("healthz")

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/AppcuesService.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/AppcuesService.kt
@@ -18,6 +18,7 @@ internal interface AppcuesService {
     suspend fun activity(
         @Path("account") account: String,
         @Path("user") user: String,
+        @Header("Authorization") authorization: String?,
         @Body activity: RequestBody
     ): ActivityResponse
 
@@ -25,6 +26,7 @@ internal interface AppcuesService {
     suspend fun qualify(
         @Path("account") account: String,
         @Path("user") user: String,
+        @Header("Authorization") authorization: String?,
         @Header("appcues-request-id") requestId: UUID,
         @Body activity: RequestBody
     ): QualifyResponse
@@ -34,6 +36,7 @@ internal interface AppcuesService {
         @Path("account") account: String,
         @Path("user") user: String,
         @Path("experienceId") experienceId: String,
+        @Header("Authorization") authorization: String?,
     ): ExperienceResponse
 
     @GET("v1/accounts/{account}/users/{user}/experience_preview/{experienceId}")
@@ -41,12 +44,14 @@ internal interface AppcuesService {
         @Path("account") account: String,
         @Path("user") user: String,
         @Path("experienceId") experienceId: String,
+        @Header("Authorization") authorization: String?,
     ): ExperienceResponse
 
     @GET("v1/accounts/{account}/experience_preview/{experienceId}")
     suspend fun experiencePreview(
         @Path("account") account: String,
         @Path("experienceId") experienceId: String,
+        @Header("Authorization") authorization: String?,
     ): ExperienceResponse
 
     @GET("healthz")

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSource.kt
@@ -23,12 +23,18 @@ internal class RetrofitAppcuesRemoteSource(
     private val sessionMonitor: SessionMonitor,
 ) : AppcuesRemoteSource {
 
-    override suspend fun getExperienceContent(experienceId: String): ResultOf<ExperienceResponse, RemoteError> =
+    override suspend fun getExperienceContent(
+        experienceId: String,
+        userSignature: String?,
+    ): ResultOf<ExperienceResponse, RemoteError> =
         request {
-            appcuesService.experienceContent(accountId, storage.userId, experienceId)
+            appcuesService.experienceContent(accountId, storage.userId, experienceId, userSignature?.let { "Bearer $it" })
         }
 
-    override suspend fun getExperiencePreview(experienceId: String): ResultOf<ExperienceResponse, RemoteError> =
+    override suspend fun getExperiencePreview(
+        experienceId: String,
+        userSignature: String?,
+    ): ResultOf<ExperienceResponse, RemoteError> =
         // preview _can_ be personalized, so attempt to use the user info, if a valid session exists
         if (sessionMonitor.isActive) {
             request {
@@ -36,25 +42,36 @@ internal class RetrofitAppcuesRemoteSource(
             }
         } else {
             request {
-                appcuesService.experiencePreview(accountId, experienceId)
+                appcuesService.experiencePreview(accountId, experienceId, userSignature?.let { "Bearer $it" })
             }
         }
 
-    override suspend fun postActivity(userId: String, activityJson: String): ResultOf<ActivityResponse, RemoteError> =
+    override suspend fun postActivity(
+        userId: String,
+        userSignature: String?,
+        activityJson: String,
+    ): ResultOf<ActivityResponse, RemoteError> =
         request {
             appcuesService.activity(
                 account = accountId,
                 user = userId,
+                authorization = userSignature?.let { "Bearer $it" },
                 activity = activityJson.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
             )
         }
 
-    override suspend fun qualify(userId: String, requestId: UUID, activityJson: String): ResultOf<QualifyResponse, RemoteError> =
+    override suspend fun qualify(
+        userId: String,
+        userSignature: String?,
+        requestId: UUID,
+        activityJson: String,
+    ): ResultOf<QualifyResponse, RemoteError> =
         request {
             appcuesService.qualify(
                 account = accountId,
                 user = userId,
                 requestId = requestId,
+                authorization = userSignature?.let { "Bearer $it" },
                 activity = activityJson.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
             )
         }

--- a/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSource.kt
@@ -38,11 +38,11 @@ internal class RetrofitAppcuesRemoteSource(
         // preview _can_ be personalized, so attempt to use the user info, if a valid session exists
         if (sessionMonitor.isActive) {
             request {
-                appcuesService.experiencePreview(accountId, storage.userId, experienceId)
+                appcuesService.experiencePreview(accountId, storage.userId, experienceId, userSignature?.let { "Bearer $it" })
             }
         } else {
             request {
-                appcuesService.experiencePreview(accountId, experienceId, userSignature?.let { "Bearer $it" })
+                appcuesService.experiencePreview(accountId, experienceId)
             }
         }
 

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -79,6 +79,34 @@ internal class AppcuesTest : AppcuesScopeTest {
     }
 
     @Test
+    fun `identify SHOULD update Storage WHEN user signature provided`() {
+        // GIVEN
+        val userId = "default-0000"
+        val properties = mapOf<String, Any>("appcues:user_id_signature" to "user-signature")
+        val storage: Storage = get()
+
+        // WHEN
+        appcues.identify(userId, properties)
+
+        // THEN
+        assertThat(storage.userSignature).isEqualTo("user-signature")
+    }
+
+    @Test
+    fun `identify SHOULD set user signature to null in Storage WHEN no user signature provided`() {
+        // GIVEN
+        val userId = "default-0000"
+        val properties = mapOf<String, Any>("foo" to 123)
+        val storage: Storage = get()
+
+        // WHEN
+        appcues.identify(userId, properties)
+
+        // THEN
+        assertThat(storage.userSignature).isNull()
+    }
+
+    @Test
     fun `track event SHOULD call AnalyticsTracker track function`() {
         // GIVEN
         val eventName = "test_event"
@@ -158,6 +186,21 @@ internal class AppcuesTest : AppcuesScopeTest {
             sessionMonitor.reset()
             storage.userId = ""
         }
+    }
+
+    @Test
+    fun `reset SHOULD clear user signature`() {
+        // GIVEN
+        val userId = "default-0000"
+        val properties = mapOf<String, Any>("appcues:user_id_signature" to "user-signature")
+        val storage: Storage = get()
+
+        // WHEN
+        appcues.identify(userId, properties)
+        appcues.reset()
+
+        // THEN
+        verify { storage setProperty Storage::userSignature.name value null }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/analytics/ActivityRequestBuilderTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ActivityRequestBuilderTest.kt
@@ -23,6 +23,7 @@ class ActivityRequestBuilderTest {
     private val storage: Storage = mockk<Storage>(relaxed = true).apply {
         every { userId } returns "userId"
         every { groupId } returns "groupId"
+        every { userSignature } returns "user-signature"
     }
 
     private val autoPropertyDecorator: AutoPropertyDecorator = mockk<AutoPropertyDecorator>().apply {
@@ -50,6 +51,7 @@ class ActivityRequestBuilderTest {
             assertThat(accountId).isEqualTo("accountId")
             assertThat(profileUpdate).hasSize(1)
             assertThat(profileUpdate).containsEntry("_test", "test")
+            assertThat(userSignature).isEqualTo("user-signature")
         }
     }
 
@@ -65,6 +67,7 @@ class ActivityRequestBuilderTest {
             assertThat(accountId).isEqualTo("accountId")
             assertThat(groupUpdate).hasSize(1)
             assertThat(groupUpdate).containsEntry("_test", "test")
+            assertThat(userSignature).isEqualTo("user-signature")
         }
     }
 
@@ -98,6 +101,7 @@ class ActivityRequestBuilderTest {
             assertThat(profileUpdate).hasSize(1)
             assertThat(profileUpdate).containsEntry("auto", "properties")
             assertThat(events).hasSize(1)
+            assertThat(userSignature).isEqualTo("user-signature")
         }
     }
 
@@ -133,6 +137,7 @@ class ActivityRequestBuilderTest {
             assertThat(profileUpdate).hasSize(1)
             assertThat(profileUpdate).containsEntry("auto", "properties")
             assertThat(events).hasSize(1)
+            assertThat(userSignature).isEqualTo("user-signature")
         }
     }
 }

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/AppcuesServiceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/AppcuesServiceTest.kt
@@ -38,6 +38,7 @@ class AppcuesServiceTest {
                 account = "1234",
                 user = "TestUser",
                 experienceId = "5678",
+                authorization = null,
             )
         }
         // Then
@@ -60,6 +61,7 @@ class AppcuesServiceTest {
             api.qualify(
                 account = "1234",
                 user = "TestUser",
+                authorization = null,
                 requestId = UUID.randomUUID(),
                 activity = "".toRequestBody(),
             )
@@ -113,8 +115,10 @@ class AppcuesServiceTest {
             with(experiences[5] as FailedExperienceResponse) {
                 assertThat(this.id.appcuesFormatted()).isEqualTo("c9c11671-f418-451e-9b4a-33d54ed5299f")
                 assertThat(this.error)
-                    .isEqualTo("Error parsing Experience JSON data: Expected STRING but was true, a java.lang.Boolean," +
-                        " at path \$.steps[0].children[0].content.id")
+                    .isEqualTo(
+                        "Error parsing Experience JSON data: Expected STRING but was true, a java.lang.Boolean," +
+                            " at path \$.steps[0].children[0].content.id"
+                    )
             }
         }
     }

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/MockWebServerExt.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/MockWebServerExt.kt
@@ -33,6 +33,24 @@ internal fun MockWebServer.dispatchResponses(responses: HashMap<String, String>)
     }
 }
 
+internal fun MockWebServer.confirmAuth(expected: String?, fileName: String) {
+    dispatcher = object : Dispatcher() {
+
+        override fun dispatch(request: RecordedRequest): MockResponse {
+            val authorization = request.headers["Authorization"]
+            // confirms that either the given signature is empty and thus no auth header, OR
+            // the signature is not empty and matches
+            if (authorization == expected) {
+                return MockResponse()
+                    .setResponseCode(200)
+                    .setBody(readJsonFromResource(fileName))
+            }
+
+            return MockResponse().setResponseCode(404)
+        }
+    }
+}
+
 private fun MockWebServer.readJsonFromResource(fileName: String): String {
     val inputStream = javaClass.classLoader?.getResourceAsStream(fileName)
 

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSourceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSourceTest.kt
@@ -1,0 +1,127 @@
+package com.appcues.data.remote.retrofit
+
+import com.appcues.SessionMonitor
+import com.appcues.Storage
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RetrofitAppcuesRemoteSourceTest {
+
+    private lateinit var storage: Storage
+    private lateinit var appcuesService: AppcuesService
+    private lateinit var sessionMonitor: SessionMonitor
+    private lateinit var retrofitAppcuesRemoteSource: RetrofitAppcuesRemoteSource
+
+    @Before
+    fun setUp() {
+        storage = mockk() {
+            every { this@mockk.userId } returns "test-user"
+        }
+        appcuesService = mockk()
+        sessionMonitor = mockk()
+        retrofitAppcuesRemoteSource = RetrofitAppcuesRemoteSource(
+            appcuesService = appcuesService,
+            accountId = "123",
+            storage = storage,
+            sessionMonitor = sessionMonitor,
+        )
+    }
+
+    @Test
+    fun `getExperienceContent SHOULD add Bearer token auth WHEN userSignature is not null`() = runTest {
+        // When
+        retrofitAppcuesRemoteSource.getExperienceContent("test-experience", "abc")
+
+        // Then
+        coVerify { appcuesService.experienceContent("123", "test-user", "test-experience", "Bearer abc") }
+    }
+
+    @Test
+    fun `getExperienceContent SHOULD NOT add Bearer token auth WHEN userSignature is null`() = runTest {
+        // When
+        retrofitAppcuesRemoteSource.getExperienceContent("test-experience", null)
+
+        // Then
+        coVerify { appcuesService.experienceContent("123", "test-user", "test-experience", null) }
+    }
+
+    @Test
+    fun `getExperiencePreview SHOULD add Bearer token auth WHEN userSignature is not null AND session is active`() = runTest {
+        // Given
+        every { sessionMonitor.isActive } returns true
+
+        // When
+        retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", "abc")
+
+        // Then
+        coVerify { appcuesService.experiencePreview("123", "test-user", "test-experience", "Bearer abc") }
+    }
+
+    @Test
+    fun `getExperiencePreview SHOULD NOT add Bearer token auth WHEN userSignature is null AND session is active`() = runTest {
+        // Given
+        every { sessionMonitor.isActive } returns true
+
+        // When
+        retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", null)
+
+        // Then
+        coVerify { appcuesService.experiencePreview("123", "test-user", "test-experience", null) }
+    }
+
+    @Test
+    fun `getExperiencePreview SHOULD NOT add Bearer token auth WHEN userSignature is not null AND session is not active`() = runTest {
+        // Given
+        every { sessionMonitor.isActive } returns false
+
+        // When
+        retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", "abc")
+
+        // Then
+        coVerify { appcuesService.experiencePreview("123", "test-experience") }
+        coVerify(exactly = 0) { appcuesService.experiencePreview("123", any(), "test-experience", "Bearer abc") }
+    }
+
+    @Test
+    fun `postActivity SHOULD add Bearer token auth WHEN userSignature is not null`() = runTest {
+        // When
+        retrofitAppcuesRemoteSource.postActivity("test-user", "abc", "")
+
+        // Then
+        coVerify { appcuesService.activity("123", "test-user", "Bearer abc", any()) }
+    }
+
+    @Test
+    fun `postActivity SHOULD NOT add Bearer token auth WHEN userSignature is null`() = runTest {
+        // When
+        retrofitAppcuesRemoteSource.postActivity("test-user", null, "")
+
+        // Then
+        coVerify { appcuesService.activity("123", "test-user", null, any()) }
+    }
+
+    @Test
+    fun `qualify SHOULD add Bearer token auth WHEN userSignature is not null`() = runTest {
+        // When
+        retrofitAppcuesRemoteSource.qualify("test-user", "abc", UUID.randomUUID(), "")
+
+        // Then
+        coVerify { appcuesService.qualify("123", "test-user", "Bearer abc", any(), any()) }
+    }
+
+    @Test
+    fun `qualify SHOULD NOT add Bearer token auth WHEN userSignature is null`() = runTest {
+        // When
+        retrofitAppcuesRemoteSource.qualify("test-user", null, UUID.randomUUID(), "")
+
+        // Then
+        coVerify { appcuesService.qualify("123", "test-user", null, any(), any()) }
+    }
+}

--- a/appcues/src/test/java/com/appcues/mocks/StorageMock.kt
+++ b/appcues/src/test/java/com/appcues/mocks/StorageMock.kt
@@ -13,6 +13,7 @@ internal fun storageMockk(): Storage = mockk(relaxed = true) {
     // https://github.com/mockk/mockk/issues/293#issuecomment-774785539
     val groupIdSlot = mutableListOf<String>()
     val isAnonymousSlot = slot<Boolean>().apply { captured = true }
+    val userSignatureSlot = mutableListOf<String>()
     every { this@mockk.userId = capture(userIdSlot) } just runs
     every { this@mockk.userId } answers { userIdSlot.captured }
     every { this@mockk.groupId = capture(groupIdSlot) } just runs
@@ -20,4 +21,6 @@ internal fun storageMockk(): Storage = mockk(relaxed = true) {
     every { this@mockk.isAnonymous = capture(isAnonymousSlot) } just runs
     every { this@mockk.isAnonymous } answers { isAnonymousSlot.captured }
     every { this@mockk.deviceId } returns "test_device_id"
+    every { this@mockk.userSignature = capture(userSignatureSlot) } just runs
+    every { this@mockk.userSignature } answers { userSignatureSlot.firstOrNull() }
 }

--- a/appcues/src/test/resources/content/empty_qualification.json
+++ b/appcues/src/test/resources/content/empty_qualification.json
@@ -1,0 +1,4 @@
+{
+  "experiences": [],
+  "performed_qualification": false
+}


### PR DESCRIPTION
targeting `release/1.3.1` - unsure exact timing on when we need this, but sooner rather than later.

The code changes here are not actually that large, but a lot of test updates and new tests, as well as some Room DB schema files. I'll note the important parts inline.

In short, you can identify with this optional new property, supplying a token, which then gets added to the Authorization header on any requests from this user.
```
appcues.identify(userID, mapOf("appcues:user_id_signature" to base64token))
```