### PR TITLE
♻️  Ensure Tooltip view is added just after content view

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import com.appcues.R
+import com.appcues.databinding.AppcuesOverlayLayoutBinding
 import com.appcues.logging.Logcues
 import com.appcues.monitor.AppcuesActivityMonitor
 import com.appcues.monitor.AppcuesActivityMonitor.ActivityMonitorListener
@@ -77,11 +78,16 @@ class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLifecycleObse
         // if view is not there
         if (parentView.findViewById<ComposeView>(R.id.appcues_overlay_layout) == null) {
             // then we add
-            val binding = com.appcues.databinding.AppcuesOverlayLayoutBinding.inflate(layoutInflater)
+            val binding = AppcuesOverlayLayoutBinding.inflate(layoutInflater)
             if (viewModel == null) viewModel = AppcuesViewModel(scope)
             shakeGestureListener = ShakeGestureListener(this)
 
-            parentView.addView(binding.root)
+            // ensures it always comes before appcues_debugger_view
+            parentView.findViewById<ViewGroup>(R.id.appcues_debugger_view)?.let {
+                parentView.addView(binding.root, parentView.indexOfChild(it))
+            } ?: run {
+                parentView.addView(binding.root)
+            }
 
             binding.root.layoutParams =
                 android.widget.FrameLayout.LayoutParams(


### PR DESCRIPTION
very easy fix in the end but I took the time to explore different options, in the end enforcing an index was the way to go for our new tooltip view.

I also tried to reposition in other places our views but it doesnt work as well. and also its probably inconsistent between android versions/devices the structure of the decorView, the only thing we know for sure is that there is a decorView, somewhere in there we have android.R.id.content which contains the content (excluding old actionbar). so one of the takes I had was to get the its parent by calling

( findViewById(android.R.id.content).parent as ViewGroup)

and adding the view into this one. the problem is that here on my emulator this one is actually an ActionBarOverlayView which is internal to the android and position views similarly to linear layout, so even if we set the LayoutParams to Match_parent it wont take space since none is available.

good to keep in mind that whenever we add the debugger view we are just adding it, and now with this change we force this overlayed view to be put at the same index as the debugger view makes so that debugger view moves on the list and remains on top of it.

![image](https://user-images.githubusercontent.com/5244805/220767762-18acecc4-7dd0-44b7-b822-6c4c4c238cbd.png)
