### PR TITLE
Use a ConcurrentHashMap for SdkMetrics

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
+++ b/appcues/src/main/java/com/appcues/analytics/SdkMetrics.kt
@@ -2,6 +2,7 @@ package com.appcues.analytics
 
 import java.util.Date
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 internal data class SdkMetrics(
     private var trackedAt: Date? = null,
@@ -13,7 +14,7 @@ internal data class SdkMetrics(
 
         const val METRICS_PROPERTY = "_sdkMetrics"
 
-        private val metrics = hashMapOf<UUID, SdkMetrics>()
+        private val metrics = ConcurrentHashMap<UUID, SdkMetrics>()
 
         fun clear() {
             metrics.clear()

--- a/appcues/src/test/java/com/appcues/analytics/SdkMetricsTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/SdkMetricsTest.kt
@@ -1,0 +1,40 @@
+package com.appcues.analytics
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.util.Date
+import java.util.UUID
+import kotlin.math.floor
+
+class SdkMetricsTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `metrics SHOULD NOT crash`() = runTest {
+
+        val ids = (0..19).map { UUID.randomUUID() }
+        val results = mutableListOf<Map<String, Any>>()
+
+        (0..99).asyncAll {
+            val index = (floor(it / 5.0)).toInt()
+            when (it % 5) {
+                0 -> SdkMetrics.tracked(ids[index], Date())
+                1 -> SdkMetrics.requested(ids[index].toString())
+                2 -> SdkMetrics.responded(ids[index].toString())
+                3 -> SdkMetrics.renderStart(ids[index])
+                else -> results.add(SdkMetrics.trackRender(ids[index]))
+            }
+        }
+
+        assertThat(results.count()).isEqualTo(20)
+    }
+
+    private suspend fun <T, V> Iterable<T>.asyncAll(coroutine: suspend (T) -> V): Iterable<V> = coroutineScope {
+        this@asyncAll.map { async { coroutine(it) } }.awaitAll()
+    }
+}


### PR DESCRIPTION
This is the one-liner change discussed when an issue arose on the iOS side with SdkMetrics and concurrent access https://github.com/appcues/appcues-ios-sdk/pull/336, [discussed here](https://appcues.slack.com/archives/C031RLGS4F8/p1676042652884329?thread_ts=1675968353.962369&cid=C031RLGS4F8)

changes
```kotlin
private val metrics = hashMapOf<UUID, SdkMetrics>()
```

to
```kotlin
private val metrics = ConcurrentHashMap<UUID, SdkMetrics>()
```

However, I was never able to see any real issue here in testing. This includes a unit test to exercise concurrent access in the same fashion that made iOS crash in some cases. This seems like perhaps a safe change without a perceived downside, but unclear if it is really needed. Going ahead and posting the work here for review/discussion.