### PR TITLE
✨ Added remaining props for Tooltips + fix insets padding

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/BackdropDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/BackdropDecoratingTrait.kt
@@ -5,6 +5,15 @@ import androidx.compose.runtime.Composable
 
 interface BackdropDecoratingTrait : ExperienceTrait {
 
+    /**
+     * Decorates the backdrop of the experience
+     *
+     * Example usage:
+     * @sample com.appcues.trait.appcues.BackdropTrait
+     *
+     * @param content BackdropDecoratingTraits are chained together as one composition.
+     *                Its important to call [content] if you want to apply every decoration on stack
+     */
     @Composable
     fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit)
 }

--- a/appcues/src/main/java/com/appcues/trait/ContainerDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContainerDecoratingTrait.kt
@@ -15,6 +15,14 @@ interface ContainerDecoratingTrait : ExperienceTrait {
      */
     val containerComposeOrder: ContainerDecoratingType
 
+    /**
+     * Decorates the container, it can decorate UNDER the content or OVER the content.
+     *
+     * Example usage:
+     * @sample com.appcues.trait.appcues.BackgroundContentTrait
+     *
+     * @param wrapperInsets The safe area information from the wrapper trait.
+     */
     @Composable
     fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues)
 }

--- a/appcues/src/main/java/com/appcues/trait/ContainerDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContainerDecoratingTrait.kt
@@ -1,6 +1,7 @@
 package com.appcues.trait
 
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 
 interface ContainerDecoratingTrait : ExperienceTrait {
@@ -15,5 +16,5 @@ interface ContainerDecoratingTrait : ExperienceTrait {
     val containerComposeOrder: ContainerDecoratingType
 
     @Composable
-    fun BoxScope.DecorateContainer()
+    fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues)
 }

--- a/appcues/src/main/java/com/appcues/trait/ContentHolderTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContentHolderTrait.kt
@@ -7,6 +7,15 @@ import com.appcues.ui.composables.appcuesPaginationData
 
 interface ContentHolderTrait : ExperienceTrait {
 
+    /**
+     * Defines the content holder, usually used to support different kinds of pagination between steps
+     * that belong inside the same step group
+     *
+     * Example usage:
+     * @sample com.appcues.trait.appcues.CarouselTrait
+     *
+     * @param countainerPages current page information
+     */
     @Composable
     fun BoxScope.CreateContentHolder(containerPages: ContainerPages)
 

--- a/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
@@ -2,18 +2,20 @@ package com.appcues.trait
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 interface ContentWrappingTrait : ExperienceTrait {
 
     /**
-     * Create a wrap of the content, the default wrap used by appcues is the modal with different types.
+     * Creates a wrapper for the [content].
      *
-     * When creating a custom WrapContent is important to pass [hasFixedHeight] as true if you are defining the height constraint yourself.
-     * or else the SDK will consider the container with the same height as the content we will inflate within
+     * Example usage:
+     * @sample com.appcues.trait.appcues.ModalTrait
      *
-     * [contentPadding] is passed from the WrapContent without applying it yourself so we can modify the correct
-     * container in order to keep the vertical scroll nicely at the edge or the container.
+     * @param content The content of the wrapper.
+     *                [modifier] gives flexibility of the content main box down the stream of composition.
+     *                [wrapperInsets] defines safe area padding for the content inside.
      */
     @Composable
-    fun WrapContent(content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit)
+    fun WrapContent(content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit)
 }

--- a/appcues/src/main/java/com/appcues/trait/MetadataSettingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/MetadataSettingTrait.kt
@@ -3,7 +3,12 @@ package com.appcues.trait
 interface MetadataSettingTrait : ExperienceTrait {
 
     /**
-     * returns a map of shared values
+     * produce a map of information that can be accessed from other traits
+     *
+     * Example usage:
+     * @sample com.appcues.trait.appcues.StepAnimationTrait
+     *
+     * @return map of shared values
      */
     fun produceMetadata(): Map<String, Any?>
 }

--- a/appcues/src/main/java/com/appcues/trait/PresentingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/PresentingTrait.kt
@@ -3,8 +3,13 @@ package com.appcues.trait
 interface PresentingTrait : ExperienceTrait {
 
     /**
+     * Presents the experience.
+     *
      * If this method cannot properly apply the trait behavior, it may throw an AppcuesTraitException,
      * ending the attempt to display the experience.
+     *
+     * Example usage:
+     * @sample com.appcues.trait.appcues.ModalTrait
      */
     @Throws(AppcuesTraitException::class)
     fun present()

--- a/appcues/src/main/java/com/appcues/trait/StepDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/StepDecoratingTrait.kt
@@ -1,6 +1,7 @@
 package com.appcues.trait
 
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 
 interface StepDecoratingTrait : ExperienceTrait {
@@ -15,5 +16,5 @@ interface StepDecoratingTrait : ExperienceTrait {
     val stepComposeOrder: StepDecoratingType
 
     @Composable
-    fun BoxScope.DecorateStep(stepDecoratingPadding: StepDecoratingPadding)
+    fun BoxScope.DecorateStep(wrapperInsets: PaddingValues, stickyContentPadding: StickyContentPadding)
 }

--- a/appcues/src/main/java/com/appcues/trait/StepDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/StepDecoratingTrait.kt
@@ -15,6 +15,15 @@ interface StepDecoratingTrait : ExperienceTrait {
      */
     val stepComposeOrder: StepDecoratingType
 
+    /**
+     * Decorates Specific step
+     *
+     * Example usage:
+     * @sample com.appcues.trait.appcues.BackgroundContentTrait
+     *
+     * @param wrapperInsets The safe area information from the wrapper trait.
+     * @param stickyContentPadding Padding amount defined by sticky content elements in this step
+     */
     @Composable
     fun BoxScope.DecorateStep(wrapperInsets: PaddingValues, stickyContentPadding: StickyContentPadding)
 }

--- a/appcues/src/main/java/com/appcues/trait/StickyContentPadding.kt
+++ b/appcues/src/main/java/com/appcues/trait/StickyContentPadding.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.unit.Density
 
-class StepDecoratingPadding(private val density: Density) {
+class StickyContentPadding(private val density: Density) {
 
     private val topPaddingPx = mutableStateOf(0)
     private val bottomPaddingPx = mutableStateOf(0)

--- a/appcues/src/main/java/com/appcues/trait/TraitExtensions.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitExtensions.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 fun Modifier.alignStepOverlay(
     boxScope: BoxScope,
     alignment: Alignment,
-    stepDecoratingPadding: StepDecoratingPadding
+    stickyContentPadding: StickyContentPadding
 ): Modifier {
     return with(boxScope) {
         then(
@@ -26,10 +26,10 @@ fun Modifier.alignStepOverlay(
                     if (alignment is BiasAlignment) {
                         with(alignment) {
                             when {
-                                horizontalBias == -1f && verticalBias == 0f -> stepDecoratingPadding.setStartPadding(it.size.width)
-                                horizontalBias == 1f && verticalBias == 0f -> stepDecoratingPadding.setEndPadding(it.size.width)
-                                verticalBias == -1f -> stepDecoratingPadding.setTopPadding(it.size.height)
-                                verticalBias == 1f -> stepDecoratingPadding.setBottomPadding(it.size.height)
+                                horizontalBias == -1f && verticalBias == 0f -> stickyContentPadding.setStartPadding(it.size.width)
+                                horizontalBias == 1f && verticalBias == 0f -> stickyContentPadding.setEndPadding(it.size.width)
+                                verticalBias == -1f -> stickyContentPadding.setTopPadding(it.size.height)
+                                verticalBias == 1f -> stickyContentPadding.setBottomPadding(it.size.height)
                             }
                         }
                     }

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackgroundContentTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackgroundContentTrait.kt
@@ -2,6 +2,7 @@ package com.appcues.trait.appcues
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -14,9 +15,9 @@ import com.appcues.trait.ContainerDecoratingTrait.ContainerDecoratingType
 import com.appcues.trait.ExperienceTraitLevel
 import com.appcues.trait.ExperienceTraitLevel.GROUP
 import com.appcues.trait.ExperienceTraitLevel.STEP
-import com.appcues.trait.StepDecoratingPadding
 import com.appcues.trait.StepDecoratingTrait
 import com.appcues.trait.StepDecoratingTrait.StepDecoratingType
+import com.appcues.trait.StickyContentPadding
 import com.appcues.ui.primitive.Compose
 
 internal class BackgroundContentTrait(
@@ -36,12 +37,12 @@ internal class BackgroundContentTrait(
     private val content = config.getConfigPrimitive("content")
 
     @Composable
-    override fun BoxScope.DecorateStep(stepDecoratingPadding: StepDecoratingPadding) {
+    override fun BoxScope.DecorateStep(wrapperInsets: PaddingValues, stickyContentPadding: StickyContentPadding) {
         if (level == STEP) Decorate()
     }
 
     @Composable
-    override fun BoxScope.DecorateContainer() {
+    override fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues) {
         if (level == GROUP) Decorate()
     }
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -3,6 +3,7 @@ package com.appcues.trait.appcues
 import android.content.Context
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfigOrDefault
 import com.appcues.data.model.getConfigStyle
@@ -33,7 +34,7 @@ internal class ModalTrait(
     private val style = config.getConfigStyle("style")
 
     @Composable
-    override fun WrapContent(content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit) {
+    override fun WrapContent(content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit) {
         val windowInfo = rememberAppcuesWindowInfo()
 
         when (presentationStyle) {

--- a/appcues/src/main/java/com/appcues/trait/appcues/PagingDotsTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/PagingDotsTrait.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -45,7 +46,7 @@ internal class PagingDotsTrait(
     private val style = config.getConfigStyle("style")
 
     @Composable
-    override fun BoxScope.DecorateContainer() {
+    override fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues) {
         val paginationData = rememberAppcuesPaginationState()
         val pageCount = paginationData.value.pageCount
 
@@ -69,13 +70,9 @@ internal class PagingDotsTrait(
 
         Box(
             modifier = Modifier
+                .padding(wrapperInsets)
                 .align(style.getBoxAlignment())
-                .padding(
-                    (DEFAULT_PADDING + (style?.marginLeading ?: 0.0)).dp,
-                    (DEFAULT_PADDING + (style?.marginTop ?: 0.0)).dp,
-                    (DEFAULT_PADDING + (style?.marginTrailing ?: 0.0)).dp,
-                    (DEFAULT_PADDING + (style?.marginBottom ?: 0.0)).dp
-                ),
+                .stylePadding(),
             contentAlignment = Alignment.CenterStart
         ) {
             Row(
@@ -114,4 +111,12 @@ internal class PagingDotsTrait(
             )
         }
     }
+
+    @Composable
+    private fun Modifier.stylePadding(): Modifier = padding(
+        (DEFAULT_PADDING + (style?.marginLeading ?: 0.0)).dp,
+        (DEFAULT_PADDING + (style?.marginTop ?: 0.0)).dp,
+        (DEFAULT_PADDING + (style?.marginTrailing ?: 0.0)).dp,
+        (DEFAULT_PADDING + (style?.marginBottom ?: 0.0)).dp
+    )
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -76,10 +77,11 @@ internal class SkippableTrait(
     private val ignoreBackdropTap = config.getConfigOrDefault(CONFIG_IGNORE_BACKDROP_TAP, false)
 
     @Composable
-    override fun BoxScope.DecorateContainer() {
+    override fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues) {
         val description = stringResource(id = R.string.appcues_skippable_trait_dismiss)
         Spacer(
             modifier = Modifier
+                .padding(wrapperInsets)
                 .align(Alignment.TopEnd)
                 .padding(buttonAppearance.margin)
                 .size(buttonAppearance.size)

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -129,11 +129,11 @@ internal class TooltipTrait(
                 // positions both the tip and modal of the tooltip on the screen
                 Column(
                     modifier = Modifier.positionTooltip(
-                        targetRect,
-                        containerDimens.value,
-                        tooltipSettings,
-                        windowInfo,
-                        dpAnimation
+                        targetRect = targetRect,
+                        containerDimens = containerDimens.value,
+                        pointerSettings = tooltipSettings,
+                        windowInfo = windowInfo,
+                        animationSpec = dpAnimation
                     )
                 ) {
                     val tooltipPath = tooltipPath(tooltipSettings, containerDimens.value, style, floatAnimation)

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipsPaths.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipsPaths.kt
@@ -25,7 +25,6 @@ import com.appcues.trait.appcues.TooltipPointerPosition.NONE
 import com.appcues.trait.appcues.TooltipPointerPosition.TOP
 import com.appcues.trait.appcues.TooltipPointerPosition.TOP_END
 import com.appcues.trait.appcues.TooltipPointerPosition.TOP_START
-import com.appcues.ui.utils.AppcuesWindowInfo
 import com.appcues.util.ne
 
 internal enum class TooltipPointerPosition {
@@ -69,18 +68,6 @@ internal fun getTooltipSettings(
         pointerBasePx = with(density) { pointerBaseDp.toPx() },
         pointerLengthPx = with(density) { pointerLengthDp.toPx() }
     )
-}
-
-internal fun getPointerPosition(
-    windowInfo: AppcuesWindowInfo,
-    targetRect: Rect?,
-): TooltipPointerPosition {
-    // Figure out where to position the tooltip
-    return when {
-        targetRect == null -> NONE
-        targetRect.center.y.dp < windowInfo.heightDp / 2 -> TOP
-        else -> BOTTOM
-    }
 }
 
 @Composable

--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -26,12 +26,15 @@ internal fun ComponentStyle.getMargins() = PaddingValues(
     end = marginTrailing.dp,
 )
 
-internal fun ComponentStyle.getPaddings() = PaddingValues(
-    start = paddingLeading.dp.coerceAtLeast(0.dp),
-    bottom = paddingBottom.dp.coerceAtLeast(0.dp),
-    top = paddingTop.dp.coerceAtLeast(0.dp),
-    end = paddingTrailing.dp.coerceAtLeast(0.dp),
-)
+internal fun ComponentStyle?.getPaddings(): PaddingValues {
+    return if (this == null) PaddingValues() else
+        PaddingValues(
+            start = paddingLeading.dp.coerceAtLeast(0.dp),
+            bottom = paddingBottom.dp.coerceAtLeast(0.dp),
+            top = paddingTop.dp.coerceAtLeast(0.dp),
+            end = paddingTrailing.dp.coerceAtLeast(0.dp),
+        )
+}
 
 internal fun ComponentStyle.getTextAlignment(): TextAlign? {
     return when (textAlignment) {

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -41,7 +43,7 @@ private const val HEIGHT_TABLET = 0.6f
 @Composable
 internal fun BottomSheetModal(
     style: ComponentStyle?,
-    content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit,
+    content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit,
     appcuesWindowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -72,7 +74,15 @@ internal fun BottomSheetModal(
                         .fillMaxHeight(height.value)
                         // default modal style modifiers
                         .modalStyle(style, isDark) { Modifier.sheetModifier(appcuesWindowInfo, isDark, it) },
-                    content = { content(true, style?.getPaddings()) },
+                    content = {
+                        content(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .verticalScroll(rememberScrollState())
+                                .padding(style.getPaddings()),
+                            wrapperInsets = PaddingValues()
+                        )
+                    },
                 )
             }
         }

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -37,7 +39,7 @@ private const val SCREEN_PADDING = 0.05
 @Composable
 internal fun DialogModal(
     style: ComponentStyle?,
-    content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit,
+    content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo
 ) {
     val configuration = LocalConfiguration.current
@@ -63,7 +65,14 @@ internal fun DialogModal(
                     .padding(horizontal = dialogHorizontalMargin, vertical = dialogVerticalMargin)
                     // default modal style modifiers
                     .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) },
-                content = { content(false, style?.getPaddings()) },
+                content = {
+                    content(
+                        modifier = Modifier
+                            .verticalScroll(rememberScrollState())
+                            .padding(style.getPaddings()),
+                        wrapperInsets = PaddingValues()
+                    )
+                },
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -12,6 +12,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -39,7 +42,7 @@ private const val HEIGHT_TABLET = 0.7f
 @Composable
 internal fun ExpandedBottomSheetModal(
     style: ComponentStyle?,
-    content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit,
+    content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -68,7 +71,15 @@ internal fun ExpandedBottomSheetModal(
                         .fillMaxHeight(height.value)
                         // default modal style modifiers
                         .modalStyle(style, isDark) { Modifier.sheetModifier(windowInfo, isDark, it) },
-                    content = { content(true, style?.getPaddings()) },
+                    content = {
+                        content(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .verticalScroll(rememberScrollState())
+                                .padding(style.getPaddings()),
+                            wrapperInsets = PaddingValues()
+                        )
+                    },
                 )
             }
         }

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -16,6 +16,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -42,7 +45,7 @@ private const val HEIGHT_TABLET = 0.85f
 @Composable
 internal fun FullScreenModal(
     style: ComponentStyle?,
-    content: @Composable (hasFixedHeight: Boolean, contentPadding: PaddingValues?) -> Unit,
+    content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -71,7 +74,15 @@ internal fun FullScreenModal(
                         .fillMaxHeight(fullHeight.value)
                         // default modal style modifiers
                         .modalStyle(style, isDark) { Modifier.fullModifier(windowInfo, isDark, it) },
-                    content = { content(true, style?.getPaddings()) },
+                    content = {
+                        content(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .verticalScroll(rememberScrollState())
+                                .padding(style.getPaddings()),
+                            wrapperInsets = PaddingValues()
+                        )
+                    },
                 )
             }
         }

--- a/appcues/src/test/java/com/appcues/data/mapper/step/StepMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/StepMapperTest.kt
@@ -1,6 +1,7 @@
 package com.appcues.data.mapper.step
 
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import com.appcues.data.mapper.LeveledTraitResponse
 import com.appcues.data.mapper.trait.TraitsMapper
@@ -15,10 +16,10 @@ import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse
 import com.appcues.data.remote.appcues.response.trait.TraitResponse
 import com.appcues.trait.ExperienceTraitLevel
 import com.appcues.trait.PresentingTrait
-import com.appcues.trait.StepDecoratingPadding
 import com.appcues.trait.StepDecoratingTrait
 import com.appcues.trait.StepDecoratingTrait.StepDecoratingType
 import com.appcues.trait.StepDecoratingTrait.StepDecoratingType.OVERLAY
+import com.appcues.trait.StickyContentPadding
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
@@ -27,6 +28,7 @@ import org.junit.Test
 import java.util.UUID
 
 class StepMapperTest {
+
     @Test
     fun `map SHOULD extract top and bottom sticky content`() {
         // Given
@@ -259,7 +261,7 @@ private class TestStepDecoratingTrait : StepDecoratingTrait {
         get() = OVERLAY
 
     @Composable
-    override fun BoxScope.DecorateStep(stepDecoratingPadding: StepDecoratingPadding) {
+    override fun BoxScope.DecorateStep(wrapperInsets: PaddingValues, stickyContentPadding: StickyContentPadding) {
         return
     }
 


### PR DESCRIPTION
Another pass on tooltips, this time focusing on missing properties from trait config.

 will note on the code important pieces, but the main goal of this was to better organize the composition and allow for flexibility over wrapperInsets and stickyContentPadding.
 
 this PR got little heavier than expected, this is supposed to tackle down https://app.shortcut.com/appcues/story/48658/tooltip-implement-missing-properties
  and https://app.shortcut.com/appcues/story/48660/tooltips-adjust-safe-content-area-for-tooltips