### PR TITLE
🔧 Update release changelog emoji exclusion

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -113,7 +113,7 @@ case "$response" in
 esac
 
 # get the commits since the last release, filtering ones that aren't relevant.
-changelog=$(git log --pretty=format:"- [%as] %s (%h)" $(git describe --tags --abbrev=0 @^)..@ --abbrev=7 | sed '/[🔧🎬⬆️📸✅💡📝]/d')
+changelog=$(git log --pretty=format:"- [%as] %s (%h)" $(git describe --tags --abbrev=0 @^)..@ --abbrev=7 | sed '/[🔧🎬⬆📸✅💡📝]/d')
 tempFile=$(mktemp)
 echo $changelog
 # write changelog to temp file.


### PR DESCRIPTION
A hidden `<fe0f>` was filtering out some emoji we want to include.

If you want to fix the GitHub release notes for the previous releases, you can generate them with this (updating the version tags appropriately)

```sh
git log --pretty=format:"- [%as] %s (%h)"  1.3.0..1.4.0 | sed '/[🔧🎬⬆📸✅💡📝]/d'
```