### PR TITLE
Refactor step container render into a testable function for snapshot testing

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -1,20 +1,32 @@
 package com.appcues
 
+import android.content.Context
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import coil.ImageLoader
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
 import com.appcues.data.MoshiConfiguration
+import com.appcues.data.mapper.experience.ExperienceMapper
 import com.appcues.data.mapper.step.primitives.mapPrimitive
 import com.appcues.data.model.ExperienceStepFormState
+import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.remote.appcues.response.experience.ExperienceResponse
 import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse
+import com.appcues.data.remote.appcues.response.trait.TraitResponse
+import com.appcues.di.AppcuesKoinContext
 import com.appcues.logging.Logcues
 import com.appcues.ui.composables.AppcuesActionsDelegate
+import com.appcues.ui.composables.ComposeContainer
 import com.appcues.ui.composables.LocalAppcuesActionDelegate
 import com.appcues.ui.composables.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.composables.LocalImageLoader
 import com.appcues.ui.composables.LocalLogcues
+import com.appcues.ui.composables.isContentVisible
 import com.appcues.ui.primitive.Compose
 import com.appcues.ui.theme.AppcuesTheme
 
@@ -31,6 +43,63 @@ fun ComposeContent(json: String, imageLoader: ImageLoader) {
             LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate()
         ) {
             primitive.Compose()
+        }
+    }
+}
+
+@Composable
+fun ComposeContainer(
+    context: Context,
+    experienceJson: String,
+    traitJson: String,
+    groupIndex: Int,
+    stepIndex: Int,
+    imageLoader: ImageLoader)
+{
+    // set up a Koin scope for testing - for experience/trait mapping, trait registry, etc
+    val scope = AppcuesKoinContext.createAppcuesScope(context, AppcuesConfig("", ""))
+
+    // read the JSON test data
+    val experienceResponse = MoshiConfiguration.moshi.adapter(ExperienceResponse::class.java).fromJson(experienceJson)!!
+    val traitResponse = MoshiConfiguration.moshi.adapter(TraitResponse::class.java).fromJson(traitJson)!!
+
+    // update the experience to add the given trait in the given step
+     val updatedExperienceResponse = experienceResponse.copy(
+        steps = experienceResponse.steps.mapIndexed { stepContainerResponseIndex, stepContainerResponse ->
+            stepContainerResponse.copy(
+                children = stepContainerResponse.children.mapIndexed { stepResponseIndex, stepResponse ->
+                    stepResponse.copy(
+                        traits = stepResponse.traits.toMutableList().also {
+                            if (stepContainerResponseIndex == groupIndex && stepResponseIndex == stepIndex) {
+                                it.add(traitResponse)
+                            }
+                        }
+                    )
+                }
+            )
+        }
+    )
+
+    // map the experience
+    val experienceMapper: ExperienceMapper = scope.get()
+    val experience = experienceMapper.map(updatedExperienceResponse, ExperienceTrigger.Preview)
+    val container = experience.stepContainers[groupIndex]
+
+    // render the step container on the desired step
+    isContentVisible.targetState = true // so animated visibility works
+    AppcuesTheme {
+        CompositionLocalProvider(
+            LocalImageLoader provides imageLoader,
+            LocalLogcues provides Logcues(LoggingLevel.DEBUG),
+            LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
+            LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate()
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                ComposeContainer(container, stepIndex)
+            }
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -10,6 +10,7 @@ import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.Interactio
 import com.appcues.data.model.Action
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.logging.Logcues
+import com.appcues.trait.AppcuesTraitException
 import com.appcues.ui.AppcuesViewModel
 import com.appcues.ui.ShakeGestureListener
 import com.appcues.ui.composables.StackScope.ColumnStackScope
@@ -60,6 +61,9 @@ internal val LocalExperienceStepFormStateDelegate = compositionLocalOf { Experie
 internal val LocalStackScope = compositionLocalOf<StackScope> { ColumnStackScope(null, 0) }
 
 internal val LocalChromeClient = compositionLocalOf { AccompanistWebChromeClient() }
+
+internal val LocalAppcuesTraitExceptionHandler = compositionLocalOf { AppcuesTraitExceptionHandler {} }
+internal data class AppcuesTraitExceptionHandler(val onTraitException: (AppcuesTraitException) -> Unit)
 
 internal sealed class StackScope(private val childrenCount: Int) {
 


### PR DESCRIPTION
The `CompositionTestHelper.ComposeContainer` is a debug only public helper that allows our snapshot test tools (different project) to send in experience and trait JSON data and render a step for snapshot purposes. It is similar in concept to how the existing `ComposeContent` works for primitives, but supports a more advanced case with the full experience and trait decoding and mapping. The given trait is injected into the specified step, for testing. This allows our test cases to have some base experience JSON and then add variations of traits as needed. (test updates will be in another PR in that repo)

The change in `AppcuesComposition` is just a refactor to make the render of a step container a testable piece with limited  dependencies, and internal visibility, in support of this new test helper.

