### PR TITLE
Fix crash when applying border to tooltip

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -191,7 +191,8 @@ internal class TooltipTrait(
         path: Path,
         isDark: Boolean
     ) = this.then(
-        if (style?.borderWidth != null && style.borderWidth ne 0.0 && style.borderColor != null) {
+        @Suppress("ComplexCondition")
+        if (style?.borderWidth != null && style.borderWidth ne 0.0 && style.borderColor != null && !path.isEmpty) {
             Modifier
                 .border(style.borderWidth.dp, style.borderColor.getColor(isDark), GenericShape { _, _ -> addPath(path) })
                 .padding(style.borderWidth.dp)


### PR DESCRIPTION
I was hacking around on some testing items and came across what seems to be the relatively simple fix for the crash seen when applying a border to a tooltip trait style. It simply needs to guard against an empty path during some layout passes. 

I'm guessing there is a first pass composition running before the tooltip size is first set and the `containerDimens` are fully known. In the `tooltipPath` helper, if no `containerDimens` are set yet, it does not draw any path. Later, if using this empty path when drawing a border, a crash is observed:

```
    java.lang.IllegalArgumentException: width and height must be > 0
    	at android.graphics.Bitmap.createBitmap(Bitmap.java:1095)
    	at androidx.compose.ui.graphics.Api26Bitmap.createBitmap-x__-hDU$ui_graphics_release(AndroidImageBitmap.android.kt:198)
    	at androidx.compose.ui.graphics.AndroidImageBitmap_androidKt.ActualImageBitmap-x__-hDU(AndroidImageBitmap.android.kt:44)
    	at androidx.compose.ui.graphics.ImageBitmapKt.ImageBitmap-x__-hDU(ImageBitmap.kt:255)
    	at androidx.compose.ui.graphics.ImageBitmapKt.ImageBitmap-x__-hDU$default(ImageBitmap.kt:249)
    	at androidx.compose.foundation.BorderKt.drawGenericBorder(Border.kt:474)
    	at androidx.compose.foundation.BorderKt.access$drawGenericBorder(Border.kt:1)
    	at androidx.compose.foundation.BorderKt$border$2$1.invoke(Border.kt:119)
    	at androidx.compose.foundation.BorderKt$border$2$1.invoke(Border.kt:100)
```

checking `!path.isEmpty` can avoid that and render as expected:

![Screenshot 2023-03-30 at 1 14 21 PM](https://user-images.githubusercontent.com/19266448/228914513-306d667a-20db-4363-b172-318e16a0dc61.png)
