### PR TITLE
Fix handling of pointerBase larger than available space

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
@@ -189,18 +189,18 @@ internal fun calculatePointerXOffset(
         }
         // After this it means the position is either TOP or BOTTOM. - NONE is irrelevant here since the pointer is not drawn.
         // * pointer offset is between min and max, we coerceIn the value accounting for cornerRadius and set alignment to CENTER
-        pointerOffset > minPointerOffset && pointerOffset < maxPointerOffset -> {
+        pointerOffset >= minPointerOffset && pointerOffset <= maxPointerOffset -> {
             tooltipSettings.tooltipPointerPosition.horizontalAlignment(PointerHorizontalAlignment.CENTER)
             pointerOffset = pointerOffset.coerceIn(minPointerOffsetCornerRadius..maxPointerOffsetCornerRadius).toFloat()
         }
-        // * pointer is less or equal to the min, its anchored to the LEFT
-        pointerOffset <= minPointerOffset -> {
+        // * pointer is less than the min, its anchored to the LEFT
+        pointerOffset < minPointerOffset -> {
             pointerTipOffset = -tooltipSettings.pointerBaseCenterPx
             tooltipSettings.tooltipPointerPosition.horizontalAlignment(PointerHorizontalAlignment.LEFT)
             pointerOffset = minPointerOffset
         }
-        // * pointer is greater or equal the max, its anchored to the RIGHT
-        pointerOffset >= maxPointerOffset -> {
+        // * pointer is greater than the max, its anchored to the RIGHT
+        pointerOffset > maxPointerOffset -> {
             pointerTipOffset = tooltipSettings.pointerBaseCenterPx
             tooltipSettings.tooltipPointerPosition.horizontalAlignment(PointerHorizontalAlignment.RIGHT)
             pointerOffset = maxPointerOffset
@@ -244,18 +244,18 @@ internal fun calculatePointerYOffset(
         }
         // After this it means the position is either LEFT or RIGHT. - NONE is irrelevant here since the pointer is not drawn.
         // * pointer offset is between min and max, we coerceIn the value accounting for cornerRadius and set alignment to CENTER
-        pointerOffset > minPointerOffset && pointerOffset < maxPointerOffset -> {
+        pointerOffset >= minPointerOffset && pointerOffset <= maxPointerOffset -> {
             tooltipSettings.tooltipPointerPosition.verticalAlignment(PointerVerticalAlignment.CENTER)
             pointerOffset = pointerOffset.coerceIn(minPointerOffsetCornerRadius..maxPointerOffsetCornerRadius).toFloat()
         }
         // * pointer is less or equal to the min, its anchored to the TOP
-        pointerOffset <= minPointerOffset -> {
+        pointerOffset < minPointerOffset -> {
             pointerTipOffset = -tooltipSettings.pointerBaseCenterPx
             tooltipSettings.tooltipPointerPosition.verticalAlignment(PointerVerticalAlignment.TOP)
             pointerOffset = minPointerOffset
         }
         // * pointer is greater or equal the max, its anchored to the BOTTOM
-        pointerOffset >= maxPointerOffset -> {
+        pointerOffset > maxPointerOffset -> {
             pointerTipOffset = tooltipSettings.pointerBaseCenterPx
             tooltipSettings.tooltipPointerPosition.verticalAlignment(PointerVerticalAlignment.BOTTOM)
             pointerOffset = maxPointerOffset


### PR DESCRIPTION
This fixes the issue where the pointerBase max was causing the pointer alignment to be incorrect in some cases. Validated with snapshot tests coming. Turned out to just be a simple off by one case in calculating the pointer x/y offsets.

| After | Before |
| --- | --- |
| ![com appcues host TooltipTraitTests_testPointerBaseGreaterThanContentTop](https://user-images.githubusercontent.com/19266448/233709244-067bfaee-a1e6-4233-8302-75cec3e07ac7.png) | ![com appcues host TooltipTraitTests_testPointerBaseGreaterThanContentTop](https://user-images.githubusercontent.com/19266448/233709181-4a88e536-9a3a-4a80-90a4-c5c6f3f83643.png) | 

