### PR TITLE
Ensure sticky content respects the container padding defined in trait style

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/ContainerDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContainerDecoratingTrait.kt
@@ -21,8 +21,9 @@ interface ContainerDecoratingTrait : ExperienceTrait {
      * Example usage:
      * @sample com.appcues.trait.appcues.BackgroundContentTrait
      *
-     * @param wrapperInsets The safe area information from the wrapper trait.
+     * @param containerPadding The padding defined in the style of the container, to apply to main content within.
+     * @param safeAreaInsets The safe area information from the wrapper trait.
      */
     @Composable
-    fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues)
+    fun BoxScope.DecorateContainer(containerPadding: PaddingValues, safeAreaInsets: PaddingValues)
 }

--- a/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
@@ -17,5 +17,5 @@ interface ContentWrappingTrait : ExperienceTrait {
      *                [wrapperInsets] defines safe area padding for the content inside.
      */
     @Composable
-    fun WrapContent(content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit)
+    fun WrapContent(content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit)
 }

--- a/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
@@ -14,8 +14,9 @@ interface ContentWrappingTrait : ExperienceTrait {
      *
      * @param content The content of the wrapper.
      *                [modifier] gives flexibility of the content main box down the stream of composition.
-     *                [wrapperInsets] defines safe area padding for the content inside.
+     *                [containerPadding] the padding defined in container style. The main content renders inside this padding.
+     *                [safeAreaInsets] defines safe area padding for the content inside.
      */
     @Composable
-    fun WrapContent(content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit)
+    fun WrapContent(content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit)
 }

--- a/appcues/src/main/java/com/appcues/trait/StepDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/StepDecoratingTrait.kt
@@ -21,9 +21,10 @@ interface StepDecoratingTrait : ExperienceTrait {
      * Example usage:
      * @sample com.appcues.trait.appcues.BackgroundContentTrait
      *
-     * @param wrapperInsets The safe area information from the wrapper trait.
+     * @param containerPadding The padding defined in the style of the container, to apply to main content within.
+     * @param safeAreaInsets The safe area information from the wrapper trait.
      * @param stickyContentPadding Padding amount defined by sticky content elements in this step
      */
     @Composable
-    fun BoxScope.DecorateStep(wrapperInsets: PaddingValues, stickyContentPadding: StickyContentPadding)
+    fun BoxScope.DecorateStep(containerPadding: PaddingValues, safeAreaInsets: PaddingValues, stickyContentPadding: StickyContentPadding)
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackgroundContentTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackgroundContentTrait.kt
@@ -37,12 +37,19 @@ internal class BackgroundContentTrait(
     private val content = config.getConfigPrimitive("content")
 
     @Composable
-    override fun BoxScope.DecorateStep(wrapperInsets: PaddingValues, stickyContentPadding: StickyContentPadding) {
+    override fun BoxScope.DecorateStep(
+        containerPadding: PaddingValues,
+        safeAreaInsets: PaddingValues,
+        stickyContentPadding: StickyContentPadding,
+    ) {
         if (level == STEP) Decorate()
     }
 
     @Composable
-    override fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues) {
+    override fun BoxScope.DecorateContainer(
+        containerPadding: PaddingValues,
+        safeAreaInsets: PaddingValues,
+    ) {
         if (level == GROUP) Decorate()
     }
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -34,7 +34,9 @@ internal class ModalTrait(
     private val style = config.getConfigStyle("style")
 
     @Composable
-    override fun WrapContent(content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit) {
+    override fun WrapContent(
+        content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit
+    ) {
         val windowInfo = rememberAppcuesWindowInfo()
 
         when (presentationStyle) {

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -35,7 +35,7 @@ internal class ModalTrait(
 
     @Composable
     override fun WrapContent(
-        content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit
+        content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit
     ) {
         val windowInfo = rememberAppcuesWindowInfo()
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/PagingDotsTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/PagingDotsTrait.kt
@@ -46,7 +46,7 @@ internal class PagingDotsTrait(
     private val style = config.getConfigStyle("style")
 
     @Composable
-    override fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues) {
+    override fun BoxScope.DecorateContainer(containerPadding: PaddingValues, safeAreaInsets: PaddingValues) {
         val paginationData = rememberAppcuesPaginationState()
         val pageCount = paginationData.value.pageCount
 
@@ -70,7 +70,7 @@ internal class PagingDotsTrait(
 
         Box(
             modifier = Modifier
-                .padding(wrapperInsets)
+                .padding(safeAreaInsets)
                 .align(style.getBoxAlignment())
                 .stylePadding(),
             contentAlignment = Alignment.CenterStart

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -77,11 +77,11 @@ internal class SkippableTrait(
     private val ignoreBackdropTap = config.getConfigOrDefault(CONFIG_IGNORE_BACKDROP_TAP, false)
 
     @Composable
-    override fun BoxScope.DecorateContainer(wrapperInsets: PaddingValues) {
+    override fun BoxScope.DecorateContainer(containerPadding: PaddingValues, safeAreaInsets: PaddingValues) {
         val description = stringResource(id = R.string.appcues_skippable_trait_dismiss)
         Spacer(
             modifier = Modifier
-                .padding(wrapperInsets)
+                .padding(safeAreaInsets)
                 .align(Alignment.TopEnd)
                 .padding(buttonAppearance.margin)
                 .size(buttonAppearance.size)

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -96,7 +96,7 @@ internal class TooltipTrait(
 
     @Composable
     override fun WrapContent(
-        content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit
+        content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit
     ) {
         val density = LocalDensity.current
         val metadata = LocalAppcuesStepMetadata.current
@@ -152,7 +152,7 @@ internal class TooltipTrait(
                         content(
                             modifier = Modifier.verticalScroll(rememberScrollState()),
                             containerPadding = style.getPaddings(),
-                            wrapperInsets = tooltipSettings.getContentPaddingValues()
+                            safeAreaInsets = tooltipSettings.getContentPaddingValues()
                         )
                     }
                 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -95,7 +95,9 @@ internal class TooltipTrait(
     }
 
     @Composable
-    override fun WrapContent(content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit) {
+    override fun WrapContent(
+        content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit
+    ) {
         val density = LocalDensity.current
         val metadata = LocalAppcuesStepMetadata.current
 
@@ -148,9 +150,8 @@ internal class TooltipTrait(
                             .styleBorderPath(style, tooltipPath, isSystemInDarkTheme())
                     ) {
                         content(
-                            modifier = Modifier
-                                .verticalScroll(rememberScrollState())
-                                .padding(style.getPaddings()),
+                            modifier = Modifier.verticalScroll(rememberScrollState()),
+                            containerPadding = style.getPaddings(),
                             wrapperInsets = tooltipSettings.getContentPaddingValues()
                         )
                     }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -127,7 +127,7 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
             ApplyBackgroundDecoratingTraits(backdropDecoratingTraits.value)
 
             // create wrapper
-            contentWrappingTrait.WrapContent { modifier, wrapperInsets ->
+            contentWrappingTrait.WrapContent { modifier, containerPadding, wrapperInsets ->
                 Box(contentAlignment = Alignment.TopCenter) {
                     ApplyUnderlayContainerTraits(containerDecoratingTraits.value, wrapperInsets)
 
@@ -141,6 +141,7 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
                                 steps[it]
                                     .ComposeStep(
                                         modifier = modifier.testTag("page_$it"),
+                                        containerPadding = containerPadding,
                                         wrapperInsets = wrapperInsets,
                                         parent = this@Box
                                     )

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -127,9 +127,9 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
             ApplyBackgroundDecoratingTraits(backdropDecoratingTraits.value)
 
             // create wrapper
-            contentWrappingTrait.WrapContent { modifier, containerPadding, wrapperInsets ->
+            contentWrappingTrait.WrapContent { modifier, containerPadding, safeAreaInsets ->
                 Box(contentAlignment = Alignment.TopCenter) {
-                    ApplyUnderlayContainerTraits(containerDecoratingTraits.value, wrapperInsets)
+                    ApplyUnderlayContainerTraits(containerDecoratingTraits.value, containerPadding, safeAreaInsets)
 
                     // Apply content holder trait
                     with(contentHolderTrait) {
@@ -142,7 +142,7 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
                                     .ComposeStep(
                                         modifier = modifier.testTag("page_$it"),
                                         containerPadding = containerPadding,
-                                        wrapperInsets = wrapperInsets,
+                                        safeAreaInsets = safeAreaInsets,
                                         parent = this@Box
                                     )
                             }
@@ -154,7 +154,7 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
                         }
                     }
 
-                    ApplyOverlayContainerTraits(containerDecoratingTraits.value, wrapperInsets)
+                    ApplyOverlayContainerTraits(containerDecoratingTraits.value, containerPadding, safeAreaInsets)
                 }
             }
         }
@@ -162,10 +162,14 @@ private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
 }
 
 @Composable
-internal fun BoxScope.ApplyUnderlayContainerTraits(list: List<ContainerDecoratingTrait>, wrapperInsets: PaddingValues) {
+internal fun BoxScope.ApplyUnderlayContainerTraits(
+    list: List<ContainerDecoratingTrait>,
+    containerPadding: PaddingValues,
+    safeAreaInsets: PaddingValues,
+) {
     list
         .filter { it.containerComposeOrder == ContainerDecoratingType.UNDERLAY }
-        .forEach { it.run { DecorateContainer(wrapperInsets) } }
+        .forEach { it.run { DecorateContainer(containerPadding, safeAreaInsets) } }
 }
 
 @Composable
@@ -178,8 +182,12 @@ private fun BoxScope.ApplyBackgroundDecoratingTraits(list: List<BackdropDecorati
 }
 
 @Composable
-internal fun BoxScope.ApplyOverlayContainerTraits(list: List<ContainerDecoratingTrait>, wrapperInsets: PaddingValues) {
+internal fun BoxScope.ApplyOverlayContainerTraits(
+    list: List<ContainerDecoratingTrait>,
+    containerPadding: PaddingValues,
+    safeAreaInsets: PaddingValues,
+) {
     list
         .filter { it.containerComposeOrder == ContainerDecoratingType.OVERLAY }
-        .forEach { it.run { DecorateContainer(wrapperInsets) } }
+        .forEach { it.run { DecorateContainer(containerPadding, safeAreaInsets) } }
 }

--- a/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
@@ -21,7 +21,7 @@ import com.appcues.ui.primitive.Compose
 internal fun Step.ComposeStep(
     modifier: Modifier = Modifier,
     containerPadding: PaddingValues,
-    wrapperInsets: PaddingValues,
+    safeAreaInsets: PaddingValues,
     parent: BoxScope
 ) {
     CompositionLocalProvider(
@@ -32,50 +32,52 @@ internal fun Step.ComposeStep(
         val density = LocalDensity.current
         val stickyContentPadding = remember(this) { StickyContentPadding(density) }
 
-        ApplyUnderlayStepTraits(parent, wrapperInsets, stickyContentPadding)
+        ApplyUnderlayStepTraits(parent, containerPadding, safeAreaInsets, stickyContentPadding)
 
-        ComposeStepContent(modifier, containerPadding, wrapperInsets, stickyContentPadding)
+        ComposeStepContent(modifier, containerPadding, safeAreaInsets, stickyContentPadding)
 
-        ComposeStickyContent(parent, containerPadding, wrapperInsets, stickyContentPadding)
+        ComposeStickyContent(parent, containerPadding, safeAreaInsets, stickyContentPadding)
 
-        ApplyOverlayStepTraits(parent, wrapperInsets, stickyContentPadding)
+        ApplyOverlayStepTraits(parent, containerPadding, safeAreaInsets, stickyContentPadding)
     }
 }
 
 @Composable
 private fun Step.ApplyUnderlayStepTraits(
     boxScope: BoxScope,
-    wrapperInsets: PaddingValues,
+    containerPadding: PaddingValues,
+    safeAreaInsets: PaddingValues,
     stickyContentPadding: StickyContentPadding
 ) {
     stepDecoratingTraits
         .filter { it.stepComposeOrder == StepDecoratingType.UNDERLAY }
-        .forEach { it.run { boxScope.DecorateStep(wrapperInsets, stickyContentPadding) } }
+        .forEach { it.run { boxScope.DecorateStep(containerPadding, safeAreaInsets, stickyContentPadding) } }
 }
 
 @Composable
 private fun Step.ApplyOverlayStepTraits(
     boxScope: BoxScope,
-    wrapperInsets: PaddingValues,
+    containerPadding: PaddingValues,
+    safeAreaInsets: PaddingValues,
     stickyContentPadding: StickyContentPadding
 ) {
     stepDecoratingTraits
         .filter { it.stepComposeOrder == StepDecoratingType.OVERLAY }
-        .forEach { it.run { boxScope.DecorateStep(wrapperInsets, stickyContentPadding) } }
+        .forEach { it.run { boxScope.DecorateStep(containerPadding, safeAreaInsets, stickyContentPadding) } }
 }
 
 @Composable
 private fun Step.ComposeStepContent(
     modifier: Modifier,
     containerPadding: PaddingValues,
-    wrapperInsets: PaddingValues,
+    safeAreaInsets: PaddingValues,
     stickyContentPadding: StickyContentPadding
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .padding(containerPadding)
-            .padding(wrapperInsets)
+            .padding(safeAreaInsets)
             .padding(stickyContentPadding.paddingValues.value)
     ) { content.Compose() }
 }
@@ -84,14 +86,14 @@ private fun Step.ComposeStepContent(
 private fun Step.ComposeStickyContent(
     boxScope: BoxScope,
     containerPadding: PaddingValues,
-    wrapperInsets: PaddingValues,
+    safeAreaInsets: PaddingValues,
     stickyContentPadding: StickyContentPadding
 ) {
     topStickyContent?.let {
         Box(
             modifier = Modifier
                 .padding(containerPadding)
-                .padding(wrapperInsets)
+                .padding(safeAreaInsets)
                 .alignStepOverlay(boxScope, Alignment.TopCenter, stickyContentPadding),
             contentAlignment = Alignment.BottomCenter
         ) { it.Compose() }
@@ -101,7 +103,7 @@ private fun Step.ComposeStickyContent(
         Box(
             modifier = Modifier
                 .padding(containerPadding)
-                .padding(wrapperInsets)
+                .padding(safeAreaInsets)
                 .alignStepOverlay(boxScope, Alignment.BottomCenter, stickyContentPadding),
             contentAlignment = Alignment.BottomCenter
         ) { it.Compose() }

--- a/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
@@ -18,7 +18,12 @@ import com.appcues.trait.alignStepOverlay
 import com.appcues.ui.primitive.Compose
 
 @Composable
-internal fun Step.ComposeStep(modifier: Modifier = Modifier, wrapperInsets: PaddingValues, parent: BoxScope) {
+internal fun Step.ComposeStep(
+    modifier: Modifier = Modifier,
+    containerPadding: PaddingValues,
+    wrapperInsets: PaddingValues,
+    parent: BoxScope
+) {
     CompositionLocalProvider(
         LocalAppcuesActions provides actions,
         LocalExperienceStepFormStateDelegate provides formState
@@ -29,9 +34,9 @@ internal fun Step.ComposeStep(modifier: Modifier = Modifier, wrapperInsets: Padd
 
         ApplyUnderlayStepTraits(parent, wrapperInsets, stickyContentPadding)
 
-        ComposeStepContent(modifier, wrapperInsets, stickyContentPadding)
+        ComposeStepContent(modifier, containerPadding, wrapperInsets, stickyContentPadding)
 
-        ComposeStickyContent(parent, wrapperInsets, stickyContentPadding)
+        ComposeStickyContent(parent, containerPadding, wrapperInsets, stickyContentPadding)
 
         ApplyOverlayStepTraits(parent, wrapperInsets, stickyContentPadding)
     }
@@ -62,12 +67,14 @@ private fun Step.ApplyOverlayStepTraits(
 @Composable
 private fun Step.ComposeStepContent(
     modifier: Modifier,
+    containerPadding: PaddingValues,
     wrapperInsets: PaddingValues,
     stickyContentPadding: StickyContentPadding
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
+            .padding(containerPadding)
             .padding(wrapperInsets)
             .padding(stickyContentPadding.paddingValues.value)
     ) { content.Compose() }
@@ -76,12 +83,14 @@ private fun Step.ComposeStepContent(
 @Composable
 private fun Step.ComposeStickyContent(
     boxScope: BoxScope,
+    containerPadding: PaddingValues,
     wrapperInsets: PaddingValues,
     stickyContentPadding: StickyContentPadding
 ) {
     topStickyContent?.let {
         Box(
             modifier = Modifier
+                .padding(containerPadding)
                 .padding(wrapperInsets)
                 .alignStepOverlay(boxScope, Alignment.TopCenter, stickyContentPadding),
             contentAlignment = Alignment.BottomCenter
@@ -91,6 +100,7 @@ private fun Step.ComposeStickyContent(
     bottomStickyContent?.let {
         Box(
             modifier = Modifier
+                .padding(containerPadding)
                 .padding(wrapperInsets)
                 .alignStepOverlay(boxScope, Alignment.BottomCenter, stickyContentPadding),
             contentAlignment = Alignment.BottomCenter

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -43,7 +43,7 @@ private const val HEIGHT_TABLET = 0.6f
 @Composable
 internal fun BottomSheetModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit,
+    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
     appcuesWindowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -80,7 +80,7 @@ internal fun BottomSheetModal(
                                 .fillMaxSize()
                                 .verticalScroll(rememberScrollState()),
                             containerPadding = style.getPaddings(),
-                            wrapperInsets = PaddingValues()
+                            safeAreaInsets = PaddingValues()
                         )
                     },
                 )

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -43,7 +43,7 @@ private const val HEIGHT_TABLET = 0.6f
 @Composable
 internal fun BottomSheetModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit,
+    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit,
     appcuesWindowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -78,8 +78,8 @@ internal fun BottomSheetModal(
                         content(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .verticalScroll(rememberScrollState())
-                                .padding(style.getPaddings()),
+                                .verticalScroll(rememberScrollState()),
+                            containerPadding = style.getPaddings(),
                             wrapperInsets = PaddingValues()
                         )
                     },

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -39,7 +39,7 @@ private const val SCREEN_PADDING = 0.05
 @Composable
 internal fun DialogModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit,
+    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo
 ) {
     val configuration = LocalConfiguration.current
@@ -69,7 +69,7 @@ internal fun DialogModal(
                     content(
                         modifier = Modifier.verticalScroll(rememberScrollState()),
                         containerPadding = style.getPaddings(),
-                        wrapperInsets = PaddingValues()
+                        safeAreaInsets = PaddingValues()
                     )
                 },
             )

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -39,7 +39,7 @@ private const val SCREEN_PADDING = 0.05
 @Composable
 internal fun DialogModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit,
+    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo
 ) {
     val configuration = LocalConfiguration.current
@@ -67,9 +67,8 @@ internal fun DialogModal(
                     .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) },
                 content = {
                     content(
-                        modifier = Modifier
-                            .verticalScroll(rememberScrollState())
-                            .padding(style.getPaddings()),
+                        modifier = Modifier.verticalScroll(rememberScrollState()),
+                        containerPadding = style.getPaddings(),
                         wrapperInsets = PaddingValues()
                     )
                 },

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
@@ -42,7 +41,7 @@ private const val HEIGHT_TABLET = 0.7f
 @Composable
 internal fun ExpandedBottomSheetModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit,
+    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -75,8 +74,8 @@ internal fun ExpandedBottomSheetModal(
                         content(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .verticalScroll(rememberScrollState())
-                                .padding(style.getPaddings()),
+                                .verticalScroll(rememberScrollState()),
+                            containerPadding = style.getPaddings(),
                             wrapperInsets = PaddingValues()
                         )
                     },

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -41,7 +41,7 @@ private const val HEIGHT_TABLET = 0.7f
 @Composable
 internal fun ExpandedBottomSheetModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit,
+    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -76,7 +76,7 @@ internal fun ExpandedBottomSheetModal(
                                 .fillMaxSize()
                                 .verticalScroll(rememberScrollState()),
                             containerPadding = style.getPaddings(),
-                            wrapperInsets = PaddingValues()
+                            safeAreaInsets = PaddingValues()
                         )
                     },
                 )

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
@@ -45,7 +44,7 @@ private const val HEIGHT_TABLET = 0.85f
 @Composable
 internal fun FullScreenModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, wrapperInsets: PaddingValues) -> Unit,
+    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -78,8 +77,8 @@ internal fun FullScreenModal(
                         content(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .verticalScroll(rememberScrollState())
-                                .padding(style.getPaddings()),
+                                .verticalScroll(rememberScrollState()),
+                            containerPadding = style.getPaddings(),
                             wrapperInsets = PaddingValues()
                         )
                     },

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -44,7 +44,7 @@ private const val HEIGHT_TABLET = 0.85f
 @Composable
 internal fun FullScreenModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, wrapperInsets: PaddingValues) -> Unit,
+    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
     windowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -79,7 +79,7 @@ internal fun FullScreenModal(
                                 .fillMaxSize()
                                 .verticalScroll(rememberScrollState()),
                             containerPadding = style.getPaddings(),
-                            wrapperInsets = PaddingValues()
+                            safeAreaInsets = PaddingValues()
                         )
                     },
                 )

--- a/appcues/src/test/java/com/appcues/data/mapper/step/StepMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/StepMapperTest.kt
@@ -261,7 +261,11 @@ private class TestStepDecoratingTrait : StepDecoratingTrait {
         get() = OVERLAY
 
     @Composable
-    override fun BoxScope.DecorateStep(wrapperInsets: PaddingValues, stickyContentPadding: StickyContentPadding) {
+    override fun BoxScope.DecorateStep(
+        containerPadding: PaddingValues,
+        safeAreaInsets: PaddingValues,
+        stickyContentPadding: StickyContentPadding,
+    ) {
         return
     }
 


### PR DESCRIPTION
This is the translation to `main` branch structure for what was updated in #348 on the 1.3.x code branch.

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-01 at 3 56 10 PM](https://user-images.githubusercontent.com/19266448/222263304-f370c865-a2fb-431a-96d3-09fb9e4e317a.png) | ![Screenshot 2023-03-01 at 3 56 47 PM](https://user-images.githubusercontent.com/19266448/222263328-90d5c5b0-eea9-49d8-89eb-5ab629b15ebe.png) | 