### PR TITLE
Apply error tint color to text spans when indicating required field validation errors

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/extensions/TextPrimitiveExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/TextPrimitiveExt.kt
@@ -7,8 +7,13 @@ import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
 internal fun TextPrimitive.checkErrorStyle(showError: Boolean, errorLabel: TextPrimitive?): TextPrimitive {
     val errorTint = if (showError) errorLabel?.style?.foregroundColor else null
     return if (errorTint != null) {
-        // use a copy of the label with a modified foreground color
-        copy(style = style.copy(foregroundColor = errorTint))
+        // need to push this foreground color down into each text span (or single in default case)
+        // for styling to properly apply when rendered into UI
+        copy(
+            spans = spans.map {
+                it.copy(style = it.style.copy(foregroundColor = errorTint))
+            }
+        )
     } else {
         // use unchanged label
         this


### PR DESCRIPTION
Simple oversight we had when we moved from `text` to `spans` for rendering text primitive content. When we apply the error tint color, we can no longer apply to the root `style`, but rather need to apply to each individual span within, to the span `style`. Prior to this fix, the label text was just remaining in the same style - unchanged by the error tint.

| validation error | normal state |
| ---- | ----|
| ![Screenshot 2023-03-29 at 12 57 53 PM](https://user-images.githubusercontent.com/19266448/228627807-45112119-b1a6-4c5d-9db5-40fb9b7595eb.png) | ![Screenshot 2023-03-29 at 12 57 46 PM](https://user-images.githubusercontent.com/19266448/228627815-75a99cec-7fe5-440c-b46f-67e28e11af7d.png) |
