### PR TITLE
Fix Proguard consumer-rules for file location changes in network response models

### DIFF
--- a/appcues/consumer-rules.pro
+++ b/appcues/consumer-rules.pro
@@ -1,1 +1,1 @@
--keep class com.appcues.data.remote.response.** { *; }
+-keep class com.appcues.data.remote.**.response.** { *; }


### PR DESCRIPTION
In #343 some files were moved and others added for network response models that are used in Moshi generated adapters. It was an oversight on my part to not also update the Proguard rules that are needed to keep those adapters from getting optimized away. This was causing broken network behavior and flows not rendering in the sample app.