### PR TITLE
Handle errors in decoding trait configs

### DIFF
--- a/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
+++ b/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
@@ -20,6 +20,7 @@ import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse
 import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.TextPrimitiveResponse
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonAdapter.Factory
+import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonQualifier
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -68,7 +69,11 @@ internal object MoshiConfiguration {
         val adapter = moshi.adapter(T::class.java)
         val anyAdapter = moshi.adapter<Any>(Object::class.java)
         return adapter.run {
-            fromJson(anyAdapter.toJson(any))
+            try {
+                fromJson(anyAdapter.toJson(any))
+            } catch (exception: JsonDataException) {
+                null
+            }
         }
     }
 


### PR DESCRIPTION
If something inside of a trait `config` block was malformed, things would silently fail due to a Moshi error which ends up causing the trait to fail to instantiate when Koin tried to inflate it. This would not render anything at all, nor give a step error.

Now, it will gracefully handle decoding errors and return null to the caller, which has the option of whether to continue with default config values or do any other sort of error handling desired.