### PR TITLE
Add support for close button styling

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -93,8 +94,13 @@ private fun Header(debuggerViewModel: DebuggerViewModel) {
                     onClickLabel = stringResource(id = string.appcues_screen_capture_dismiss)
                 )
                 .drawBehind {
-                    xShapePath(color = Color.Black, pathSize = 16.dp, strokeWidth = 1.5.dp)
-                        .also { drawPath(path = it, Color.Black) }
+                    xShapePath(pathSize = 16.dp).also {
+                        drawPath(
+                            path = it,
+                            color = Color.Black,
+                            style = Stroke(1.5.dp.toPx()),
+                        )
+                    }
                 }
         )
     }

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -1,45 +1,60 @@
 package com.appcues.trait.appcues
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.PaintingStyle
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.R
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfig
 import com.appcues.data.model.getConfigOrDefault
+import com.appcues.data.model.getConfigStyle
+import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment
+import com.appcues.data.model.styling.ComponentStyle.ComponentVerticalAlignment
 import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.ContainerDecoratingTrait
 import com.appcues.trait.ContainerDecoratingTrait.ContainerDecoratingType
-import com.appcues.trait.appcues.SkippableTrait.ButtonAppearance.Default
-import com.appcues.trait.appcues.SkippableTrait.ButtonAppearance.Hidden
-import com.appcues.trait.appcues.SkippableTrait.ButtonAppearance.Minimal
 import com.appcues.ui.ExperienceRenderer
+import com.appcues.ui.extensions.getBoxAlignment
+import com.appcues.ui.extensions.getColor
+import com.appcues.ui.extensions.getMargins
 import com.appcues.ui.extensions.xShapePath
+import com.appcues.util.ne
 import kotlinx.coroutines.launch
+import kotlin.math.min
 
 internal class SkippableTrait(
     override val config: AppcuesConfigMap,
@@ -48,56 +63,78 @@ internal class SkippableTrait(
 ) : ContainerDecoratingTrait, BackdropDecoratingTrait {
 
     companion object {
-
         const val TYPE = "@appcues/skippable"
 
         private const val CONFIG_BUTTON_APPEARANCE = "buttonAppearance"
+        private const val CONFIG_BUTTON_STYLE = "buttonStyle"
         private const val CONFIG_IGNORE_BACKDROP_TAP = "ignoreBackdropTap"
+
+        // default button is 30x30 - can override in buttonStyle
+        private const val BUTTON_DEFAULT_SIZE = 30.0
+
+        // default margin of 8 around every side - can override in buttonStyle
+        private const val BUTTON_DEFAULT_MARGIN = 8
+
+        // the 'X' drawn in the button will scale to 40% of button size (height)
+        private const val BUTTON_X_SCALE_FACTOR = 0.4
+
+        // the 'X' in a minimal style button uses a 1.5 dp stroke width for a 30 dp size button
+        // and scales accordingly with different sizes
+        private const val BUTTON_X_MINIMAL_STROKE_FACTOR = 1.5
+
+        // the 'X' in a default style button uses a 2.0 dp stroke width for a 30 dp size button
+        // and scales accordingly with different sizes
+        private const val BUTTON_X_DEFAULT_STOKE_FACTOR = 2.0
     }
 
-    private sealed class ButtonAppearance(val margin: Dp, val size: Dp, val padding: Dp) {
-
-        // calculates rippleRadius based on size and padding provided
-        val rippleRadius = (size / 2) - padding
-
-        object Hidden : ButtonAppearance(0.dp, 0.dp, 0.dp)
-        object Minimal : ButtonAppearance(4.dp, 30.dp, 8.dp)
-        object Default : ButtonAppearance(8.dp, 30.dp, 8.dp)
+    private enum class ButtonAppearance {
+        DEFAULT, MINIMAL, HIDDEN
     }
 
     override val containerComposeOrder = ContainerDecoratingType.OVERLAY
 
+    // config properties
+
+    private val buttonStyle = config.getConfigStyle(CONFIG_BUTTON_STYLE)
+    private val ignoreBackdropTap = config.getConfigOrDefault(CONFIG_IGNORE_BACKDROP_TAP, false)
     private val buttonAppearance = when (config.getConfig<String>(CONFIG_BUTTON_APPEARANCE)) {
-        "hidden" -> Hidden
-        "minimal" -> Minimal
-        "default" -> Default
-        else -> Default
+        "hidden" -> ButtonAppearance.HIDDEN
+        "minimal" -> ButtonAppearance.MINIMAL
+        "default" -> ButtonAppearance.DEFAULT
+        else -> ButtonAppearance.DEFAULT
     }
 
-    private val ignoreBackdropTap = config.getConfigOrDefault(CONFIG_IGNORE_BACKDROP_TAP, false)
+    // computed style props
+
+    private val buttonWidth by lazy { buttonStyle?.width ?: buttonStyle?.height ?: BUTTON_DEFAULT_SIZE }
+    private val buttonHeight by lazy { buttonStyle?.height ?: BUTTON_DEFAULT_SIZE }
+    private val defaultCornerRadius by lazy { min(buttonWidth, buttonHeight) / 2 }
+    private val horizontalAlignment by lazy { buttonStyle?.horizontalAlignment ?: ComponentHorizontalAlignment.TRAILING }
+    private val verticalAlignment by lazy { buttonStyle?.verticalAlignment ?: ComponentVerticalAlignment.TOP }
+    private val cornerRadius by lazy { buttonStyle?.cornerRadius ?: defaultCornerRadius }
+    private val rippleRadius by lazy { buttonSize / 2 }
+    private val strokeWidth by lazy {
+        val strokeFactor = when (buttonAppearance) {
+            ButtonAppearance.MINIMAL -> BUTTON_X_MINIMAL_STROKE_FACTOR
+            else -> BUTTON_X_DEFAULT_STOKE_FACTOR
+        }
+        (strokeFactor / BUTTON_DEFAULT_SIZE * buttonSize).dp
+    }
+    private val buttonSize
+        // normally height and width are equal, but for any calculations where a single
+        // size value is needed, height is the proxy for size
+        get() = buttonHeight
 
     @Composable
     override fun BoxScope.DecorateContainer(containerPadding: PaddingValues, safeAreaInsets: PaddingValues) {
         val description = stringResource(id = R.string.appcues_skippable_trait_dismiss)
+
         Spacer(
             modifier = Modifier
                 .padding(safeAreaInsets)
-                .align(Alignment.TopEnd)
-                .padding(buttonAppearance.margin)
-                .size(buttonAppearance.size)
-                .clip(CircleShape)
-                .clickable(
-                    onClick = {
-                        appcuesCoroutineScope.launch {
-                            experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
-                        }
-                    },
-                    role = Role.Button,
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = rememberRipple(bounded = false, radius = buttonAppearance.rippleRadius),
-                    onClickLabel = description
-                )
-                .drawSkippableButton(buttonAppearance)
+                .align(getBoxAlignment(horizontalAlignment, verticalAlignment))
+                .padding(buttonStyle.getMargins(BUTTON_DEFAULT_MARGIN.dp))
+                .styleButton(isSystemInDarkTheme())
                 // useful for testing and also for accessibility
                 .semantics { this.contentDescription = description }
         )
@@ -123,37 +160,171 @@ internal class SkippableTrait(
         content()
     }
 
-    /**
-     * Apply different modifiers based on ButtonAppearance
-     */
-    private fun Modifier.drawSkippableButton(buttonAppearance: ButtonAppearance): Modifier {
+    // styles the close X button differently based on the appearance set in config
+    private fun Modifier.styleButton(isDark: Boolean): Modifier {
         return this.then(
             when (buttonAppearance) {
-                Hidden -> Modifier
-                Default ->
+                ButtonAppearance.HIDDEN -> Modifier
+                ButtonAppearance.DEFAULT ->
                     Modifier
-                        .background(Color(color = 0x54000000))
-                        .padding(buttonAppearance.padding)
-                        .clip(CircleShape)
-                        .drawBehind {
-                            xShapePath(
-                                color = Color(color = 0xFFEFEFEF),
-                                pathSize = buttonAppearance.size,
-                                strokeWidth = 1.5.dp,
-                            ).also { drawPath(path = it, color = Color.Transparent) }
-                        }
-                Minimal ->
+                        .buttonShadow(isDark)
+                        .width(buttonWidth.dp)
+                        .height(buttonHeight.dp)
+                        .clip(RoundedCornerShape(cornerRadius.dp))
+                        .handleSkipClick()
+                        .drawDefaultX(isDark)
+                        .buttonBorder(isDark)
+                ButtonAppearance.MINIMAL ->
                     Modifier
-                        .padding(buttonAppearance.padding)
-                        .clip(CircleShape)
-                        .drawBehind {
-                            xShapePath(
-                                color = Color(color = 0xFFB2B2B2),
-                                pathSize = buttonAppearance.size,
-                                strokeWidth = 1.5.dp,
-                            ).also { drawPath(path = it, color = Color.Transparent, blendMode = BlendMode.Difference) }
-                        }
+                        .width(buttonWidth.dp)
+                        .height(buttonHeight.dp)
+                        .handleSkipClick()
+                        .drawMinimalX(isDark)
             }
         )
+    }
+
+    // default X button
+    // - background shape with a background color from style or a default semi-transparent 0x54000000
+    // - foreground X path with color from style or a default 0xFFEFEFEF
+    private fun Modifier.drawDefaultX(isDark: Boolean): Modifier {
+        return this.then(
+            background(buttonStyle?.backgroundColor?.getColor(isDark) ?: Color(color = 0x54000000))
+                .drawBehind {
+                    xShapePath(pathSize = (buttonHeight * BUTTON_X_SCALE_FACTOR).dp).also {
+                        drawPath(
+                            path = it,
+                            color = buttonStyle?.foregroundColor?.getColor(isDark) ?: Color(color = 0xFFEFEFEF),
+                            style = Stroke(strokeWidth.toPx()),
+                        )
+                    }
+                }
+        )
+    }
+
+    // minimal X button
+    // - no background
+    // - foreground color uses 70% white tint with an exclusion blend by default, but a specific color from style can override
+    // - an optional shadow can be applied to the path of the X itself (not a background container shadow like default)
+    private fun Modifier.drawMinimalX(isDark: Boolean): Modifier {
+        return this.then(
+            drawBehind {
+                xShapePath(pathSize = (buttonHeight * BUTTON_X_SCALE_FACTOR).dp).also {
+                    drawPathShadow(it, isDark)
+                    val foregroundColor = buttonStyle?.foregroundColor?.getColor(isDark)
+                    val drawStyle = Stroke(strokeWidth.toPx())
+                    if (foregroundColor != null) {
+                        drawPath(
+                            path = it,
+                            color = foregroundColor,
+                            style = drawStyle
+                        )
+                    } else {
+                        drawPath(
+                            path = it,
+                            color = Color.Black,
+                            colorFilter = ColorFilter.tint(Color(color = 0xB3FFFFFF), BlendMode.Difference),
+                            style = drawStyle
+                        )
+                    }
+                }
+            }
+        )
+    }
+
+    // draws a shadow on the outer button shape - only used in default appearance
+    private fun Modifier.buttonShadow(isDark: Boolean): Modifier {
+        return this.then(
+            buttonStyle?.shadow?.let { shadow ->
+                drawBehind {
+                    val color = shadow.color.getColor(isDark)
+                    val shadowColor = color.toArgb()
+                    val transparent = color.copy(alpha = 0.0f).toArgb()
+
+                    drawIntoCanvas {
+                        val paint = Paint()
+                        val frameworkPaint = paint.asFrameworkPaint()
+                        frameworkPaint.color = transparent
+
+                        frameworkPaint.setShadowLayer(
+                            shadow.radius.dp.toPx(),
+                            shadow.x.dp.toPx(),
+                            shadow.y.dp.toPx(),
+                            shadowColor
+                        )
+
+                        it.drawRoundRect(
+                            0f,
+                            0f,
+                            this.size.width,
+                            this.size.height,
+                            cornerRadius.dp.toPx(),
+                            cornerRadius.dp.toPx(),
+                            paint
+                        )
+                    }
+                }
+            } ?: Modifier
+        )
+    }
+
+    // draws a border around the outer button shape - only used in default appearance
+    private fun Modifier.buttonBorder(isDark: Boolean) = this.then(
+        if (buttonStyle?.borderWidth != null && buttonStyle.borderWidth ne 0.0 && buttonStyle.borderColor != null) {
+            Modifier
+                .border(
+                    width = buttonStyle.borderWidth.dp,
+                    color = buttonStyle.borderColor.getColor(isDark),
+                    shape = RoundedCornerShape(cornerRadius.dp)
+                )
+                .padding(buttonStyle.borderWidth.dp)
+        } else {
+            Modifier
+        }
+    )
+
+    // dismiss the experience on button tap
+    private fun Modifier.handleSkipClick(): Modifier {
+        return this.then(
+            Modifier.composed {
+                clickable(
+                    onClick = {
+                        appcuesCoroutineScope.launch {
+                            experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
+                        }
+                    },
+                    role = Role.Button,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = rememberRipple(bounded = false, radius = rippleRadius.dp),
+                    onClickLabel = stringResource(id = R.string.appcues_skippable_trait_dismiss)
+                )
+            }
+        )
+    }
+
+    // used to draw a shadow under the 'X' in minimal appearance
+    private fun DrawScope.drawPathShadow(path: Path, isDark: Boolean) {
+        buttonStyle?.shadow?.let { shadow ->
+            val color = shadow.color.getColor(isDark)
+            val shadowColor = color.toArgb()
+            val transparent = color.copy(alpha = 0.0f).toArgb()
+
+            drawIntoCanvas { canvas ->
+                val paint = Paint().apply {
+                    this.style = PaintingStyle.Stroke
+                    this.strokeWidth = this@SkippableTrait.strokeWidth.toPx()
+                }
+                paint.asFrameworkPaint().apply {
+                    this.color = transparent
+                    setShadowLayer(
+                        shadow.radius.dp.toPx(),
+                        shadow.x.dp.toPx(),
+                        shadow.y.dp.toPx(),
+                        shadowColor
+                    )
+                }
+                canvas.drawPath(path, paint)
+            }
+        }
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -129,15 +129,17 @@ internal class SkippableTrait(
     override fun BoxScope.DecorateContainer(containerPadding: PaddingValues, safeAreaInsets: PaddingValues) {
         val description = stringResource(id = R.string.appcues_skippable_trait_dismiss)
 
-        Spacer(
-            modifier = Modifier
-                .padding(safeAreaInsets)
-                .align(getBoxAlignment(horizontalAlignment, verticalAlignment))
-                .padding(buttonStyle.getMargins(BUTTON_DEFAULT_MARGIN.dp))
-                .styleButton(isSystemInDarkTheme())
-                // useful for testing and also for accessibility
-                .semantics { this.contentDescription = description }
-        )
+        if (buttonAppearance != ButtonAppearance.HIDDEN) {
+            Spacer(
+                modifier = Modifier
+                    .padding(safeAreaInsets)
+                    .align(getBoxAlignment(horizontalAlignment, verticalAlignment))
+                    .padding(buttonStyle.getMargins(BUTTON_DEFAULT_MARGIN.dp))
+                    .styleButton(isSystemInDarkTheme())
+                    // useful for testing and also for accessibility
+                    .semantics { this.contentDescription = description }
+            )
+        }
     }
 
     @Composable

--- a/appcues/src/main/java/com/appcues/ui/extensions/DrawScopeEx.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/DrawScopeEx.kt
@@ -1,8 +1,6 @@
 package com.appcues.ui.extensions
 
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.toRect
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.Dp
@@ -11,39 +9,25 @@ import java.lang.Float.max
 /**
  * Defines a path to draw the X by drawing two lines crossing from edge to edge.
  */
-internal fun DrawScope.xShapePath(
-    color: Color,
-    pathSize: Dp,
-    strokeWidth: Dp,
-): Path {
+internal fun DrawScope.xShapePath(pathSize: Dp): Path {
     return Path()
         .apply {
-            val strokeWidthPx = strokeWidth.toPx()
             val pathSizePx = pathSize.toPx()
+            val sizeRect = size.toRect()
 
             // center the desired size within the current bounds
+            // find the delta to deflate the container rect in each direction
             val deltaX = max(size.width - pathSizePx, 0.0f) / 2
             val deltaY = max(size.height - pathSizePx, 0.0f) / 2
 
-            val sizeRect = size.toRect()
-            val pathRect = Rect(
-                left = sizeRect.left + deltaX,
-                top = sizeRect.top + deltaY,
-                right = sizeRect.right - deltaX,
-                bottom = sizeRect.bottom - deltaY
-            )
+            val minX = 0 + deltaX
+            val minY = 0 + deltaY
+            val maxX = sizeRect.right - deltaX
+            val maxY = sizeRect.bottom - deltaY
 
-            drawLine(
-                color = color,
-                start = pathRect.topLeft,
-                end = pathRect.bottomRight,
-                strokeWidth = strokeWidthPx,
-            )
-            drawLine(
-                color = color,
-                start = pathRect.bottomLeft,
-                end = pathRect.topRight,
-                strokeWidth = strokeWidthPx,
-            )
+            moveTo(minX, minY) // move to top left
+            lineTo(maxX, maxY) // line to bottom right
+            moveTo(minX, maxY) // move to bottom left
+            lineTo(maxX, minY) // line to top right
         }
 }


### PR DESCRIPTION
This PR stacks on #367 and adds the new styling support in the `SkippableTrait`. 

I would suggest not really looking at the diff here and really just looking at `SkippableTrait` as a new "2.0" implementation of the close button, since it now has a much different capability set. Almost all the changes are in there, other than the one related change to `X` path drawing in `DrawScopeExt` (and updated usage in one other spot in `CaptureConfirmDialog`).

There were a lot of little details covered here, but in summary - it handles all of the spec updates defined in https://github.com/appcues/appcues-mobile-experience-spec/pull/165 for styling options in `buttonStyle` on the `@appcues/skippable` trait. 

I restructured the code a bit to pull out the distinct differences in how `default` and `minimal` appearances are handled. In a couple spots, I opted to use a specific implementation in the file here (border and shadow) rather than try to use the shared one in `ModifierExt` - the reason being that there were subtle specific details here around how the default corner radius should be handled, for back compat, and I didn't want to over complicate the shared version used by everything else for experience rendering.

Next I'll work on UI testing to match what is in https://github.com/appcues/appcues-mobile-experience-spec/pull/165, for the Android side. In the short term, I'll include some side by side screens with iOS and Android to demonstrate the core capabilities here. iOS on the left, Android on the right.

| test case | screenshot|
| --- | ---|
| default on dark, no styling | ![appcues-skippable-default](https://user-images.githubusercontent.com/19266448/228556673-17bcc974-42ed-42f8-a9ed-c98a3c991c88.png) |
| default on light, no styling | ![appcues-skippable-default-light](https://user-images.githubusercontent.com/19266448/228556700-278e2a25-68c3-4952-8c9c-6a4227fc8baf.png) |
| default, styled | ![appcues-skippable-default-styled](https://user-images.githubusercontent.com/19266448/228556731-8619068e-d682-4c94-8d00-ee00c123dfb2.png) |
| minimal on dark, no styling | ![appcues-skippable-minimal](https://user-images.githubusercontent.com/19266448/228556755-de27669f-f5e1-4201-a68b-a6c48c33b8aa.png) |
| minimal on light no styling | ![appcues-skippable-minimal-light](https://user-images.githubusercontent.com/19266448/228556782-ff4a80e1-f267-4e77-b0f7-f25e4e1b3349.png) |
| minmal, styled | ![appcues-skippable-minimal-styled](https://user-images.githubusercontent.com/19266448/228556802-30a6524a-3c45-4f31-b0d4-b6323ffbc11a.png) |


notes:
* the default background circle should have the same discrepancy on ios/android as today - just due to iOS using the vibrancy/blur effect there, and android using a semi-transparent fixed `0x54000000`
* the shadow behind the `X` in minimal was a little tricky, but I think I have it working, though it looks slightly less pronounced on android than iOS. In any case, this is not expected to be a builder option anytime soon, maybe ever.
* the minimal 'X' approach was changed a bit to properly support optionally styling the foreground color - by default, it should be the same end result though, using the `BlendMode.Difference` with a `ColorFIlter.tint(...)` using 70% white -- this matches exactly what iOS is doing, from what I can tell.
