### PR TITLE
Account for the pointer length in the horizontal tooltip padding start calculation

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
@@ -143,6 +143,13 @@ internal data class TooltipSettings(
     val pointerOffsetY = mutableStateOf(0.dp)
 }
 
+// represents the size of the content only, not including the pointer
+internal data class TooltipContentDimens(
+    val widthDp: Dp,
+    val heightDp: Dp,
+)
+
+// represents the full size of the composition, including the pointer
 internal data class TooltipContainerDimens(
     val widthDp: Dp,
     val heightDp: Dp,

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -241,7 +241,7 @@ internal class TooltipTrait(
         windowInfo: AppcuesWindowInfo,
         animationSpec: FiniteAnimationSpec<Dp>,
     ): Modifier = composed {
-        // skip this until we have containerDimens defined
+        // skip this until we have contentDimens defined
         if (contentDimens == null) return@composed Modifier
 
         Modifier.padding(
@@ -259,8 +259,10 @@ internal class TooltipTrait(
         animationSpec: FiniteAnimationSpec<Dp>
     ): State<Dp> {
         val minPaddingStart = 0.dp
-        val maxPaddingStart = (windowInfo.widthDp - contentDimens.widthDp - (SCREEN_HORIZONTAL_PADDING * 2)).coerceAtLeast(0.dp)
         val pointerLengthDp = with(LocalDensity.current) { pointerSettings.pointerLengthPx.toDp() }
+        val pointerWidthDp = if (pointerSettings.tooltipPointerPosition.isVertical) 0.dp else pointerLengthDp
+        val maxPaddingStart =
+            (windowInfo.widthDp - contentDimens.widthDp - pointerWidthDp - (SCREEN_HORIZONTAL_PADDING * 2)).coerceAtLeast(0.dp)
 
         return animateDpAsState(
             targetValue = when (pointerSettings.tooltipPointerPosition) {
@@ -268,14 +270,14 @@ internal class TooltipTrait(
                     val targetReference = (targetRect?.right?.dp ?: 0.dp) - SCREEN_HORIZONTAL_PADDING
                     val padding = targetReference + pointerSettings.distance
                     // note: on horizontal, the max needs to account for the pointerLength as well
-                    padding.coerceIn(minPaddingStart, maxPaddingStart - pointerLengthDp)
+                    padding.coerceIn(minPaddingStart, maxPaddingStart)
                 }
                 Right -> {
                     val targetReference = (targetRect?.left?.dp ?: 0.dp) - SCREEN_HORIZONTAL_PADDING
                     // when pointing to the right - offset by the container width AND the pointer length to find the start
                     val padding = targetReference - pointerSettings.distance - contentDimens.widthDp - pointerLengthDp
                     // note: on horizontal, the max needs to account for the pointerLength as well
-                    padding.coerceIn(minPaddingStart, maxPaddingStart - pointerLengthDp)
+                    padding.coerceIn(minPaddingStart, maxPaddingStart)
                 }
                 None -> {
                     // in None case, the width is a fixed full width, 400 max

--- a/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/extensions/TargetRectangleInfoExt.kt
@@ -13,7 +13,7 @@ import com.appcues.trait.appcues.ContentPreferredPosition.RIGHT
 import com.appcues.trait.appcues.ContentPreferredPosition.TOP
 import com.appcues.trait.appcues.TARGET_RECTANGLE_METADATA
 import com.appcues.trait.appcues.TargetRectangleInfo
-import com.appcues.trait.appcues.TooltipContainerDimens
+import com.appcues.trait.appcues.TooltipContentDimens
 import com.appcues.trait.appcues.TooltipPointerPosition
 import com.appcues.trait.appcues.TooltipPointerPosition.Bottom
 import com.appcues.trait.appcues.TooltipPointerPosition.Left
@@ -53,7 +53,7 @@ internal fun TargetRectangleInfo?.getContentDistance(): Dp {
 
 internal fun TargetRectangleInfo?.getTooltipPointerPosition(
     windowInfo: AppcuesWindowInfo,
-    contentDimens: TooltipContainerDimens?,
+    contentDimens: TooltipContentDimens?,
     targetRect: Rect?,
     distance: Dp,
     pointerLength: Dp,


### PR DESCRIPTION
These updates are to ensure that the desired target width gets satisfied and the start padding is not too large, in some horizontal tooltip cases. It was observed in tests that content positioned to left (pointing to right) could sometimes be compressed in width by the pointer length, leading to a narrow than expected tooltip.