### PR TITLE
Do not mark experience completed if dismissed on the final step

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -52,17 +52,4 @@ internal sealed class State {
             is Paused -> this.state.currentStepIndex
             is RenderingStep -> this.flatStepIndex
         }
-
-    val isOnLastStep: Boolean
-        get() {
-            val currentStepIndex = currentStepIndex
-            val stepCount = currentExperience?.flatSteps?.count()
-
-            return if (currentStepIndex != null && stepCount != null) {
-                // force it to mark complete (the last step and the experience) if on the last step
-                currentStepIndex == stepCount - 1
-            } else {
-                false
-            }
-        }
 }

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -216,7 +216,7 @@ internal class StateMachine(
 
     fun stop() {
         appcuesCoroutineScope.launch {
-            handleAction(EndExperience(markComplete = state.isOnLastStep, destroyed = true))
+            handleAction(EndExperience(markComplete = false, destroyed = true))
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -120,7 +120,7 @@ internal class ExperienceRenderer(
     }
 
     suspend fun dismissCurrentExperience(markComplete: Boolean, destroyed: Boolean): ResultOf<State, Error> =
-        stateMachine.handleAction(EndExperience(markComplete || stateMachine.state.isOnLastStep, destroyed))
+        stateMachine.handleAction(EndExperience(markComplete, destroyed))
 
     private fun Experiment.shouldExecute() =
         group != "control"

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -743,6 +743,28 @@ class StateMachineTest : AppcuesScopeTest {
         assertThat(stateMachine.state).isEqualTo(Idling)
     }
 
+    @Test
+    fun `stop SHOULD NOT mark complete WHEN on last step of experience`() = runTest {
+        // GIVEN
+        val experience = mockExperience()
+        val completion: CompletableDeferred<Boolean> = CompletableDeferred()
+        val stateMachine = initMachine(
+            state = RenderingStep(experience, 3, false),
+            onStateChange = {
+                if (it is EndingExperience) {
+                    completion.complete(it.markComplete)
+                }
+            },
+            onError = null
+        )
+
+        // WHEN
+        stateMachine.stop()
+
+        // THEN
+        assertThat(completion.await(1.seconds)).isFalse()
+    }
+
     // Helpers
     private suspend fun initMachine(
         state: State,

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -39,7 +39,7 @@ class ExperienceRendererTest {
     }
 
     @Test
-    fun `dismissCurrentExperience SHOULD mark complete WHEN current state is on last step`() = runTest {
+    fun `dismissCurrentExperience SHOULD NOT mark complete WHEN current state is on last step`() = runTest {
         // GIVEN
         val state = RenderingStep(mockExperience(), 3, false)
         val stateMachine = mockk<StateMachine>(relaxed = true) {
@@ -52,7 +52,7 @@ class ExperienceRendererTest {
         experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
 
         // THEN
-        coVerify { stateMachine.handleAction(EndExperience(markComplete = true, destroyed = false)) }
+        coVerify { stateMachine.handleAction(EndExperience(markComplete = false, destroyed = false)) }
     }
 
     @Test


### PR DESCRIPTION
target `release/1.3.1`

Requested change for parity with web, and to make our Studio analytics dashboards more comprehendible for customers. This is the same change as was applied on iOS here https://github.com/appcues/appcues-ios-sdk/pull/345.