### PR TITLE
Add success and failure toast messages on screen capture

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/model/DebuggerToast.kt
+++ b/appcues/src/main/java/com/appcues/debugger/model/DebuggerToast.kt
@@ -1,0 +1,8 @@
+package com.appcues.debugger.model
+
+import com.appcues.debugger.screencapture.Capture
+
+internal sealed class DebuggerToast {
+    data class ScreenCaptureSuccess(val capture: Capture, val onDismiss: () -> Unit) : DebuggerToast()
+    data class ScreenCaptureFailure(val capture: Capture, val onDismiss: () -> Unit, val onRetry: () -> Unit) : DebuggerToast()
+}

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
@@ -23,6 +23,8 @@ import androidx.lifecycle.LifecycleEventObserver
 import com.appcues.debugger.DebugMode.Debugger
 import com.appcues.debugger.DebugMode.ScreenCapture
 import com.appcues.debugger.DebuggerViewModel
+import com.appcues.debugger.DebuggerViewModel.ToastState
+import com.appcues.debugger.DebuggerViewModel.ToastState.Rendering
 import com.appcues.debugger.DebuggerViewModel.UIState.Creating
 import com.appcues.debugger.DebuggerViewModel.UIState.Dismissed
 import com.appcues.debugger.DebuggerViewModel.UIState.Dismissing
@@ -80,6 +82,8 @@ internal fun DebuggerComposition(viewModel: DebuggerViewModel, onDismiss: () -> 
                 debuggerViewModel = viewModel
             )
         }
+
+        ToastView(debuggerState = debuggerState)
     }
 
     with(debuggerState.isVisible) {
@@ -98,9 +102,31 @@ internal fun DebuggerComposition(viewModel: DebuggerViewModel, onDismiss: () -> 
         onDismiss = onDismiss,
     )
 
+    LaunchedToastStateEffect(
+        viewModel = viewModel,
+        debuggerState = debuggerState,
+    )
+
     // run once to transition state in viewModel
     LaunchedEffect(Unit) {
         viewModel.onRender()
+    }
+}
+
+@Composable
+private fun LaunchedToastStateEffect(
+    viewModel: DebuggerViewModel,
+    debuggerState: MutableDebuggerState,
+) {
+    viewModel.toastState.collectAsState().value.let {
+        when (it) {
+            is ToastState.Idle -> {
+                debuggerState.toast.targetState = null
+            }
+            is Rendering -> {
+                debuggerState.toast.targetState = it.type
+            }
+        }
     }
 }
 

--- a/appcues/src/main/java/com/appcues/debugger/ui/MutableDebuggerState.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/MutableDebuggerState.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.appcues.debugger.DebugMode
+import com.appcues.debugger.model.DebuggerToast
 import com.appcues.debugger.screencapture.Capture
 import kotlin.math.roundToInt
 
@@ -37,6 +38,7 @@ internal class MutableDebuggerState(
     val isExpanded = MutableTransitionState(false)
     val screenCapture = mutableStateOf<Capture?>(null)
     val isPaused = mutableStateOf(value = false)
+    val toast = MutableTransitionState<DebuggerToast?>(null)
 
     val fabXOffset = mutableStateOf(value = -1f)
     val fabYOffset = mutableStateOf(value = -1f)

--- a/appcues/src/main/java/com/appcues/debugger/ui/ToastView.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/ToastView.kt
@@ -1,0 +1,157 @@
+package com.appcues.debugger.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.appcues.R.string
+import com.appcues.debugger.model.DebuggerToast.ScreenCaptureFailure
+import com.appcues.debugger.model.DebuggerToast.ScreenCaptureSuccess
+import com.appcues.ui.theme.AppcuesColors
+import kotlinx.coroutines.delay
+
+private const val TOAST_LENGTH = 3_000L
+
+@Composable
+internal fun BoxScope.ToastView(debuggerState: MutableDebuggerState) {
+
+    when (val toastState = debuggerState.toast.targetState) {
+        is ScreenCaptureSuccess -> SuccessToast(toast = toastState, debuggerState = debuggerState)
+        is ScreenCaptureFailure -> FailureToast(toast = toastState, debuggerState = debuggerState)
+        null -> Unit
+    }
+}
+
+@Composable
+internal fun BoxScope.SuccessToast(toast: ScreenCaptureSuccess, debuggerState: MutableDebuggerState) {
+    // any tap on this background will dismiss the toast before it auto expires
+    Spacer(
+        modifier = Modifier
+            .matchParentSize()
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = toast.onDismiss
+            )
+    )
+
+    AnimatedVisibility(
+        visible = debuggerState.toast.targetState != null,
+        modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .padding(20.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .background(color = AppcuesColors.DebuggerToastSuccessBackground, shape = RoundedCornerShape(6.dp))
+                .fillMaxWidth()
+                .height(64.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = buildAnnotatedString {
+                    withStyle(
+                        style = SpanStyle(fontWeight = FontWeight.Bold, color = Color.White, fontSize = 14.sp)
+                    ) {
+                        append("\"${toast.capture.displayName}\" ")
+                    }
+                    withStyle(
+                        style = SpanStyle(fontWeight = FontWeight.Normal, color = Color.White, fontSize = 14.sp)
+                    ) {
+                        append(stringResource(id = string.appcues_screen_capture_toast_success_suffix))
+                    }
+                },
+                modifier = Modifier
+                    .padding(start = 16.dp, end = 16.dp)
+            )
+        }
+        LaunchedEffect(debuggerState.toast.targetState) {
+            delay(timeMillis = TOAST_LENGTH)
+            toast.onDismiss()
+        }
+    }
+}
+@Composable
+internal fun BoxScope.FailureToast(toast: ScreenCaptureFailure, debuggerState: MutableDebuggerState) {
+    // any tap on this background will dismiss the toast before it auto expires
+    Spacer(
+        modifier = Modifier
+            .matchParentSize()
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = toast.onDismiss
+            )
+    )
+
+    AnimatedVisibility(
+        visible = debuggerState.toast.targetState != null,
+        modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .padding(20.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .background(color = AppcuesColors.DebuggerToastFailureBackground, shape = RoundedCornerShape(6.dp))
+                .fillMaxWidth()
+                .height(64.dp)
+                .padding(start = 16.dp, end = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(id = string.appcues_screen_capture_toast_upload_failed),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+            Spacer(modifier = Modifier.weight(1.0f))
+
+            Box(
+                modifier = Modifier
+                    .height(40.dp)
+                    .border(
+                        width = 1.dp,
+                        shape = RoundedCornerShape(6.dp),
+                        color = Color.White
+                    )
+                    .clickable(onClick = toast.onRetry)
+            ) {
+                Text(
+                    text = stringResource(id = string.appcues_screen_capture_toast_try_again),
+                    fontSize = 14.sp,
+                    color = Color.White,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(start = 16.dp, end = 16.dp)
+                )
+            }
+        }
+        LaunchedEffect(debuggerState.toast.targetState) {
+            delay(timeMillis = TOAST_LENGTH)
+            toast.onDismiss()
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/theme/AppcuesColors.kt
+++ b/appcues/src/main/java/com/appcues/ui/theme/AppcuesColors.kt
@@ -18,4 +18,6 @@ internal object AppcuesColors {
     val CaptureButtonGradientEnd = Color(color = 0xFF7D52FF)
     val CaptureImageBorder = Color(color = 0xFFDCE4F2)
     val CaptureTextInputBorder = Color(color = 0xFF79747E)
+    val DebuggerToastSuccessBackground = Color(color = 0xFF0072D6)
+    val DebuggerToastFailureBackground = Color(color = 0xFFDD2270)
 }

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -90,4 +90,7 @@
     <string name="appcues_screen_capture_text_input_label">Name</string>
     <string name="appcues_screen_capture_cancel">Retry</string>
     <string name="appcues_screen_capture_ok">Send to builder</string>
+    <string name="appcues_screen_capture_toast_upload_failed">Upload failed</string>
+    <string name="appcues_screen_capture_toast_try_again">Try again</string>
+    <string name="appcues_screen_capture_toast_success_suffix">is now available for preview and targeting.</string>
 </resources>


### PR DESCRIPTION
stacks on #344 

This adds the blue success and pink failure toasts per design. Failure allows a retry.

A new `ToastState` is used in the DebuggerViewModel, in addition to the `UIState`, as toasts are really independent of other UI and can show up on top of whatever other UI state is rendering. They auto dismiss after 3 seconds, or if the background is tapped.

Failure:

https://user-images.githubusercontent.com/19266448/221929787-9b65e1e4-4a21-42d3-a278-a18b6a6738f2.mov

Success:

https://user-images.githubusercontent.com/19266448/221929846-f391e510-66d4-4c33-91bf-ba4ab1a3153d.mov
