### PR TITLE
Add anonymous user ID prefix

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -141,7 +141,7 @@ class Appcues internal constructor(koinScope: Scope) {
         // use the device ID as the default anonymous user ID, unless an override for generating
         // anonymous user IDs is supplied in the config builder
         val anonymousId = config.anonymousIdFactory?.invoke() ?: storage.deviceId
-        identify(true, anonymousId, properties)
+        identify(true, "anon:$anonymousId", properties)
     }
 
     /**

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -215,7 +215,7 @@ internal class AppcuesTest : AppcuesScopeTest {
         appcues.anonymous(properties)
 
         // THEN
-        assertThat(storage.userId).isEqualTo(storage.deviceId)
+        assertThat(storage.userId).isEqualTo("anon:${storage.deviceId}")
         assertThat(storage.isAnonymous).isTrue()
         // called once at startup automatically, which is ignored, then again for the new valid user/session
         verify(exactly = 2) { sessionMonitor.start() }
@@ -235,7 +235,7 @@ internal class AppcuesTest : AppcuesScopeTest {
 
         // THEN
         assertThat(storage.userId).isNotEqualTo(storage.deviceId)
-        assertThat(storage.userId).isEqualTo(configUserId)
+        assertThat(storage.userId).isEqualTo("anon:$configUserId")
     }
 
     @Test


### PR DESCRIPTION
targets `release/1.3.1`

Matching web SDK behavior by adding an `anon:` prefix on any anonymous user ID generated and used in the anonymous() function call. Backend services can use this convention to reliably differentiate anonymous user traffic.