### PR TITLE
Add support for token param on capture_screen deep link

### DIFF
--- a/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
@@ -55,8 +55,13 @@ internal class DeepLinkHandler(
                 true
             }
             segments.any() && segments[0] == "capture_screen" -> {
-                debuggerManager.start(activity, ScreenCapture)
-                true
+                val token = linkData.getQueryParameter("token")
+                if (token != null) {
+                    debuggerManager.start(activity, ScreenCapture(token))
+                    true
+                } else {
+                    false
+                }
             }
             else -> false
         }

--- a/appcues/src/main/java/com/appcues/debugger/DebugMode.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebugMode.kt
@@ -2,5 +2,5 @@ package com.appcues.debugger
 
 internal sealed class DebugMode {
     data class Debugger(val deepLinkPath: String?) : DebugMode()
-    object ScreenCapture : DebugMode()
+    data class ScreenCapture(val token: String) : DebugMode()
 }

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
@@ -125,7 +125,8 @@ internal class DebuggerViewModel(
                     // if no path is given, and currently expanded, go back to Idle
                     if (_uiState.value is Expanded ||
                         // OR if showing FAB but the mode changed, reset to new Idle mode
-                        (_uiState.value is Idle && reset)) {
+                        (_uiState.value is Idle && reset)
+                    ) {
                         _uiState.value = Idle(mode)
                     }
                     return
@@ -150,7 +151,8 @@ internal class DebuggerViewModel(
                 // if in debugger mode, expanded, go to new Idle state
                 if (_uiState.value is Expanded ||
                     // OR if in Idle (FAB) mode but mode changed, reset to new Idle mode
-                    (_uiState.value is Idle && reset)) {
+                    (_uiState.value is Idle && reset)
+                ) {
                     _uiState.value = Idle(mode)
                 }
             }
@@ -203,21 +205,28 @@ internal class DebuggerViewModel(
         screenCaptureProcessor.captureScreen()
 
     fun onScreenCaptureConfirm(capture: Capture) {
-        _uiState.value = Idle(ScreenCapture)
+        // return back to Idle for the current mode (ScreenCapture)
+        _uiState.value = Idle(mode)
 
-        viewModelScope.launch {
-            val result = screenCaptureProcessor.save(capture)
+        when (val currentMode = mode) {
+            // saving a capture is only valid in screen capture mode with token
+            is ScreenCapture -> {
+                viewModelScope.launch {
+                    val result = screenCaptureProcessor.save(capture, currentMode.token)
 
-            result.doIfSuccess {
-                // show success toast
+                    result.doIfSuccess {
+                        // show success toast
 
-                // TESTING!!
-                it.prettyPrint()
+                        // TESTING!!
+                        it.prettyPrint()
+                    }
+
+                    result.doIfFailure {
+                        // show failure toast
+                    }
+                }
             }
-
-            result.doIfFailure {
-                // show failure toast
-            }
+            else -> Unit
         }
     }
 

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
@@ -48,7 +48,8 @@ internal class ScreenCaptureProcessor(
         }
     }
 
-    suspend fun save(capture: Capture): ResultOf<Capture, Error> {
+    @Suppress("UnusedPrivateMember")
+    suspend fun save(capture: Capture, token: String): ResultOf<Capture, Error> {
 
         // upcoming work to execute API calls starts here
 


### PR DESCRIPTION
stacks on #340 

Small prep work for upcoming API integration - allowing a `token` query parameter on the deep link
```
appcues-{app_id}://sdk/capture_screen?token={jwt}
```

This will come from the builder QR code flow, and allow authentication for screen capture requests coming up. The updates here capture the token and pass it through to spots it will be needed.