### PR TITLE
♻️ Adjusting tooltip composition to fix pointer positioning

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
@@ -130,7 +130,6 @@ internal sealed class TooltipPointerPosition {
 }
 
 internal data class TooltipSettings(
-    val hidePointer: Boolean,
     val tooltipPointerPosition: TooltipPointerPosition,
     val distance: Dp,
     val pointerBasePx: Float,

--- a/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt
@@ -1,7 +1,6 @@
 package com.appcues.trait.extensions
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -54,19 +53,24 @@ internal fun TargetRectangleInfo?.getContentDistance(): Dp {
 
 internal fun TargetRectangleInfo?.getTooltipPointerPosition(
     windowInfo: AppcuesWindowInfo,
-    containerDimens: TooltipContainerDimens?,
+    contentDimens: TooltipContainerDimens?,
     targetRect: Rect?,
-    tooltipMaxHeight: MutableState<Dp>,
+    distance: Dp,
+    pointerLength: Dp,
 ): TooltipPointerPosition {
-    if (this == null || targetRect == null || containerDimens == null) return None
+    if (this == null || targetRect == null || contentDimens == null) return None
 
     val availableSpaceTop = targetRect.top.dp - TooltipTrait.SCREEN_VERTICAL_PADDING
     val availableSpaceBottom = windowInfo.heightDp - TooltipTrait.SCREEN_VERTICAL_PADDING - targetRect.bottom.dp
 
-    val excessSpaceTop = availableSpaceTop - containerDimens.heightDp
-    val excessSpaceBottom = availableSpaceBottom - containerDimens.heightDp
-    val excessSpaceLeft = targetRect.left.dp - TooltipTrait.SCREEN_HORIZONTAL_PADDING - containerDimens.widthDp
-    val excessSpaceRight = windowInfo.widthDp - TooltipTrait.SCREEN_HORIZONTAL_PADDING - targetRect.right.dp - containerDimens.widthDp
+    val excessSpaceTop = availableSpaceTop - contentDimens.heightDp - distance - pointerLength
+    val excessSpaceBottom = availableSpaceBottom - contentDimens.heightDp - distance - pointerLength
+
+    val availableSpaceLeft = targetRect.left.dp - TooltipTrait.SCREEN_HORIZONTAL_PADDING
+    val availableSpaceRight = windowInfo.widthDp - TooltipTrait.SCREEN_HORIZONTAL_PADDING
+
+    val excessSpaceLeft = availableSpaceLeft - contentDimens.widthDp - distance - pointerLength
+    val excessSpaceRight = availableSpaceRight - targetRect.right.dp - contentDimens.widthDp - distance - pointerLength
 
     val canPositionVertically = excessSpaceTop > 0.dp || excessSpaceBottom > 0.dp
     val canPositionHorizontally = excessSpaceLeft > 0.dp || excessSpaceRight > 0.dp
@@ -77,8 +81,8 @@ internal fun TargetRectangleInfo?.getTooltipPointerPosition(
         canPositionHorizontally -> if (excessSpaceLeft > excessSpaceRight) Right else Left
         // Doesn't fit anywhere so pick the top/bottom side that has the most space.
         // Allowing left/right here would mean the width gets compressed and that opens a can of worms.
-        excessSpaceTop > excessSpaceBottom -> Bottom.also { tooltipMaxHeight.value = availableSpaceTop }
-        else -> Top.also { tooltipMaxHeight.value = availableSpaceBottom }
+        excessSpaceTop > excessSpaceBottom -> Bottom
+        else -> Top
     }
 }
 


### PR DESCRIPTION
the way the tooltip is built at the moment sometimes gives us unexpected results, where the pointer is in the wrong position and/or the content is not visible.

Some adjustments to align positioning logic between android and ios.

* TargetRectangleInfo?.getTooltipPointerPosition(..) we added distance as one parameter that can influence available space, and changed the containerDimens with contentDimens.
* Added contentDimens that is calculated based on existing containerDimens and known tooltip position.
* Fixed tooltipSize to mirror rules from IOS
* general improvement on how the composition is organized (fixing some of the detekt warnings)