### PR TITLE
Implement target element trait

### DIFF
--- a/appcues/src/main/java/com/appcues/data/model/ModelExtensions.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ModelExtensions.kt
@@ -59,3 +59,11 @@ internal fun AppcuesConfigMap.getConfigColor(key: String): ComponentColor? {
         MoshiConfiguration.fromAny<StyleColorResponse>(it)?.mapComponentColor()
     }
 }
+
+// general helper to get any object of type T from the config map and have it deserialized from JSON
+// using it's Moshi adapter
+internal inline fun <reified T : Any> AppcuesConfigMap.getConfigObject(key: String): T? {
+    return getConfig<Any>(key)?.let {
+        MoshiConfiguration.fromAny(it)
+    }
+}

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
@@ -189,6 +189,18 @@ private fun View.asCaptureView(): Capture.View? {
         children = null
     }
 
+    return Capture.View(
+        x = actualPosition.left.toDp(density),
+        y = actualPosition.top.toDp(density),
+        width = actualPosition.width().toDp(density),
+        height = actualPosition.height().toDp(density),
+        selector = selector(),
+        type = this.javaClass.name,
+        children = children,
+    )
+}
+
+internal fun View.selector(): ElementSelector? {
     val selector = ElementSelector(
         id = null, // for manual tagging
         accessibilityIdentifier = null, // not valid on android
@@ -196,15 +208,7 @@ private fun View.asCaptureView(): Capture.View? {
         tag = tag?.toString()
     )
 
-    return Capture.View(
-        x = actualPosition.left.toDp(density),
-        y = actualPosition.top.toDp(density),
-        width = actualPosition.width().toDp(density),
-        height = actualPosition.height().toDp(density),
-        selector = if (selector.isValid) selector else null,
-        type = this.javaClass.name,
-        children = children,
-    )
+    return if (selector.isValid) selector else null
 }
 
 private fun View.screenshot() =

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -1,6 +1,7 @@
 package com.appcues.statemachine
 
 import com.appcues.data.model.Experience
+import com.appcues.util.ResultOf
 
 internal sealed class State {
 
@@ -12,7 +13,7 @@ internal sealed class State {
         val isFirst: Boolean,
         // this is how the UI communicates success/failure in presentation
         // back to the state machine
-        val presentationComplete: (() -> Unit),
+        val presentationComplete: ((ResultOf<Unit, Error>) -> Unit),
     ) : State()
 
     data class RenderingStep(val experience: Experience, val flatStepIndex: Int, val isFirst: Boolean) : State()

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
@@ -63,8 +63,10 @@ internal class BackdropKeyholeTrait(
         val density = LocalDensity.current
         val metadata = LocalAppcuesStepMetadata.current
 
+        // trait does not apply if no target rectangle in metadata
+        val targetRectInfo = rememberTargetRectangleInfo(metadata) ?: return
+
         val shapeBlurRadius = if (shape == CIRCLE) configBlurRadius.toFloat() else 0.0f
-        val targetRectInfo = rememberTargetRectangleInfo(metadata)
         val targetRect = targetRectInfo.getRect(rememberAppcuesWindowInfo()).inflateOrEmpty(configSpreadRadius)
         val floatAnimation = rememberFloatStepAnimation(metadata)
         val encompassesDiameter = getRectEncompassesRadius(targetRect.width, targetRect.height, shapeBlurRadius) * 2
@@ -92,20 +94,22 @@ internal class BackdropKeyholeTrait(
                 .drawWithContent {
                     drawContent()
 
-                    val shapeCenter = Offset(positionPx.x + sizePx.width / 2, positionPx.y + sizePx.height / 2)
-                    val blurStartPoint = ((sizePx.width / 2) - blurRadiusPx) / (sizePx.width / 2)
+                    if (sizePx.width > 0 && sizePx.height > 0) {
+                        val shapeCenter = Offset(positionPx.x + sizePx.width / 2, positionPx.y + sizePx.height / 2)
+                        val blurStartPoint = ((sizePx.width / 2) - blurRadiusPx) / (sizePx.width / 2)
 
-                    drawRoundRect(
-                        topLeft = positionPx,
-                        brush = Brush.radialGradient(
-                            colorStops = arrayOf(blurStartPoint to Color.Transparent, 1.0f to Color.Black),
-                            center = shapeCenter,
-                            radius = encompassesRadiusPx.value
-                        ),
-                        size = sizePx,
-                        cornerRadius = rectCornerRadius,
-                        blendMode = BlendMode.DstIn
-                    )
+                        drawRoundRect(
+                            topLeft = positionPx,
+                            brush = Brush.radialGradient(
+                                colorStops = arrayOf(blurStartPoint to Color.Transparent, 1.0f to Color.Black),
+                                center = shapeCenter,
+                                radius = encompassesRadiusPx.value
+                            ),
+                            size = sizePx,
+                            cornerRadius = rectCornerRadius,
+                            blendMode = BlendMode.DstIn
+                        )
+                    }
                 }
         ) {
             content()

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
@@ -63,8 +63,7 @@ internal class BackdropKeyholeTrait(
         val density = LocalDensity.current
         val metadata = LocalAppcuesStepMetadata.current
 
-        // trait does not apply if no target rectangle in metadata
-        val targetRectInfo = rememberTargetRectangleInfo(metadata) ?: return
+        val targetRectInfo = rememberTargetRectangleInfo(metadata)
 
         val shapeBlurRadius = if (shape == CIRCLE) configBlurRadius.toFloat() else 0.0f
         val targetRect = targetRectInfo.getRect(rememberAppcuesWindowInfo()).inflateOrEmpty(configSpreadRadius)
@@ -94,7 +93,7 @@ internal class BackdropKeyholeTrait(
                 .drawWithContent {
                     drawContent()
 
-                    if (sizePx.width > 0 && sizePx.height > 0) {
+                    if (encompassesRadiusPx.value > 0) {
                         val shapeCenter = Offset(positionPx.x + sizePx.width / 2, positionPx.y + sizePx.height / 2)
                         val blurStartPoint = ((sizePx.width / 2) - blurRadiusPx) / (sizePx.width / 2)
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetContent.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetContent.kt
@@ -1,0 +1,30 @@
+package com.appcues.trait.appcues
+
+internal const val TARGET_RECTANGLE_METADATA = "targetRectangle"
+
+internal data class TargetRectangleInfo(
+    val x: Float = 0f,
+    val y: Float = 0f,
+    val relativeX: Double = 0.0,
+    val relativeY: Double = 0.0,
+    val width: Float = 0f,
+    val height: Float = 0f,
+    val relativeWidth: Double = 0.0,
+    val relativeHeight: Double = 0.0,
+    val contentDistance: Double = 0.0,
+    val prefPosition: ContentPreferredPosition? = null
+)
+
+internal enum class ContentPreferredPosition {
+    TOP, BOTTOM, LEADING, TRAILING
+}
+
+internal fun String?.toPosition(): ContentPreferredPosition? {
+    return when (this) {
+        "top" -> ContentPreferredPosition.TOP
+        "bottom" -> ContentPreferredPosition.BOTTOM
+        "leading" -> ContentPreferredPosition.LEADING
+        "trailing" -> ContentPreferredPosition.TRAILING
+        else -> null
+    }
+}

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetElementTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetElementTrait.kt
@@ -1,36 +1,88 @@
 package com.appcues.trait.appcues
 
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
+import android.graphics.Rect
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.children
 import com.appcues.data.model.AppcuesConfigMap
-import com.appcues.data.model.getConfigInt
+import com.appcues.data.model.getConfig
+import com.appcues.data.model.getConfigObject
+import com.appcues.data.model.getConfigOrDefault
+import com.appcues.debugger.screencapture.selector
+import com.appcues.debugger.screencapture.toDp
+import com.appcues.monitor.AppcuesActivityMonitor
+import com.appcues.trait.AppcuesTraitException
 import com.appcues.trait.MetadataSettingTrait
+import com.appcues.ui.ElementSelector
 
 internal class TargetElementTrait(
     override val config: AppcuesConfigMap,
 ) : MetadataSettingTrait {
 
     companion object {
-
         const val TYPE = "@appcues/target-element"
-
-        const val METADATA_TARGET_RECT = "targetRectangle"
     }
+
+    private val selector: ElementSelector? = config.getConfigObject("selector")
+    private val contentDistance = config.getConfigOrDefault("contentDistanceFromTarget", 0.0)
+    private val preferredPosition = config.getConfig<String>("contentPreferredPosition").toPosition()
 
     override fun produceMetadata(): Map<String, Any?> {
-        // TODO replace this with dynamic element found based on "selector" config property
-        val rect = Rect(
-            Offset(
-                x = config.getConfigInt("x")?.toFloat() ?: 0f,
-                y = config.getConfigInt("y")?.toFloat() ?: 0f
-            ),
-            Size(
-                width = config.getConfigInt("width")?.toFloat() ?: 0f,
-                height = config.getConfigInt("height")?.toFloat() ?: 0f
-            )
+        val rootView = AppcuesActivityMonitor.activity?.window?.decorView?.rootView
+            ?: throw AppcuesTraitException("could not find root view")
+
+        val selectedView = rootView.findMatch(selector)
+            ?: throw AppcuesTraitException("could not find view matching selector ${selector ?: "(null)"}")
+
+        val insets = ViewCompat.getRootWindowInsets(rootView)?.getInsets(WindowInsetsCompat.Type.systemBars()) ?: Insets.NONE
+
+        // this is the position of the view relative to the entire screen
+        val actualPosition = Rect()
+        selectedView.getGlobalVisibleRect(actualPosition)
+
+        // this global position includes system bars, so we need to subtract those insets to get coordinates relative to the root
+        // view of what we are drawing content on top of
+        val x = actualPosition.left - insets.left
+        val y = actualPosition.top - insets.top
+
+        val displayMetrics = selectedView.context.resources.displayMetrics
+        val density = displayMetrics.density
+
+        val targetRectangle = TargetRectangleInfo(
+            x = x.toDp(density).toFloat(),
+            y = y.toDp(density).toFloat(),
+            width = actualPosition.width().toDp(density).toFloat(),
+            height = actualPosition.height().toDp(density).toFloat(),
+            contentDistance = contentDistance,
+            prefPosition = preferredPosition,
         )
 
-        return hashMapOf(METADATA_TARGET_RECT to rect)
+        return hashMapOf(TARGET_RECTANGLE_METADATA to targetRectangle)
     }
+}
+
+private fun View.findMatch(selector: ElementSelector?): View? {
+    return selector?.let {
+        val views = viewsMatchingSelector(selector)
+        views.firstOrNull()
+    }
+}
+
+private fun View.viewsMatchingSelector(selector: ElementSelector): List<View> {
+    val views = mutableListOf<View>()
+
+    this.selector()?.let {
+        if (it.hasAnyMatch(selector)) {
+            views.add(this)
+        }
+    }
+
+    (this as? ViewGroup)?.children?.forEach {
+        views.addAll(it.viewsMatchingSelector(selector))
+    }
+
+    return views
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetRectangleTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetRectangleTrait.kt
@@ -13,25 +13,6 @@ internal class TargetRectangleTrait(
     companion object {
 
         const val TYPE = "@appcues/target-rectangle"
-
-        const val TARGET_RECTANGLE_METADATA = "targetRectangle"
-    }
-
-    internal data class TargetRectangleInfo(
-        val x: Float = 0f,
-        val y: Float = 0f,
-        val relativeX: Double = 0.0,
-        val relativeY: Double = 0.0,
-        val width: Float = 0f,
-        val height: Float = 0f,
-        val relativeWidth: Double = 0.0,
-        val relativeHeight: Double = 0.0,
-        val contentDistance: Double = 0.0,
-        val prefPosition: ContentPreferredPosition? = null
-    )
-
-    enum class ContentPreferredPosition {
-        TOP, BOTTOM, LEADING, TRAILING
     }
 
     override fun produceMetadata(): Map<String, Any?> {
@@ -49,15 +30,5 @@ internal class TargetRectangleTrait(
         )
 
         return hashMapOf(TARGET_RECTANGLE_METADATA to targetRectangle)
-    }
-
-    private fun String?.toPosition(): ContentPreferredPosition? {
-        return when (this) {
-            "top" -> ContentPreferredPosition.TOP
-            "bottom" -> ContentPreferredPosition.BOTTOM
-            "leading" -> ContentPreferredPosition.LEADING
-            "trailing" -> ContentPreferredPosition.TRAILING
-            else -> null
-        }
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -96,9 +96,7 @@ internal class TooltipTrait(
         val density = LocalDensity.current
         val metadata = LocalAppcuesStepMetadata.current
 
-        // trait does not apply if no target rectangle in metadata
-        val targetRectInfo = rememberTargetRectangleInfo(metadata) ?: return
-
+        val targetRectInfo = rememberTargetRectangleInfo(metadata)
         val windowInfo = rememberAppcuesWindowInfo()
         val containerDimens = remember { mutableStateOf<TooltipContainerDimens?>(null) }
         val targetRect = targetRectInfo.getRect(windowInfo)

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -38,7 +38,6 @@ import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.trait.AppcuesTraitAnimatedVisibility
 import com.appcues.trait.ContentWrappingTrait
 import com.appcues.trait.PresentingTrait
-import com.appcues.trait.appcues.TargetRectangleTrait.TargetRectangleInfo
 import com.appcues.trait.appcues.TooltipPointerPosition.Bottom
 import com.appcues.trait.appcues.TooltipPointerPosition.None
 import com.appcues.trait.appcues.TooltipPointerPosition.Top
@@ -97,8 +96,10 @@ internal class TooltipTrait(
         val density = LocalDensity.current
         val metadata = LocalAppcuesStepMetadata.current
 
+        // trait does not apply if no target rectangle in metadata
+        val targetRectInfo = rememberTargetRectangleInfo(metadata) ?: return
+
         val windowInfo = rememberAppcuesWindowInfo()
-        val targetRectInfo = rememberTargetRectangleInfo(metadata)
         val containerDimens = remember { mutableStateOf<TooltipContainerDimens?>(null) }
         val targetRect = targetRectInfo.getRect(windowInfo)
         val distance = targetRectInfo.getContentDistance()

--- a/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt
@@ -6,9 +6,9 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.appcues.trait.appcues.TargetRectangleTrait
-import com.appcues.trait.appcues.TargetRectangleTrait.ContentPreferredPosition
-import com.appcues.trait.appcues.TargetRectangleTrait.TargetRectangleInfo
+import com.appcues.trait.appcues.ContentPreferredPosition
+import com.appcues.trait.appcues.TARGET_RECTANGLE_METADATA
+import com.appcues.trait.appcues.TargetRectangleInfo
 import com.appcues.trait.appcues.TooltipContainerDimens
 import com.appcues.trait.appcues.TooltipPointerPosition
 import com.appcues.trait.appcues.TooltipTrait
@@ -17,7 +17,7 @@ import com.appcues.ui.utils.AppcuesWindowInfo
 
 @Composable
 internal fun rememberTargetRectangleInfo(metadata: AppcuesStepMetadata): TargetRectangleInfo? {
-    return metadata.actual[TargetRectangleTrait.TARGET_RECTANGLE_METADATA] as TargetRectangleInfo?
+    return metadata.actual[TARGET_RECTANGLE_METADATA] as TargetRectangleInfo?
 }
 
 internal fun TargetRectangleInfo?.getRect(windowInfo: AppcuesWindowInfo): Rect? {

--- a/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesActivity.kt
@@ -34,7 +34,7 @@ internal class AppcuesActivity : AppCompatActivity() {
 
     private val scope: Scope by lazy { AppcuesKoinContext.koin.getScope(intent.getStringExtra(EXTRA_SCOPE_ID)!!) }
 
-    private val viewModel: AppcuesViewModel by viewModels { AppcuesViewModelFactory(scope) }
+    private val viewModel: AppcuesViewModel by viewModels { AppcuesViewModelFactory(scope, ::finish) }
 
     private val shakeGestureListener: ShakeGestureListener by lazy { ShakeGestureListener(context = this) }
 
@@ -52,7 +52,6 @@ internal class AppcuesActivity : AppCompatActivity() {
                 shakeGestureListener = shakeGestureListener,
                 logcues = logcues,
                 chromeClient = EmbedChromeClient(binding.appcuesCustomViewContainer),
-                onCompositionDismissed = ::finish
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
@@ -79,7 +79,7 @@ class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLifecycleObse
         if (parentView.findViewById<ComposeView>(R.id.appcues_overlay_layout) == null) {
             // then we add
             val binding = AppcuesOverlayLayoutBinding.inflate(layoutInflater)
-            if (viewModel == null) viewModel = AppcuesViewModel(scope)
+            if (viewModel == null) viewModel = AppcuesViewModel(scope, ::onCompositionDismiss)
             shakeGestureListener = ShakeGestureListener(this)
 
             // ensures it always comes before appcues_debugger_view
@@ -104,7 +104,6 @@ class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLifecycleObse
                     shakeGestureListener = remember { shakeGestureListener!! },
                     logcues = logcues,
                     chromeClient = EmbedChromeClient(binding.appcuesOverlayCustomViewContainer),
-                    onCompositionDismissed = ::onCompositionDismiss
                 )
             }
         }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesViewModelFactory.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesViewModelFactory.kt
@@ -5,11 +5,12 @@ import androidx.lifecycle.ViewModelProvider
 import org.koin.core.scope.Scope
 
 internal class AppcuesViewModelFactory(
-    private val scope: Scope
+    private val scope: Scope,
+    private val onDismiss: () -> Unit,
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return AppcuesViewModel(scope) as T
+        return AppcuesViewModel(scope, onDismiss) as T
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/ElementSelector.kt
+++ b/appcues/src/main/java/com/appcues/ui/ElementSelector.kt
@@ -11,4 +11,10 @@ internal data class ElementSelector(
 ) {
     val isValid: Boolean
         get() = accessibilityIdentifier != null || description != null || tag != null || id != null
+
+    fun hasAnyMatch(other: ElementSelector) =
+        (other.accessibilityIdentifier != null && other.accessibilityIdentifier == accessibilityIdentifier) ||
+            (other.description != null && other.description == description) ||
+            (other.tag != null && other.tag == tag) ||
+            (other.id != null && other.id == id)
 }

--- a/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
@@ -23,6 +23,7 @@ import com.appcues.statemachine.StepReference.StepOffset
 import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
 import com.appcues.util.LinkOpener
+import com.appcues.util.ResultOf.Success
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -135,7 +136,7 @@ class ExperienceLifecycleTrackerTest : KoinTest {
             machine.stateFlow.collect {
                 when (it) {
                     is BeginningStep -> {
-                        it.presentationComplete.invoke()
+                        it.presentationComplete.invoke(Success(Unit))
                     }
                     is EndingStep -> {
                         it.dismissAndContinue?.invoke()

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -37,6 +37,7 @@ import com.appcues.statemachine.StepReference.StepOffset
 import com.appcues.trait.AppcuesTraitException
 import com.appcues.trait.PresentingTrait
 import com.appcues.util.ResultOf
+import com.appcues.util.ResultOf.Success
 import com.google.common.truth.Truth.assertThat
 import io.mockk.Called
 import io.mockk.coVerify
@@ -806,7 +807,7 @@ class StateMachineTest : AppcuesScopeTest {
                 onStateChange?.invoke(it)
                 when (it) {
                     is BeginningStep -> {
-                        it.presentationComplete.invoke()
+                        it.presentationComplete.invoke(Success(Unit))
                     }
                     is EndingStep -> {
                         it.dismissAndContinue?.invoke()


### PR DESCRIPTION
## Handling Trait Errors
A big chunk of this work was to support propagation of trait errors during rendering, and appropriately ending an experience when that occurs. For example: a selector not found error when trying to render a tooltip step with a target element trait. This was generally handled by changing the completion callback on render from: 
```
val presentationComplete: (() -> Unit),
```
to
```
val presentationComplete: ((ResultOf<Unit, Error>) -> Unit),
```
This applies to the BeginningStep state property that is used in transition to RenderingStep. Now, the UI layer can signal that the presentation failed, via the Error result there, and allow the state machine to be aware of that and transition back out of the experience and trigger the proper analytics.

To actually handle the error, when a trait exception arises during the processing of metadata, deep in the composition, it is bubbled back up to the ViewModel using the `LocalViewModel` (CompositionLocal). The VM can then handle informing the StateMachine, and finally dismissing the view. The dismissal is handled in the view model, now that it is aware of the `onDismiss` handler that gets passed through from wherever the view model was initiated (ie. AppcuesOverlayManager for tooltips, AppcuesActivity for modals).

## Target Element Trait Implementation
A few elements that are common to target-rectangle and target-element traits are moved to the shared `TargetContent.kt` file - `TargetRectangleInfo`, the string key for "targetRectangle" metadata, and `ContentPreferredPosition` enum. The `TargetElementTrait` then works to look up the given selector in the current view hierarchy and, if found, populate the "targetRectangle" metadata from it. The rest of the rendering logic for keyhole and tooltips is unchanged, as it just relies on this target rectangle.

open question: iOS has a way to detect when the screen has changed size or layout in some form and recalculate this rect - it is not clear if we need anything like this, or if the normal re-composition will handle it in this case, since it's all Compose here.

## Example
This shows a 3-step element targeted tooltip experience
* find view with contentDescription "Profile", for the profile tab, first step
* find view with tag "txtGivenName" for the second step
* find view with tag "btnSaveProfile" for the third step

https://user-images.githubusercontent.com/19266448/223548512-e1c1103b-afcf-467f-8aa4-1d6eb076184e.mov

> note: some additional logic is being used in the sample app here between step 1 and 2, since a navigation action is taking place. This requires that the host app uses the `NavigationHandler` to inform Appcues when the deep link navigation has completed, otherwise target element experiences can fail, if the view they are looking for has not been fully loaded into the current activity yet. This will likely be a point of customer complication for any more sophisticated walk through type of experiences.