### PR TITLE
✨ Enable horizontal positioning for tooltip container

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetContent.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetContent.kt
@@ -16,15 +16,15 @@ internal data class TargetRectangleInfo(
 )
 
 internal enum class ContentPreferredPosition {
-    TOP, BOTTOM, LEADING, TRAILING
+    TOP, BOTTOM, LEFT, RIGHT
 }
 
 internal fun String?.toPosition(): ContentPreferredPosition? {
     return when (this) {
         "top" -> ContentPreferredPosition.TOP
         "bottom" -> ContentPreferredPosition.BOTTOM
-        "leading" -> ContentPreferredPosition.LEADING
-        "trailing" -> ContentPreferredPosition.TRAILING
+        "left" -> ContentPreferredPosition.LEFT
+        "right" -> ContentPreferredPosition.RIGHT
         else -> null
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt
@@ -1,16 +1,26 @@
 package com.appcues.trait.extensions
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.appcues.trait.appcues.ContentPreferredPosition
+import com.appcues.trait.appcues.ContentPreferredPosition.BOTTOM
+import com.appcues.trait.appcues.ContentPreferredPosition.LEFT
+import com.appcues.trait.appcues.ContentPreferredPosition.RIGHT
+import com.appcues.trait.appcues.ContentPreferredPosition.TOP
 import com.appcues.trait.appcues.TARGET_RECTANGLE_METADATA
 import com.appcues.trait.appcues.TargetRectangleInfo
 import com.appcues.trait.appcues.TooltipContainerDimens
 import com.appcues.trait.appcues.TooltipPointerPosition
+import com.appcues.trait.appcues.TooltipPointerPosition.Bottom
+import com.appcues.trait.appcues.TooltipPointerPosition.Left
+import com.appcues.trait.appcues.TooltipPointerPosition.None
+import com.appcues.trait.appcues.TooltipPointerPosition.Right
+import com.appcues.trait.appcues.TooltipPointerPosition.Top
 import com.appcues.trait.appcues.TooltipTrait
 import com.appcues.ui.composables.AppcuesStepMetadata
 import com.appcues.ui.utils.AppcuesWindowInfo
@@ -46,20 +56,43 @@ internal fun TargetRectangleInfo?.getTooltipPointerPosition(
     windowInfo: AppcuesWindowInfo,
     containerDimens: TooltipContainerDimens?,
     targetRect: Rect?,
+    tooltipMaxHeight: MutableState<Dp>,
 ): TooltipPointerPosition {
-    if (targetRect == null || containerDimens == null) return TooltipPointerPosition.None
+    if (this == null || targetRect == null || containerDimens == null) return None
 
-    val topSafeArea = targetRect.top.dp - TooltipTrait.SCREEN_VERTICAL_PADDING
-    val bottomSafeArea = windowInfo.heightDp - TooltipTrait.SCREEN_VERTICAL_PADDING - targetRect.bottom.dp
+    val availableSpaceTop = targetRect.top.dp - TooltipTrait.SCREEN_VERTICAL_PADDING
+    val availableSpaceBottom = windowInfo.heightDp - TooltipTrait.SCREEN_VERTICAL_PADDING - targetRect.bottom.dp
 
-    return when (this?.prefPosition) {
-        ContentPreferredPosition.TOP ->
-            if (topSafeArea > containerDimens.heightDp) TooltipPointerPosition.Bottom else TooltipPointerPosition.Top
-        ContentPreferredPosition.BOTTOM ->
-            if (bottomSafeArea > containerDimens.heightDp) TooltipPointerPosition.Top else TooltipPointerPosition.Bottom
-        else -> when {
-            targetRect.center.y.dp < windowInfo.heightDp / 2 -> TooltipPointerPosition.Top
-            else -> TooltipPointerPosition.Bottom
-        }
+    val excessSpaceTop = availableSpaceTop - containerDimens.heightDp
+    val excessSpaceBottom = availableSpaceBottom - containerDimens.heightDp
+    val excessSpaceLeft = targetRect.left.dp - TooltipTrait.SCREEN_HORIZONTAL_PADDING - containerDimens.widthDp
+    val excessSpaceRight = windowInfo.widthDp - TooltipTrait.SCREEN_HORIZONTAL_PADDING - targetRect.right.dp - containerDimens.widthDp
+
+    val canPositionVertically = excessSpaceTop > 0.dp || excessSpaceBottom > 0.dp
+    val canPositionHorizontally = excessSpaceLeft > 0.dp || excessSpaceRight > 0.dp
+
+    return prefPosition.toPointerPosition(excessSpaceTop, excessSpaceBottom, excessSpaceLeft, excessSpaceRight) ?: when {
+        // passed the preference positions we position the tooltip wherever is available.
+        canPositionVertically -> if (excessSpaceTop > excessSpaceBottom) Bottom else Top
+        canPositionHorizontally -> if (excessSpaceLeft > excessSpaceRight) Right else Left
+        // Doesn't fit anywhere so pick the top/bottom side that has the most space.
+        // Allowing left/right here would mean the width gets compressed and that opens a can of worms.
+        excessSpaceTop > excessSpaceBottom -> Bottom.also { tooltipMaxHeight.value = availableSpaceTop }
+        else -> Top.also { tooltipMaxHeight.value = availableSpaceBottom }
+    }
+}
+
+private fun ContentPreferredPosition?.toPointerPosition(
+    excessSpaceTop: Dp,
+    excessSpaceBottom: Dp,
+    excessSpaceLeft: Dp,
+    excessSpaceRight: Dp
+): TooltipPointerPosition? {
+    return when {
+        this == TOP && excessSpaceTop > 0.dp -> Bottom
+        this == BOTTOM && excessSpaceBottom > 0.dp -> Top
+        this == LEFT && excessSpaceLeft > 0.dp -> Right
+        this == RIGHT && excessSpaceRight > 0.dp -> Left
+        else -> null
     }
 }


### PR DESCRIPTION
Added Left and Right as preferredContentPosition supported for tooltips,

then added piece of calculation rules to determine where we should position the tooltip, and this is mirroring behavior described for IOS and WEB tooltip.

* Another pass on tooltip sizing related to task [#48999](https://app.shortcut.com/appcues/story/48999/android-update-tooltip-to-fit-in-visible-area)
* [This is](https://github.com/appcues/appcues-android-sdk/blob/2de61c114632faec66f4e9fa0da8e33d0e59f102/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt#L55) the method that should mirror IOS/WEB rules for tooltip positioning
* UI tests running OK