### PR TITLE
✨ Added property pointerCornerRadius for tooltip trait

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPath.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPath.kt
@@ -1,0 +1,230 @@
+package com.appcues.trait.appcues
+
+import android.graphics.PointF
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
+import com.appcues.trait.appcues.TooltipPointerPosition.Bottom
+import com.appcues.trait.appcues.TooltipPointerPosition.Left
+import com.appcues.trait.appcues.TooltipPointerPosition.Right
+import com.appcues.trait.appcues.TooltipPointerPosition.Top
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+@Composable
+internal fun drawTooltipPointerPath(
+    tooltipSettings: TooltipSettings,
+    containerDimens: TooltipContainerDimens?,
+    animationFloatSpec: AnimationSpec<Float>,
+    animationDpSpec: AnimationSpec<Dp>,
+): Path {
+    return Path().apply {
+        // if containerDimens is null we don't to path the tooltip yet
+        if (containerDimens == null) return@apply
+
+        op(
+            path1 = getTooltipPointerPath(containerDimens, tooltipSettings, animationFloatSpec),
+            path2 = getContainerPath(containerDimens, tooltipSettings, animationDpSpec),
+            operation = PathOperation.Union
+        )
+    }
+}
+
+@Composable
+private fun getTooltipPointerPath(
+    containerDimens: TooltipContainerDimens,
+    tooltipSettings: TooltipSettings,
+    animationSpec: AnimationSpec<Float>,
+): Path {
+    val density = LocalDensity.current
+    val containerCornerRadiusPx = with(density) { containerDimens.cornerRadius.toPx() }
+
+    val (pointerOffsetX, verticalTipOffset) = calculatePointerXOffset(
+        containerDimens = containerDimens,
+        tooltipSettings = tooltipSettings,
+        pointerOffsetX = with(density) { tooltipSettings.pointerOffsetX.value.toPx() },
+        containerCornerRadiusPx = containerCornerRadiusPx,
+    )
+
+    val (pointerOffsetY, horizontalTipOffset) = calculatePointerYOffset(
+        containerDimens = containerDimens,
+        tooltipSettings = tooltipSettings,
+        pointerOffsetY = with(density) { tooltipSettings.pointerOffsetY.value.toPx() },
+        containerCornerRadiusPx = containerCornerRadiusPx,
+    )
+
+    val animatedPointerOffsetX = animateFloatAsState(pointerOffsetX, animationSpec)
+    val animatedPointerOffsetY = animateFloatAsState(pointerOffsetY, animationSpec)
+    val length = when (tooltipSettings.tooltipPointerPosition) {
+        Top, Left -> -tooltipSettings.pointerLengthPx
+        Bottom, Right -> tooltipSettings.pointerLengthPx
+        else -> 0f
+    }
+
+    // vertical pointer implementation, probably in the future make this a separate method and add
+    // another one to generate a horizontal pointer for leading and trailing positions.
+    return Path().apply {
+        if (tooltipSettings.tooltipPointerPosition.isVertical) {
+            TooltipVerticalPointerPath(tooltipSettings, verticalTipOffset, length, animationSpec)
+            translate(Offset(animatedPointerOffsetX.value, pointerOffsetY))
+        } else {
+            TooltipHorizontalPointerPath(tooltipSettings, horizontalTipOffset, length, animationSpec)
+            translate(Offset(pointerOffsetX, animatedPointerOffsetY.value))
+        }
+    }
+}
+
+/**
+ * Calculates the pointerXOffset position, returns a pair of value containing:
+ * first: pointer x offset
+ * second: pointer tip offset
+ *
+ * during the processing of this function we also update the tooltipPointerPosition horizontal alignment
+ */
+@SuppressWarnings("MagicNumber")
+@Composable
+private fun Path.TooltipVerticalPointerPath(
+    tooltipSettings: TooltipSettings,
+    tipOffset: Float,
+    tipLength: Float,
+    animationSpec: AnimationSpec<Float>
+) {
+    val cornerRadius = tooltipSettings.pointerCornerRadiusPx
+    val animatedTipOffset = animateFloatAsState(tipOffset, animationSpec)
+
+    val pt1 = PointF(0f, 0f)
+    val pt2 = PointF(tooltipSettings.pointerBaseCenterPx + animatedTipOffset.value, tipLength)
+    val pt3 = PointF(tooltipSettings.pointerBasePx, 0f)
+    val pt0 = PointF(pt1.x - tooltipSettings.pointerBaseCenterPx, 0f)
+    val pt4 = PointF(pt3.x + tooltipSettings.pointerBaseCenterPx, 0f)
+
+    val points = if (tipLength < 0) {
+        arrayListOf(pt0, pt1, pt2, pt3, pt4)
+    } else {
+        arrayListOf(pt4, pt3, pt2, pt1, pt0)
+    }
+
+    val corner1 = getTooltipRoundedCorner(points[2], points[1], points[0], cornerRadius)
+    val corner2 = getTooltipRoundedCorner(points[1], points[2], points[3], cornerRadius, true)
+    val corner3 = getTooltipRoundedCorner(points[4], points[3], points[2], cornerRadius)
+
+    drawTooltipPath(arrayListOf(corner1, corner2, corner3))
+}
+
+@SuppressWarnings("MagicNumber")
+@Composable
+private fun Path.TooltipHorizontalPointerPath(
+    tooltipSettings: TooltipSettings,
+    tipOffset: Float,
+    tipLength: Float,
+    animationSpec: AnimationSpec<Float>
+) {
+    val cornerRadius = tooltipSettings.pointerCornerRadiusPx
+    val animatedTipOffset = animateFloatAsState(tipOffset, animationSpec)
+
+    val pt1 = PointF(0f, tooltipSettings.pointerBasePx)
+    val pt2 = PointF(tipLength, tooltipSettings.pointerBaseCenterPx + animatedTipOffset.value)
+    val pt3 = PointF(0f, 0f)
+    val pt0 = PointF(0f, pt1.y + tooltipSettings.pointerBaseCenterPx)
+    val pt4 = PointF(0f, pt3.y - tooltipSettings.pointerBaseCenterPx)
+
+    val points = if (tipLength < 0) {
+        arrayListOf(pt0, pt1, pt2, pt3, pt4)
+    } else {
+        arrayListOf(pt4, pt3, pt2, pt1, pt0)
+    }
+
+    val corner1 = getTooltipRoundedCorner(points[2], points[1], points[0], cornerRadius)
+    val corner2 = getTooltipRoundedCorner(points[1], points[2], points[3], cornerRadius, true)
+    val corner3 = getTooltipRoundedCorner(points[4], points[3], points[2], cornerRadius)
+
+    drawTooltipPath(arrayListOf(corner1, corner2, corner3))
+}
+
+private fun Path.drawTooltipPath(points: List<CornerPoint>) {
+    reset()
+    points.forEach {
+        val startX = it.centerPoint.x + it.radius * cos(it.startAngle)
+        val startY = it.centerPoint.y + it.radius * sin(it.startAngle)
+        val endX = it.centerPoint.x + it.radius * cos(it.endAngle)
+        val endY = it.centerPoint.y + it.radius * sin(it.endAngle)
+
+        val firstSweepAngle = atan2(endY - it.centerPoint.y, endX - it.centerPoint.x) -
+            atan2(startY - it.centerPoint.y, startX - it.centerPoint.x)
+
+        val reverseSweepAngle = atan2(startX - it.centerPoint.x, startY - it.centerPoint.y) -
+            atan2(endX - it.centerPoint.x, endY - it.centerPoint.y)
+
+        val sweepAngle = if (firstSweepAngle in -Math.PI..Math.PI) firstSweepAngle else reverseSweepAngle
+
+        arcTo(
+            rect = Rect(it.centerPoint.toOffset(), it.radius),
+            startAngleDegrees = Math.toDegrees(it.startAngle.toDouble()).toFloat(),
+            sweepAngleDegrees = Math.toDegrees(sweepAngle.toDouble()).toFloat(),
+            false
+        )
+    }
+    close()
+}
+
+private fun PointF.toOffset(): Offset {
+    return Offset(x, y)
+}
+
+@Composable
+private fun getContainerPath(
+    containerDimens: TooltipContainerDimens,
+    tooltipSettings: TooltipSettings,
+    animationSpec: AnimationSpec<Dp>,
+): Path {
+    val containerCornerRadius = remember(tooltipSettings.tooltipPointerPosition.alignment.value) {
+        tooltipSettings.tooltipPointerPosition.toContainerCornerRadius(containerDimens.cornerRadius)
+    }
+
+    val cornerTopStart = animateDpAsState(containerCornerRadius.topStart, animationSpec)
+    val cornerTopEnd = animateDpAsState(containerCornerRadius.topEnd, animationSpec)
+    val cornerBottomStart = animateDpAsState(containerCornerRadius.bottomStart, animationSpec)
+    val cornerBottomEnd = animateDpAsState(containerCornerRadius.bottomEnd, animationSpec)
+
+    return Path().apply {
+        // takes into account the length of the tooltip pointer when calculating new container size
+        val size = if (tooltipSettings.tooltipPointerPosition.isVertical) {
+            Size(containerDimens.widthPx, containerDimens.heightPx - tooltipSettings.pointerLengthPx)
+        } else {
+            Size(containerDimens.widthPx - tooltipSettings.pointerLengthPx, containerDimens.heightPx)
+        }
+
+        val offset = when (tooltipSettings.tooltipPointerPosition) {
+            is Top -> Offset(0f, tooltipSettings.pointerLengthPx)
+            Left -> Offset(tooltipSettings.pointerLengthPx, 0f)
+            else -> Offset(0f, 0f)
+        }
+
+        addPath(
+            Path().apply {
+                addOutline(
+                    RoundedCornerShape(
+                        topStart = cornerTopStart.value,
+                        topEnd = cornerTopEnd.value,
+                        bottomEnd = cornerBottomEnd.value,
+                        bottomStart = cornerBottomStart.value
+                    ).createOutline(size, LocalLayoutDirection.current, LocalDensity.current)
+                )
+            },
+            offset
+        )
+    }
+}

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPath.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPath.kt
@@ -90,8 +90,6 @@ private fun getTooltipPointerPath(
         animationSpec
     )
 
-    // vertical pointer implementation, probably in the future make this a separate method and add
-    // another one to generate a horizontal pointer for leading and trailing positions.
     return Path().apply {
         if (tooltipSettings.tooltipPointerPosition.isVertical) {
             TooltipVerticalPointerPath(tooltipSettings, verticalTipOffset, animatedVerticalLength.value, animationSpec)
@@ -156,7 +154,7 @@ private fun Path.TooltipHorizontalPointerPath(
     val pt0 = PointF(0f, pt1.y + tooltipSettings.pointerBaseCenterPx)
     val pt4 = PointF(0f, pt3.y - tooltipSettings.pointerBaseCenterPx)
 
-    // map points into a list and reverse the order in case vertical tooltip pointer is at bottom
+    // map points into a list and reverse the order in case vertical tooltip pointer is at Right
     val points = arrayListOf(pt0, pt1, pt2, pt3, pt4).apply { if (tooltipSettings.tooltipPointerPosition is Right) reverse() }
 
     // from points, define corners to apply cornerRadius

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
@@ -4,7 +4,6 @@ import android.graphics.PointF
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.appcues.trait.appcues.TooltipPointerPosition.Bottom
@@ -134,8 +133,6 @@ internal data class TooltipSettings(
     val hidePointer: Boolean,
     val tooltipPointerPosition: TooltipPointerPosition,
     val distance: Dp,
-    val pointerBaseDp: Dp,
-    val pointerLengthDp: Dp,
     val pointerBasePx: Float,
     val pointerLengthPx: Float,
     val pointerCornerRadiusPx: Float,
@@ -153,26 +150,6 @@ internal data class TooltipContainerDimens(
     val heightPx: Float,
     val cornerRadius: Dp,
 )
-
-internal fun getTooltipSettings(
-    density: Density,
-    position: TooltipPointerPosition,
-    distance: Dp,
-    pointerBaseDp: Dp,
-    pointerLengthDp: Dp,
-    pointerCornerRadius: Dp = 0.dp,
-): TooltipSettings {
-    return TooltipSettings(
-        hidePointer = false,
-        tooltipPointerPosition = position,
-        distance = distance,
-        pointerBaseDp = pointerBaseDp,
-        pointerLengthDp = pointerLengthDp,
-        pointerBasePx = with(density) { pointerBaseDp.toPx() },
-        pointerLengthPx = with(density) { pointerLengthDp.toPx() },
-        pointerCornerRadiusPx = with(density) { pointerCornerRadius.toPx() }
-    )
-}
 
 internal fun calculatePointerXOffset(
     containerDimens: TooltipContainerDimens,

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
@@ -15,6 +15,7 @@ import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.max
 import kotlin.math.sin
+import kotlin.math.tan
 
 internal data class PointerAlignment(
     val verticalAlignment: PointerVerticalAlignment = PointerVerticalAlignment.CENTER,
@@ -322,6 +323,27 @@ fun calculateTooltipMaxRadius(base: Float, height: Float): Float {
     return (pt1.y - pt2.y) / (1 + 2 * sin(angle - Math.PI / 2) + (1 / cos(angle))).toFloat()
 }
 
+/**
+ * determine the real width of the pointer tooltip
+ */
+@Suppress("unused")
+@SuppressWarnings("unused")
+// the value calculated here should be factored when figuring out the amount of cornerRadius to be applied,
+// if any
+fun calculateTooltipWidth(base: Float, length: Float, radius: Float, roundedBase: Int = 2): Float {
+    // (1) figure out the angle
+    val angle = atan2(base, length / 2) / 2
+    // (2) finds out the value of the opposite side using:
+    //        - tan(angle) = opposite side / adjacent side
+    //
+    //     giving that the adjacent side is radius, then:
+    //        - opposite side = tan(angle) * radius
+    //
+    // (3) multiply by two to account for the two sides of the pointer
+    //     and add the existing width to the end result
+    return (tan(angle) * radius * roundedBase) + base
+}
+
 data class CornerPoint(
     val centerPoint: PointF,
     val startAngle: Float,
@@ -336,15 +358,16 @@ fun getTooltipRoundedCorner(
     to: PointF,
     radius: Float,
     clockWise: Boolean = false,
+    shouldRound: Boolean = true,
 ): CornerPoint {
     val startAngle = (atan2(via.y - from.y, via.x - from.x) - Math.PI / 2).toFloat()
     val endAngle = (atan2(to.y - via.y, to.x - via.x) - Math.PI / 2).toFloat()
 
     return CornerPoint(
-        centerPoint = findRadiusCenterPoint(from, via, to, radius),
+        centerPoint = if (shouldRound) findRadiusCenterPoint(from, via, to, radius) else via,
         startAngle = if (clockWise) startAngle else endAngle,
         endAngle = if (clockWise) endAngle else startAngle,
-        radius = radius,
+        radius = if (shouldRound) radius else 0f,
         isClockWise = clockWise
     )
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -89,6 +89,14 @@ internal class TooltipTrait(
     private val hidePointer = config.getConfigOrDefault("hidePointer", false)
     private val pointerBaseDp = if (hidePointer) 0.dp else config.getConfigOrDefault("pointerBase", POINTER_BASE_DEFAULT).dp
     private val pointerLengthDp = if (hidePointer) 0.dp else config.getConfigOrDefault("pointerLength", POINTER_LENGTH_DEFAULT).dp
+    private val pointerCornerRadius = if (hidePointer) 0.dp else
+        config.getConfigOrDefault("pointerCornerRadius", 0.0).dp.coerceInMaxRadius(pointerBaseDp, pointerLengthDp)
+
+    // figures out the max corner radius for this shape and returns the lesser value between
+    // the pointerCornerRadius and the calculated max.
+    private fun Dp.coerceInMaxRadius(pointerBaseDp: Dp, pointerLengthDp: Dp): Dp {
+        return min(this, calculateTooltipMaxRadius(pointerBaseDp.value, pointerLengthDp.value).dp)
+    }
 
     override fun present() {
         AppcuesOverlayViewManager(scope = scope).start()
@@ -121,6 +129,9 @@ internal class TooltipTrait(
             tooltipMaxHeight = tooltipMaxHeight,
         )
 
+        val tooltipPath = drawTooltipPointerPath(tooltipSettings, containerDimens.value, floatAnimation, dpAnimation)
+        val maxWidth = windowInfo.widthDp - SCREEN_HORIZONTAL_PADDING * 2
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -141,9 +152,6 @@ internal class TooltipTrait(
                         animationSpec = dpAnimation
                     )
                 ) {
-                    val tooltipPath = tooltipPath(tooltipSettings, containerDimens.value, floatAnimation, dpAnimation)
-                    val maxWidth = windowInfo.widthDp - SCREEN_HORIZONTAL_PADDING * 2
-
                     Box(
                         modifier = Modifier
                             .tooltipSize(style, maxWidth, tooltipMaxHeight.value)
@@ -357,7 +365,8 @@ internal class TooltipTrait(
                 position = pointerPosition,
                 distance = distance,
                 pointerBaseDp = pointerBaseDp,
-                pointerLengthDp = pointerLengthDp
+                pointerLengthDp = pointerLengthDp,
+                pointerCornerRadius = pointerCornerRadius,
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -353,20 +353,20 @@ internal class TooltipTrait(
     ): TooltipSettings {
         val density = LocalDensity.current
         return remember(targetRectangleInfo, containerDimens) {
-            val pointerPosition = targetRectangleInfo.getTooltipPointerPosition(
+            val position = targetRectangleInfo.getTooltipPointerPosition(
                 windowInfo = windowInfo,
                 containerDimens = containerDimens,
                 targetRect = targetRect,
                 tooltipMaxHeight = tooltipMaxHeight
             )
 
-            getTooltipSettings(
-                density = density,
-                position = pointerPosition,
+            TooltipSettings(
+                hidePointer = false,
+                tooltipPointerPosition = position,
                 distance = distance,
-                pointerBaseDp = pointerBaseDp,
-                pointerLengthDp = pointerLengthDp,
-                pointerCornerRadius = pointerCornerRadius,
+                pointerBasePx = with(density) { pointerBaseDp.toPx() },
+                pointerLengthPx = with(density) { pointerLengthDp.toPx() },
+                pointerCornerRadiusPx = with(density) { pointerCornerRadius.toPx() }
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/util/FloatExt.kt
+++ b/appcues/src/main/java/com/appcues/util/FloatExt.kt
@@ -1,0 +1,11 @@
+@file:Suppress("unused")
+
+package com.appcues.util
+
+import kotlin.math.abs
+
+private const val TOLERANCE = 0.0001f
+
+internal infix fun Float.eq(other: Float) = abs(this - other) <= TOLERANCE
+
+internal infix fun Float.ne(other: Float) = abs(this - other) > TOLERANCE


### PR DESCRIPTION
adding cornerRadius to the previous tooltip structure required some changes and a lot of testing. part of the effort here was to keep it organized so we can come back to it later if needed.

TooltipPath now contains all the Path related methods, auxiliary classes and methods were moved to TooltipPathExt for lack of a better name. with this change we are supporting cornerRadius on tooltips including some animations, but there are still some remaining work to safe guard odd scenarios (I will create a separate ticket for this one after)


https://user-images.githubusercontent.com/5244805/231225409-9165106c-a2d0-4343-87e7-2bccd21982f6.mov


tagging @mmaatttt here since he helped quite a lot with the trigonometry involved, + I know he wanted to know how this will be merged on android to compare implementation on the web side
