### PR TITLE
Implement network calls to save screenshot and screen

### DIFF
--- a/appcues/src/main/java/com/appcues/data/remote/customerapi/CustomerApiRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/customerapi/CustomerApiRemoteSource.kt
@@ -25,7 +25,7 @@ internal class CustomerApiRemoteSource(
             service.preUploadScreenshot(
                 account = config.accountId,
                 application = config.applicationId,
-                name = capture.id.toString(),
+                name = "${capture.id}.png",
                 authorization = "Bearer $token"
             )
         }

--- a/appcues/src/main/java/com/appcues/data/remote/imageupload/ImageUploadRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/imageupload/ImageUploadRemoteSource.kt
@@ -1,26 +1,36 @@
 package com.appcues.data.remote.imageupload
 
+import android.graphics.Bitmap
+import android.graphics.Bitmap.CompressFormat.PNG
 import com.appcues.data.remote.NetworkRequest
 import com.appcues.data.remote.RemoteError
-import com.appcues.debugger.screencapture.Capture
 import com.appcues.util.ResultOf
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.ByteArrayOutputStream
 
 internal class ImageUploadRemoteSource(
     private val service: ImageUploadService,
 ) {
+    companion object {
+        private const val IMAGE_QUALITY = 100
+    }
+
     suspend fun upload(
         url: String,
-        capture: Capture,
+        bitmap: Bitmap,
     ): ResultOf<Unit, RemoteError> {
-
         return NetworkRequest.execute {
             service.upload(
                 url = url,
-                // still need to figure out how to actually get the PNG content of the capture for the PUT body
-                image = capture.displayName.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull()),
+                image = bitmap.toData().toRequestBody("image/png".toMediaTypeOrNull()),
             )
         }
+    }
+
+    private fun Bitmap.toData(): ByteArray {
+        val stream = ByteArrayOutputStream()
+        this.compress(PNG, IMAGE_QUALITY, stream)
+        return stream.toByteArray()
     }
 }

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerKoin.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerKoin.kt
@@ -28,7 +28,13 @@ internal object DebuggerKoin : KoinScopePlugin {
         }
 
         scoped {
-            ScreenCaptureProcessor(config = get(), contextResources = get())
+            ScreenCaptureProcessor(
+                config = get(),
+                contextResources = get(),
+                sdkSettingsRemoteSource = get(),
+                customerApiRemoteSource = get(),
+                imageUploadRemoteSource = get(),
+            )
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
@@ -216,7 +216,6 @@ internal class DebuggerViewModel(
 
                     result.doIfSuccess {
                         // show success toast
-
                         // TESTING!!
                         it.prettyPrint()
                     }

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
@@ -9,19 +9,31 @@ import android.view.ViewGroup
 import androidx.core.view.children
 import com.appcues.AppcuesConfig
 import com.appcues.R
+import com.appcues.data.remote.RemoteError
+import com.appcues.data.remote.customerapi.CustomerApiBaseUrlInterceptor
+import com.appcues.data.remote.customerapi.CustomerApiRemoteSource
+import com.appcues.data.remote.customerapi.response.PreUploadScreenshotResponse
+import com.appcues.data.remote.imageupload.ImageUploadRemoteSource
+import com.appcues.data.remote.sdksettings.SdkSettingsRemoteSource
+import com.appcues.data.remote.sdksettings.response.SdkSettingsResponse
 import com.appcues.monitor.AppcuesActivityMonitor
 import com.appcues.ui.ElementSelector
 import com.appcues.util.ContextResources
 import com.appcues.util.ResultOf
+import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.util.Date
 
 internal class ScreenCaptureProcessor(
     private val config: AppcuesConfig,
     private val contextResources: ContextResources,
+    private val sdkSettingsRemoteSource: SdkSettingsRemoteSource,
+    private val customerApiRemoteSource: CustomerApiRemoteSource,
+    private val imageUploadRemoteSource: ImageUploadRemoteSource,
 ) {
-
     fun captureScreen(): Capture? {
+
         return AppcuesActivityMonitor.activity?.window?.decorView?.rootView?.let {
             prepare(it)
 
@@ -35,7 +47,7 @@ internal class ScreenCaptureProcessor(
                     displayName = displayName,
                     screenshotImageUrl = null,
                     layout = layout,
-                    metadata = contextResources.generateCaptureMetadata(),
+                    metadata = contextResources.generateCaptureMetadata(it),
                     timestamp = timestamp,
                 ).apply {
                     this.screenshot = screenshot
@@ -48,13 +60,86 @@ internal class ScreenCaptureProcessor(
         }
     }
 
-    @Suppress("UnusedPrivateMember")
-    suspend fun save(capture: Capture, token: String): ResultOf<Capture, Error> {
+    suspend fun save(capture: Capture, token: String) =
+        // Saving a screen is a 4-step chain. This is implemented here as a sequence of calls, chaining
+        // a success continuation on each call to move to the next step. If any step fails, the RemoteError
+        // is bubbled up to the caller of this function instead of the successful result, and an error
+        // can be shown and handled.
 
-        // upcoming work to execute API calls starts here
+        // step 1 - get the settings, with the path to customer API
+        getSettings { sdkSettings ->
 
-        return Success(capture)
+            // step 2 - use the customer API path to get the link to upload the screenshot
+            CustomerApiBaseUrlInterceptor.baseUrl = sdkSettings.services.customerApi.toHttpUrl()
+            getUploadPath(capture, token) { preUpload ->
+
+                // step 3 - upload the screenshot
+                uploadImage(preUpload.upload.presignedUrl, capture) {
+
+                    // step 4 - update the screenshot link and save the screen
+                    val updatedCapture = capture.copy(screenshotImageUrl = preUpload.url)
+                    saveScreen(updatedCapture, token)
+                }
+            }
+        }
+
+    // step 1 - get the settings, with the path to customer API
+    private suspend fun getSettings(
+        onSuccess: suspend (SdkSettingsResponse) -> ResultOf<Capture, RemoteError>
+    ): ResultOf<Capture, RemoteError> {
+        return when (val settingsResponse = sdkSettingsRemoteSource.sdkSettings()) {
+            is Failure -> settingsResponse
+            is Success -> {
+                onSuccess(settingsResponse.value)
+            }
+        }
     }
+
+    // step 2 - use the customer API path to get the link to upload the screenshot
+    private suspend fun getUploadPath(
+        capture: Capture,
+        token: String,
+        onSuccess: suspend (PreUploadScreenshotResponse) -> ResultOf<Capture, RemoteError>
+    ): ResultOf<Capture, RemoteError> {
+        return when (val preUploadResponse = customerApiRemoteSource.preUploadScreenshot(capture, token)) {
+            is Failure -> preUploadResponse
+            is Success -> {
+                onSuccess(preUploadResponse.value)
+            }
+        }
+    }
+
+    // step 3 - upload the screenshot
+    private suspend fun uploadImage(
+        uploadUrl: String,
+        capture: Capture,
+        onSuccess: suspend () -> ResultOf<Capture, RemoteError>,
+    ): ResultOf<Capture, RemoteError> {
+
+        val density = contextResources.displayMetrics.density
+        val original = capture.screenshot
+        val bitmap = Bitmap.createScaledBitmap(
+            capture.screenshot,
+            original.width.toDp(density),
+            original.height.toDp(density),
+            true
+        )
+        return when (
+            val uploadResponse = imageUploadRemoteSource.upload(uploadUrl, bitmap)
+        ) {
+            is Failure -> uploadResponse
+            is Success -> {
+                onSuccess()
+            }
+        }
+    }
+
+    // step 4 - update the screenshot link and save the screen
+    private suspend fun saveScreen(capture: Capture, token: String) =
+        when (val screenResult = customerApiRemoteSource.screen(capture, token)) {
+            is Failure -> screenResult
+            is Success -> Success(capture)
+        }
 
     private fun prepare(view: View) {
         // hide the debugger view for screen capture, if present
@@ -99,7 +184,7 @@ private fun View.asCaptureView(): Capture.View? {
     val screenRect = Rect(0, 0, displayMetrics.widthPixels, displayMetrics.heightPixels)
 
     // if the view is not currently in the screenshot image (scrolled away), ignore
-    if (!actualPosition.intersect(screenRect)) {
+    if (Rect.intersects(actualPosition, screenRect).not()) {
         return null
     }
 
@@ -129,10 +214,10 @@ private fun View.asCaptureView(): Capture.View? {
     )
 
     return Capture.View(
-        x = actualPosition.left / density,
-        y = actualPosition.top / density,
-        width = actualPosition.width() / density,
-        height = actualPosition.height() / density,
+        x = actualPosition.left.toDp(density),
+        y = actualPosition.top.toDp(density),
+        width = actualPosition.width().toDp(density),
+        height = actualPosition.height().toDp(density),
         selector = if (selector.isValid) selector else null,
         type = this.javaClass.name,
         children = children,
@@ -141,7 +226,7 @@ private fun View.asCaptureView(): Capture.View? {
 
 private fun View.screenshot() =
     if (this.width > 0 && this.height > 0) {
-        val bitmap = Bitmap.createBitmap(this.width, this.height, Bitmap.Config.ARGB_8888)
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         this.draw(canvas)
         bitmap

--- a/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
@@ -149,7 +149,8 @@ private fun CaptureContents(debuggerViewModel: DebuggerViewModel, capture: Captu
                     .conditionalClickable(
                         enabled = text.value.isEmpty().not(),
                         onClick = {
-                            debuggerViewModel.onScreenCaptureConfirm(capture.copy(displayName = text.value))
+                            val updatedCapture = capture.copy(displayName = text.value).apply { screenshot = capture.screenshot }
+                            debuggerViewModel.onScreenCaptureConfirm(updatedCapture)
                         }
                     ),
                 text = stringResource(id = string.appcues_screen_capture_ok),


### PR DESCRIPTION
This change implements the sequence of calls to upload a screenshot and save the screen into the customer account for builder usage. Some cleanup items found and worked along the way

* capture proper screen rect for elements
* capture system window insets (top/bottom bars) for builder usage in metadata
* size bitmap to screen capture size in DP (not a much larger 3x image for instance)