### PR TITLE
Apply content padding from modal to the sticky content within

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -121,7 +121,7 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
 
                                     ApplyOverlayStepTraits(this@Box, stepDecoratingPadding)
 
-                                    ComposeStickyContent(this@Box, stepDecoratingPadding)
+                                    ComposeStickyContent(this@Box, contentPadding, stepDecoratingPadding)
                                 }
                             }
                         }

--- a/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
@@ -56,17 +56,21 @@ internal fun Step.ApplyOverlayStepTraits(boxScope: BoxScope, stepDecoratingPaddi
 }
 
 @Composable
-internal fun Step.ComposeStickyContent(boxScope: BoxScope, stepDecoratingPadding: StepDecoratingPadding) {
+internal fun Step.ComposeStickyContent(boxScope: BoxScope, contentPadding: PaddingValues?, stepDecoratingPadding: StepDecoratingPadding) {
     topStickyContent?.let {
         Box(
-            modifier = Modifier.alignStepOverlay(boxScope, Alignment.TopCenter, stepDecoratingPadding),
-            contentAlignment = Alignment.BottomCenter
+            modifier = Modifier
+                .then(if (contentPadding != null) Modifier.padding(contentPadding) else Modifier)
+                .alignStepOverlay(boxScope, Alignment.TopCenter, stepDecoratingPadding),
+            contentAlignment = Alignment.TopCenter
         ) { it.Compose() }
     }
 
     bottomStickyContent?.let {
         Box(
-            modifier = Modifier.alignStepOverlay(boxScope, Alignment.BottomCenter, stepDecoratingPadding),
+            modifier = Modifier
+                .then(if (contentPadding != null) Modifier.padding(contentPadding) else Modifier)
+                .alignStepOverlay(boxScope, Alignment.BottomCenter, stepDecoratingPadding),
             contentAlignment = Alignment.BottomCenter
         ) { it.Compose() }
     }


### PR DESCRIPTION
This will do the trick on the `release/1.3.1` branch - the sticky content composition needs the `contentPadding` passed down, just like the main content.

The change will differ on the `main` branch, as now this padding is part of the `modifier` passed through from the content wrapper (modal) -- will PR that separately and we'll handle merge conflicts when the branches sync up.

For example, consider this scrolling full screen modal with a button at the bottom. It has 20px padding all around defined at the modal level - no sticky content. Note, no margin set between the bottom of the last text and the top of the button at bottom.

https://user-images.githubusercontent.com/19266448/222220954-db6845a9-2f02-4c4e-8bfb-e9bb76239469.mov

Now, make that bottom button row `sticky=top`

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-01 at 12 48 53 PM](https://user-images.githubusercontent.com/19266448/222221247-c23dffa3-c3f2-451d-94e6-c714728ae101.png) | ![Screenshot 2023-03-01 at 12 47 53 PM](https://user-images.githubusercontent.com/19266448/222221281-f0c26805-e5e7-4a77-8a2f-ed5eeac6a530.png) |

In the after screenshot, notice that the 20px padding leading/trailing/bottom are showing as expected on the sticky button as well.

It also applies the correct additional sticky content padding still, so that the scrolling content can scroll up enough to still be fully visible above the sticky bottom row - in this case, the text scrolls until its bottom lines up with the top of the button (no margin set here for accurate testing).

![Screenshot 2023-03-01 at 12 52 10 PM](https://user-images.githubusercontent.com/19266448/222221904-e78d3287-711a-4437-9211-270f5516dd33.png)

