### PR TITLE
Remove the properties parameter from anonymous function

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -18,6 +18,7 @@ import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
 import kotlinx.coroutines.launch
 import org.koin.core.scope.Scope
+import kotlin.DeprecationLevel.ERROR
 
 /**
  * Construct and return an instance of the Appcues SDK.
@@ -132,14 +133,22 @@ class Appcues internal constructor(koinScope: Scope) {
      * Generate a unique Id for the current user when there is not a known identity to use in
      * the {@link identity(String, Map<String, Any>) identity} call. This will cause the SDK
      * to begin tracking activity and checking for qualified content.
-     *
-     * @param properties Optional properties that provide additional context about the anonymous user.
      */
-    fun anonymous(properties: Map<String, Any>? = null) {
+    fun anonymous() {
         // use the device ID as the default anonymous user ID, unless an override for generating
         // anonymous user IDs is supplied in the config builder
         val anonymousId = config.anonymousIdFactory?.invoke() ?: storage.deviceId
-        identify(true, anonymousId, properties)
+        identify(true, anonymousId, null)
+    }
+
+    /**
+     * This function has been removed. Calling the anonymous function with a properties parameter
+     * is no longer supported. A call to `anonymous()` with no parameters should be used instead.
+     */
+    @Deprecated("properties are no longer supported for anonymous users.", level = ERROR)
+    @Suppress("UnusedPrivateMember")
+    fun anonymous(properties: Map<String, Any>?) {
+        // removed
     }
 
     /**

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -164,20 +164,19 @@ internal class AppcuesTest : AppcuesScopeTest {
     @Test
     fun `anonymous SHOULD set Storage userId equal to the deviceId AND identify AND start a session`() {
         // GIVEN
-        val properties = mapOf<String, Any>("prop" to 33)
         val storage: Storage = get()
         val tracker: AnalyticsTracker = get()
         val sessionMonitor: SessionMonitor = get()
 
         // WHEN
-        appcues.anonymous(properties)
+        appcues.anonymous()
 
         // THEN
         assertThat(storage.userId).isEqualTo(storage.deviceId)
         assertThat(storage.isAnonymous).isTrue()
         // called once at startup automatically, which is ignored, then again for the new valid user/session
         verify(exactly = 2) { sessionMonitor.start() }
-        verify { tracker.identify(properties) }
+        verify { tracker.identify(null) }
     }
 
     @Test

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -62,6 +62,6 @@ If an experience fails to show, the debugger will note it with "Content Omitted"
 
 The Recent Events section of the debugger shows the list of all events that have passed through the Appcues SDK, with the most recent events at the top of the list. The list of events can be filtered by type by selecting the Filter icon in the header row and selecting an event type.
 
-Session and Experience events are automatically tracked by the SDK. Screen (`appcues.screen(title, properties)` or `appcues.trackScreens()`), Custom (`appcues.track(name, properties)`), User Profile (`appcues.identify(userId, properties)` or `appcues.anonymous(properties)`), and Group (`appcues.group(groupId,properties)`) events are tracked by your app calling the Appcues SDK.
+Session and Experience events are automatically tracked by the SDK. Screen (`appcues.screen(title, properties)` or `appcues.trackScreens()`), Custom (`appcues.track(name, properties)`), User Profile (`appcues.identify(userId, properties)` or `appcues.anonymous()`), and Group (`appcues.group(groupId,properties)`) events are tracked by your app calling the Appcues SDK.
 
 Tap an event row to see the details of that event including all the properties associated with it.


### PR DESCRIPTION
This is a `main` / 2.0 change (breaking) - we'll no longer support `properties` passed in on `anonymous()` user calls. This is to match the web SDK and comply with data security expectations.