### PR TITLE
🐛 fixing animated values related to positioning the tooltip

### DIFF
--- a/gradle/tools/detekt/detekt-config.yml
+++ b/gradle/tools/detekt/detekt-config.yml
@@ -116,6 +116,7 @@ complexity:
   LongMethod:
     active: true
     threshold: 60
+    ignoreAnnotated: [ 'Composable' ]
     excludes: [ '**/*Koin.kt' ]
   LongParameterList:
     active: true


### PR DESCRIPTION
did some small change related to the padding modifier, in order to keep the value of the animated padding values even when contentDimens is not available.