### PR TITLE
Add @appcues/request-review action

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -115,6 +115,9 @@ dependencies {
     implementation "com.google.accompanist:accompanist-webview:$accompanist_version"
     // Navigation Animated
     implementation "com.google.accompanist:accompanist-navigation-animation:$accompanist_version"
+    // Play In-App Review
+    implementation 'com.google.android.play:review:2.0.1'
+    implementation 'com.google.android.play:review-ktx:2.0.1'
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "io.mockk:mockk:1.12.2"

--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|screenSize|screenLayout"
             android:theme="@style/Appcues.AppcuesActivityTheme" />
+        <activity
+            android:name=".ui.InAppReviewActivity"
+            android:exported="false"
+            android:theme="@style/Appcues.AppcuesActivityTheme" />
     </application>
 
 </manifest>

--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -4,6 +4,7 @@ import com.appcues.action.appcues.CloseAction
 import com.appcues.action.appcues.ContinueAction
 import com.appcues.action.appcues.LaunchExperienceAction
 import com.appcues.action.appcues.LinkAction
+import com.appcues.action.appcues.RequestReviewAction
 import com.appcues.action.appcues.StepInteractionAction
 import com.appcues.action.appcues.SubmitFormAction
 import com.appcues.action.appcues.TrackEventAction
@@ -17,63 +18,14 @@ internal object ActionKoin : KoinScopePlugin {
         scoped { ActionRegistry(scope = get()) }
         scoped { ActionProcessor(scope = get()) }
 
-        factory { params ->
-            CloseAction(
-                config = params.getOrNull(),
-                experienceRenderer = get(),
-            )
-        }
-
-        factory { params ->
-            LinkAction(
-                config = params.getOrNull(),
-                linkOpener = get(),
-            )
-        }
-
-        factory { params ->
-            TrackEventAction(
-                config = params.getOrNull()
-            )
-        }
-
-        factory { params ->
-            ContinueAction(
-                config = params.getOrNull(),
-                stateMachine = get(),
-            )
-        }
-
-        factory { params ->
-            LaunchExperienceAction(
-                config = params.getOrNull(),
-                stateMachine = get(),
-                experienceRenderer = get(),
-            )
-        }
-
-        factory { params ->
-            UpdateProfileAction(
-                config = params.getOrNull(),
-                storage = get(),
-            )
-        }
-
-        factory { params ->
-            SubmitFormAction(
-                config = params.getOrNull(),
-                analyticsTracker = get(),
-                stateMachine = get(),
-            )
-        }
-
-        factory { params ->
-            StepInteractionAction(
-                config = params.getOrNull(),
-                interaction = params.get(),
-                analyticsTracker = get(),
-                stateMachine = get(),
-            )
-        }
+        factory { CloseAction(config = it.getOrNull(), experienceRenderer = get()) }
+        factory { LinkAction(config = it.getOrNull(), linkOpener = get()) }
+        factory { TrackEventAction(config = it.getOrNull()) }
+        factory { ContinueAction(config = it.getOrNull(), stateMachine = get()) }
+        factory { LaunchExperienceAction(config = it.getOrNull(), stateMachine = get(), experienceRenderer = get()) }
+        factory { UpdateProfileAction(config = it.getOrNull(), storage = get()) }
+        factory { SubmitFormAction(config = it.getOrNull(), analyticsTracker = get(), stateMachine = get()) }
+        factory { StepInteractionAction(config = it.getOrNull(), interaction = it.get(), analyticsTracker = get(), stateMachine = get()) }
+        factory { RequestReviewAction(config = it.getOrNull(), context = get(), koinScope = get()) }
     }
 }

--- a/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
@@ -4,6 +4,7 @@ import com.appcues.action.appcues.CloseAction
 import com.appcues.action.appcues.ContinueAction
 import com.appcues.action.appcues.LaunchExperienceAction
 import com.appcues.action.appcues.LinkAction
+import com.appcues.action.appcues.RequestReviewAction
 import com.appcues.action.appcues.SubmitFormAction
 import com.appcues.action.appcues.TrackEventAction
 import com.appcues.action.appcues.UpdateProfileAction
@@ -32,6 +33,7 @@ internal class ActionRegistry(override val scope: Scope) : KoinScopeComponent {
         register(UpdateProfileAction.TYPE) { get<UpdateProfileAction> { parametersOf(it) } }
         register(LaunchExperienceAction.TYPE) { get<LaunchExperienceAction> { parametersOf(it) } }
         register(SubmitFormAction.TYPE) { get<SubmitFormAction> { parametersOf(it) } }
+        register(RequestReviewAction.TYPE) { get<RequestReviewAction> { parametersOf(it) } }
     }
 
     operator fun get(key: String): ActionFactoryBlock? {

--- a/appcues/src/main/java/com/appcues/action/appcues/RequestReviewAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/RequestReviewAction.kt
@@ -1,0 +1,30 @@
+package com.appcues.action.appcues
+
+import android.content.Context
+import com.appcues.Appcues
+import com.appcues.action.ExperienceAction
+import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.ui.InAppReviewActivity
+import kotlinx.coroutines.CompletableDeferred
+import org.koin.core.scope.Scope
+
+internal class RequestReviewAction(
+    override val config: AppcuesConfigMap,
+    private val context: Context,
+    private val koinScope: Scope,
+) : ExperienceAction {
+
+    companion object {
+        const val TYPE = "@appcues/request-review"
+    }
+
+    override suspend fun execute(appcues: Appcues) {
+
+        val completion = CompletableDeferred<Boolean>()
+        InAppReviewActivity.completion = completion
+
+        context.startActivity(InAppReviewActivity.getIntent(context, koinScope.id))
+
+        completion.await()
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/InAppReviewActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/InAppReviewActivity.kt
@@ -1,0 +1,99 @@
+package com.appcues.ui
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
+import androidx.lifecycle.lifecycleScope
+import com.appcues.di.AppcuesKoinContext
+import com.appcues.logging.Logcues
+import com.google.android.play.core.review.ReviewManagerFactory
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+internal class InAppReviewActivity : AppCompatActivity() {
+
+    companion object {
+        private const val REQUEST_TIMEOUT_MILLISECONDS = 3000L
+
+        private const val EXTRA_SCOPE_ID = "EXTRA_SCOPE_ID"
+
+        // since there can only be one review activity running at a time, this companion level
+        // deferred can be used to await completion
+        var completion: CompletableDeferred<Boolean>? = null
+
+        fun getIntent(context: Context, scopeId: String): Intent =
+            Intent(context, InAppReviewActivity::class.java).apply {
+                putExtras(
+                    bundleOf(
+                        EXTRA_SCOPE_ID to scopeId
+                    )
+                )
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+    }
+
+    private var success = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        // remove enter animation from this activity
+        overridePendingTransition(0, 0)
+        super.onCreate(savedInstanceState)
+
+        val requestCompletion = CompletableDeferred<Boolean>()
+
+        val manager = ReviewManagerFactory.create(this)
+        val request = manager.requestReviewFlow()
+        request.addOnCompleteListener { task ->
+
+            // will never get here on non-play store builds - need a timeout fallback, which is handled
+            // below.  This completion handler will short-circuit that timeout and run the normal review flow,
+            // when available.
+            requestCompletion.complete(true)
+
+            if (task.isSuccessful) {
+                val reviewInfo = task.result
+
+                // We got the ReviewInfo object
+                if (reviewInfo != null) {
+                    val flow = manager.launchReviewFlow(this, reviewInfo)
+                    flow.addOnCompleteListener {
+                        // The flow has finished. The API does not indicate whether the user
+                        // reviewed or not, or even whether the review dialog was shown. Thus, no
+                        // matter the result, we continue our app flow.
+                        success = true
+                        finish()
+                    }
+                } else {
+                    finish()
+                }
+            } else {
+                finish()
+            }
+        }
+
+        lifecycleScope.launch {
+            try {
+                withTimeout(REQUEST_TIMEOUT_MILLISECONDS) {
+                    requestCompletion.await()
+                }
+            } catch (e: TimeoutCancellationException) {
+                val scope = AppcuesKoinContext.koin.getScope(intent.getStringExtra(EXTRA_SCOPE_ID)!!)
+                val logcues = scope.get<Logcues>()
+                logcues.info("In-App Review not available for this application")
+                finish()
+            }
+        }
+    }
+
+    override fun finish() {
+        super.finish()
+        // remove exit animation from this activity
+        overridePendingTransition(0, 0)
+
+        completion?.complete(true)
+    }
+}


### PR DESCRIPTION
targeting `release/1.3.1` (which will actually be 1.4.0 now)

This is effectively reverting the removal in #205 , brining back the request-review action and the dependency on the Play library to handle it.