### PR TITLE
💥  Removed Appcues param from action.execute method

### DIFF
--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -19,11 +19,11 @@ internal object ActionKoin : KoinScopePlugin {
         scoped { ActionProcessor(scope = get()) }
 
         factory { CloseAction(config = it.getOrNull(), experienceRenderer = get()) }
-        factory { LinkAction(config = it.getOrNull(), linkOpener = get()) }
-        factory { TrackEventAction(config = it.getOrNull()) }
+        factory { LinkAction(config = it.getOrNull(), linkOpener = get(), appcues = get()) }
+        factory { TrackEventAction(config = it.getOrNull(), appcues = get()) }
         factory { ContinueAction(config = it.getOrNull(), stateMachine = get()) }
         factory { LaunchExperienceAction(config = it.getOrNull(), stateMachine = get(), experienceRenderer = get()) }
-        factory { UpdateProfileAction(config = it.getOrNull(), storage = get()) }
+        factory { UpdateProfileAction(config = it.getOrNull(), storage = get(), appcues = get()) }
         factory { SubmitFormAction(config = it.getOrNull(), analyticsTracker = get(), stateMachine = get()) }
         factory { StepInteractionAction(config = it.getOrNull(), interaction = it.get(), analyticsTracker = get(), stateMachine = get()) }
         factory { RequestReviewAction(config = it.getOrNull(), context = get(), koinScope = get()) }

--- a/appcues/src/main/java/com/appcues/action/ActionProcessor.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionProcessor.kt
@@ -25,7 +25,7 @@ internal class ActionProcessor(override val scope: Scope) : KoinScopeComponent {
     init {
         appcuesCoroutineScope.launch {
             for (action in actionQueue) {
-                action.execute(appcues)
+                action.execute()
             }
         }
     }
@@ -40,7 +40,7 @@ internal class ActionProcessor(override val scope: Scope) : KoinScopeComponent {
         // typically the Continue action moving to the next step. Since we need to be able to
         // make this a suspend function and wait on them, we cannot place them in the queue or
         // suspend the currently executing action at all, or the queue would become deadlocked.
-        transformQueue(actions).toMutableList().forEach { it.execute(appcues) }
+        transformQueue(actions).toMutableList().forEach { it.execute() }
     }
 
     // This version is used by the viewModel to process interactive actions from user input - button taps.

--- a/appcues/src/main/java/com/appcues/action/ExperienceAction.kt
+++ b/appcues/src/main/java/com/appcues/action/ExperienceAction.kt
@@ -1,6 +1,5 @@
 package com.appcues.action
 
-import com.appcues.Appcues
 import com.appcues.data.model.AppcuesConfigMap
 
 /**
@@ -15,8 +14,6 @@ interface ExperienceAction {
 
     /**
      * Execute the action.
-     *
-     * @param appcues The Appcues instance displaying the experience triggering the action.
      */
-    suspend fun execute(appcues: Appcues)
+    suspend fun execute()
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
@@ -1,6 +1,5 @@
 package com.appcues.action.appcues
 
-import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.action.MetadataSettingsAction
 import com.appcues.data.model.AppcuesConfigMap
@@ -23,7 +22,7 @@ internal class CloseAction(
 
     override val destination = "end-experience"
 
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
         experienceRenderer.dismissCurrentExperience(markComplete = markComplete, destroyed = false)
     }
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/ContinueAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/ContinueAction.kt
@@ -1,6 +1,5 @@
 package com.appcues.action.appcues
 
-import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.action.MetadataSettingsAction
 import com.appcues.data.model.AppcuesConfigMap
@@ -37,7 +36,7 @@ internal class ContinueAction(
 
     override val destination: String = stepReference.destination
 
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
         stateMachine.handleAction(StartStep(stepReference))
     }
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
@@ -1,6 +1,5 @@
 package com.appcues.action.appcues
 
-import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.action.MetadataSettingsAction
 import com.appcues.data.model.AppcuesConfigMap
@@ -33,6 +32,7 @@ internal class LaunchExperienceAction(
     )
 
     companion object {
+
         const val TYPE = "@appcues/launch-experience"
     }
 
@@ -43,7 +43,7 @@ internal class LaunchExperienceAction(
 
     override val destination = experienceId ?: String()
 
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
         if (experienceId != null) {
             experienceRenderer.show(experienceId, getTrigger())
         }

--- a/appcues/src/main/java/com/appcues/action/appcues/LinkAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/LinkAction.kt
@@ -12,6 +12,7 @@ import com.appcues.util.LinkOpener
 internal class LinkAction(
     override val config: AppcuesConfigMap,
     private val linkOpener: LinkOpener,
+    private val appcues: Appcues,
 ) : ExperienceAction, MetadataSettingsAction {
 
     companion object {
@@ -19,10 +20,8 @@ internal class LinkAction(
         const val TYPE = "@appcues/link"
     }
 
-    constructor(redirectUrl: String, linkOpener: LinkOpener) : this(
-        hashMapOf<String, Any>("url" to redirectUrl),
-        linkOpener
-    )
+    constructor(redirectUrl: String, linkOpener: LinkOpener, appcues: Appcues) :
+        this(hashMapOf<String, Any>("url" to redirectUrl), linkOpener, appcues)
 
     private val url: String? = config.getConfig("url")
     private val openExternally = config.getConfigOrDefault("openExternally", false)
@@ -31,7 +30,7 @@ internal class LinkAction(
 
     override val destination: String = url ?: String()
 
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
         // start web activity if url is not null
         if (url != null) {
             val uri = Uri.parse(url)

--- a/appcues/src/main/java/com/appcues/action/appcues/RequestReviewAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/RequestReviewAction.kt
@@ -1,7 +1,6 @@
 package com.appcues.action.appcues
 
 import android.content.Context
-import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.ui.InAppReviewActivity
@@ -15,10 +14,11 @@ internal class RequestReviewAction(
 ) : ExperienceAction {
 
     companion object {
+
         const val TYPE = "@appcues/request-review"
     }
 
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
 
         val completion = CompletableDeferred<Boolean>()
         InAppReviewActivity.completion = completion

--- a/appcues/src/main/java/com/appcues/action/appcues/StepInteractionAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/StepInteractionAction.kt
@@ -1,6 +1,5 @@
 package com.appcues.action.appcues
 
-import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction
@@ -34,7 +33,7 @@ internal class StepInteractionAction(
         const val TYPE = "@appcues/step_interaction"
     }
 
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
         val experience = stateMachine.state.currentExperience
         val stepIndex = stateMachine.state.currentStepIndex
 

--- a/appcues/src/main/java/com/appcues/action/appcues/SubmitFormAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/SubmitFormAction.kt
@@ -18,6 +18,7 @@ internal class SubmitFormAction(
 ) : ExperienceActionQueueTransforming {
 
     companion object {
+
         const val TYPE = "@appcues/submit-form"
     }
 
@@ -46,7 +47,7 @@ internal class SubmitFormAction(
     }
 
     // reports analytics for step interaction, for the form submission
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
         val experience = stateMachine.state.currentExperience
         val stepIndex = stateMachine.state.currentStepIndex
 

--- a/appcues/src/main/java/com/appcues/action/appcues/TrackEventAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/TrackEventAction.kt
@@ -7,14 +7,17 @@ import com.appcues.data.model.getConfigOrDefault
 
 internal class TrackEventAction(
     override val config: AppcuesConfigMap,
+    private val appcues: Appcues,
 ) : ExperienceAction {
+
     companion object {
+
         const val TYPE = "@appcues/track"
     }
 
     private val eventName = config.getConfigOrDefault<String?>("eventName", null)
 
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
         if (!eventName.isNullOrEmpty()) {
             appcues.track(eventName)
         }

--- a/appcues/src/main/java/com/appcues/action/appcues/UpdateProfileAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/UpdateProfileAction.kt
@@ -8,13 +8,15 @@ import com.appcues.data.model.AppcuesConfigMap
 internal class UpdateProfileAction(
     override val config: AppcuesConfigMap,
     private val storage: Storage,
+    private val appcues: Appcues,
 ) : ExperienceAction {
 
     companion object {
+
         const val TYPE = "@appcues/update-profile"
     }
 
-    override suspend fun execute(appcues: Appcues) {
+    override suspend fun execute() {
         if (config != null) {
             appcues.identify(storage.userId, properties = config)
         }

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -35,6 +35,7 @@ internal class ExperienceMapper(
     private val actionsMapper: ActionsMapper,
     private val scope: Scope,
 ) {
+
     // this version is used to map all decoded response objects, which may represent real Experiences
     // or failed responses with minimal info for error reporting
     fun mapDecoded(
@@ -95,18 +96,23 @@ internal class ExperienceMapper(
             experiment = experiments?.getExperiment(from.id),
             completionActions = arrayListOf<ExperienceAction>().apply {
                 from.redirectUrl?.let {
-                    add(LinkAction(
-                        redirectUrl = it,
-                        linkOpener = scope.get()
-                    ))
+                    add(
+                        LinkAction(
+                            redirectUrl = it,
+                            linkOpener = scope.get(),
+                            appcues = scope.get(),
+                        )
+                    )
                 }
                 from.nextContentId?.let {
-                    add(LaunchExperienceAction(
-                        completedExperienceId = from.id.toString(),
-                        launchExperienceId = it,
-                        stateMachine = scope.get(),
-                        experienceRenderer = scope.get(),
-                    ))
+                    add(
+                        LaunchExperienceAction(
+                            completedExperienceId = from.id.toString(),
+                            launchExperienceId = it,
+                            stateMachine = scope.get(),
+                            experienceRenderer = scope.get(),
+                        )
+                    )
                 }
             },
             trigger = trigger,

--- a/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
@@ -147,7 +147,7 @@ class ActionProcessorTest : KoinTest {
         override val config: AppcuesConfigMap
             get() = emptyMap()
 
-        override suspend fun execute(appcues: Appcues) {
+        override suspend fun execute() {
             executeCount++
         }
     }
@@ -160,7 +160,7 @@ class ActionProcessorTest : KoinTest {
         override val config: AppcuesConfigMap
             get() = emptyMap()
 
-        override suspend fun execute(appcues: Appcues) {
+        override suspend fun execute() {
             // do nothing
         }
     }

--- a/appcues/src/test/java/com/appcues/action/appcues/CloseActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/CloseActionTest.kt
@@ -29,7 +29,7 @@ internal class CloseActionTest : AppcuesScopeTest {
         val action = CloseAction(mapOf(), experienceRenderer)
 
         // WHEN
-        action.execute(get())
+        action.execute()
 
         // THEN
         coVerify { experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false) }
@@ -42,7 +42,7 @@ internal class CloseActionTest : AppcuesScopeTest {
         val action = CloseAction(mapOf("markComplete" to true), experienceRenderer)
 
         // WHEN
-        action.execute(get())
+        action.execute()
 
         // THEN
         coVerify { experienceRenderer.dismissCurrentExperience(markComplete = true, destroyed = false) }

--- a/appcues/src/test/java/com/appcues/action/appcues/ContinueActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/ContinueActionTest.kt
@@ -34,7 +34,7 @@ internal class ContinueActionTest : AppcuesScopeTest {
         val action = ContinueAction(mapOf("index" to 1), stateMachine)
 
         // WHEN
-        action.execute(get())
+        action.execute()
 
         // THEN
         coVerify { stateMachine.handleAction(StartStep(StepIndex(1))) }
@@ -47,7 +47,7 @@ internal class ContinueActionTest : AppcuesScopeTest {
         val action = ContinueAction(mapOf("offset" to -1), stateMachine)
 
         // WHEN
-        action.execute(get())
+        action.execute()
 
         // THEN
         coVerify { stateMachine.handleAction(StartStep(StepOffset(-1))) }
@@ -61,7 +61,7 @@ internal class ContinueActionTest : AppcuesScopeTest {
         val action = ContinueAction(mapOf("stepID" to stepId.toString()), stateMachine)
 
         // WHEN
-        action.execute(get())
+        action.execute()
 
         // THEN
         coVerify { stateMachine.handleAction(StartStep(StepId(stepId))) }
@@ -74,7 +74,7 @@ internal class ContinueActionTest : AppcuesScopeTest {
         val action = ContinueAction(mapOf(), stateMachine)
 
         // WHEN
-        action.execute(get())
+        action.execute()
 
         // THEN
         coVerify { stateMachine.handleAction(StartStep(StepOffset(1))) }

--- a/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
@@ -1,6 +1,5 @@
 package com.appcues.action.appcues
 
-import com.appcues.Appcues
 import com.appcues.AppcuesScopeTest
 import com.appcues.data.model.ExperienceTrigger
 import com.appcues.mocks.mockExperience
@@ -36,7 +35,6 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
         // GIVEN
         val experienceId = UUID.randomUUID()
         val experienceIdString = experienceId.toString()
-        val appcues: Appcues = get()
         val experienceRenderer: ExperienceRenderer = get()
         val currentExperience = mockExperience()
         val stateMachine = mockk<StateMachine>(relaxed = true) {
@@ -47,7 +45,7 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
         val action = LaunchExperienceAction(mapOf("experienceID" to experienceIdString), stateMachine, get())
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         coVerify { experienceRenderer.show(experienceIdString, ExperienceTrigger.LaunchExperienceAction(currentExperience.id)) }
@@ -56,12 +54,11 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
     @Test
     fun `launch experience SHOULD NOT call ExperienceRenderer show WHEN no experience ID is in config`() = runTest {
         // GIVEN
-        val appcues: Appcues = get()
         val experienceRenderer: ExperienceRenderer = get()
         val action = LaunchExperienceAction(mapOf(), get(), get())
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         coVerify { experienceRenderer wasNot Called }

--- a/appcues/src/test/java/com/appcues/action/appcues/LinkActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/LinkActionTest.kt
@@ -52,13 +52,13 @@ internal class LinkActionTest : AppcuesScopeTest {
         // GIVEN
         val uri: Uri = Uri.parse("https://test/path")
         val linkOpener: LinkOpener = get()
-        val action = LinkAction(mapOf("url" to uri.toString(), "openExternally" to true), linkOpener)
         val appcues = mockk<Appcues>(relaxed = true) {
             every { this@mockk.navigationHandler } returns null
         }
+        val action = LinkAction(mapOf("url" to uri.toString(), "openExternally" to true), linkOpener, appcues)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         verify { linkOpener.startNewIntent(uri) }
@@ -69,17 +69,17 @@ internal class LinkActionTest : AppcuesScopeTest {
         // GIVEN
         val uri: Uri = Uri.parse("https://test/path")
         val linkOpener: LinkOpener = get()
-        val action = LinkAction(mapOf("url" to uri.toString(), "openExternally" to true), linkOpener)
-        val navigationHandler = mockk<NavigationHandler>(relaxed = true)
+        val mockkNavigationHandler = mockk<NavigationHandler>(relaxed = true)
         val appcues = mockk<Appcues>(relaxed = true) {
-            every { this@mockk.navigationHandler } returns navigationHandler
+            every { this@mockk.navigationHandler } returns mockkNavigationHandler
         }
+        val action = LinkAction(mapOf("url" to uri.toString(), "openExternally" to true), linkOpener, appcues)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
-        coVerify { navigationHandler.navigateTo(uri) }
+        coVerify { mockkNavigationHandler.navigateTo(uri) }
         verify { linkOpener wasNot Called }
     }
 
@@ -88,10 +88,10 @@ internal class LinkActionTest : AppcuesScopeTest {
         // GIVEN
         val uri: Uri = Uri.parse("https://test/path")
         val linkOpener: LinkOpener = get()
-        val action = LinkAction(mapOf("url" to uri.toString()), linkOpener)
+        val action = LinkAction(mapOf("url" to uri.toString()), linkOpener, get())
 
         // WHEN
-        action.execute(get())
+        action.execute()
 
         // THEN
         verify { linkOpener.openCustomTabs(uri) }
@@ -102,13 +102,13 @@ internal class LinkActionTest : AppcuesScopeTest {
         // GIVEN
         val uri: Uri = Uri.parse("myapp://test/path")
         val linkOpener: LinkOpener = get()
-        val action = LinkAction(mapOf("url" to uri.toString()), linkOpener)
         val appcues = mockk<Appcues>(relaxed = true) {
             every { this@mockk.navigationHandler } returns null
         }
+        val action = LinkAction(mapOf("url" to uri.toString()), linkOpener, appcues)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         verify { linkOpener.startNewIntent(uri) }
@@ -119,17 +119,17 @@ internal class LinkActionTest : AppcuesScopeTest {
         // GIVEN
         val uri: Uri = Uri.parse("myapp://test/path")
         val linkOpener: LinkOpener = get()
-        val action = LinkAction(mapOf("url" to uri.toString()), linkOpener)
-        val navigationHandler = mockk<NavigationHandler>(relaxed = true)
+        val mockkNavigationHandler = mockk<NavigationHandler>(relaxed = true)
         val appcues = mockk<Appcues>(relaxed = true) {
-            every { this@mockk.navigationHandler } returns navigationHandler
+            every { this@mockk.navigationHandler } returns mockkNavigationHandler
         }
+        val action = LinkAction(mapOf("url" to uri.toString()), linkOpener, appcues)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
-        coVerify { navigationHandler.navigateTo(uri) }
+        coVerify { mockkNavigationHandler.navigateTo(uri) }
         verify { linkOpener wasNot Called }
     }
 }

--- a/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
@@ -22,7 +22,6 @@ import com.appcues.data.model.styling.ComponentSelectMode.MULTIPLE
 import com.appcues.rules.KoinScopeRule
 import com.appcues.statemachine.State
 import com.appcues.statemachine.StateMachine
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
@@ -42,7 +41,7 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
 
     @Test
     fun `submit-form SHOULD have expected type name`() {
-        Truth.assertThat(SubmitFormAction.TYPE).isEqualTo("@appcues/submit-form")
+        assertThat(SubmitFormAction.TYPE).isEqualTo("@appcues/submit-form")
     }
 
     @Test
@@ -60,14 +59,13 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.state } answers { state }
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
-        val appcues: Appcues = mockk(relaxed = true)
         val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
         val analyticEvent = StepInteraction(experience, 0, FORM_SUBMITTED)
 
         // WHEN
         formState.setValue(textInput, "text")
         formState.setValue(optionSelect, "0")
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         assertThat(formState.isFormComplete).isTrue()
@@ -94,13 +92,11 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.state } answers { state }
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
-        val appcues: Appcues = mockk(relaxed = true)
         val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
-        val analyticEvent = StepInteraction(experience, 0, FORM_SUBMITTED)
 
         // WHEN
         formState.setValue(textInput, "text")
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         verify { analyticsTracker.identify(mapOf("_appcuesForm_label" to "text", "myCustomAttribute" to "text"), interactive = false) }
@@ -126,12 +122,11 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.state } answers { state }
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
-        val appcues: Appcues = mockk(relaxed = true)
         val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
         val analyticEvent = StepInteraction(experience, 0, FORM_SUBMITTED)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         assertThat(formState.isFormComplete).isFalse()
@@ -155,10 +150,10 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
         val appcues: Appcues = mockk(relaxed = true)
-        val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
+        val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
-        val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
-        val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
+        val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
+        val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val initialQueue = listOf(action0, action, action1, action2)
 
         // WHEN
@@ -185,10 +180,10 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
         val appcues: Appcues = mockk(relaxed = true)
-        val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
+        val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
-        val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
-        val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
+        val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
+        val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val initialQueue = listOf(action0, action, action1, action2)
 
         // WHEN
@@ -221,10 +216,10 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
         val appcues: Appcues = mockk(relaxed = true)
-        val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
+        val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val action = SubmitFormAction(mapOf("skipValidation" to true), stateMachine, analyticsTracker)
-        val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
-        val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"))
+        val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
+        val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val initialQueue = listOf(action0, action, action1, action2)
 
         // WHEN

--- a/appcues/src/test/java/com/appcues/action/appcues/TrackEventActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/TrackEventActionTest.kt
@@ -28,10 +28,10 @@ internal class TrackEventActionTest : AppcuesScopeTest {
         // GIVEN
         val event = "track_event"
         val appcues: Appcues = get()
-        val action = TrackEventAction(mapOf("eventName" to event))
+        val action = TrackEventAction(mapOf("eventName" to event), appcues)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         coVerify { appcues.track(event) }
@@ -41,10 +41,10 @@ internal class TrackEventActionTest : AppcuesScopeTest {
     fun `track event SHOULD NOT trigger Appcues track WHEN no eventName is in config`() = runTest {
         // GIVEN
         val appcues: Appcues = get()
-        val action = TrackEventAction(mapOf())
+        val action = TrackEventAction(mapOf(), appcues)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         coVerify { appcues wasNot Called }

--- a/appcues/src/test/java/com/appcues/action/appcues/UpdateProfileActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/UpdateProfileActionTest.kt
@@ -32,10 +32,10 @@ internal class UpdateProfileActionTest : AppcuesScopeTest {
         val userId = "test-user"
         storage.userId = userId
         val properties = mapOf("prop1" to 2, "prop2" to "ok")
-        val action = UpdateProfileAction(properties, storage)
+        val action = UpdateProfileAction(properties, storage, appcues)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         coVerify { appcues.identify(userId, properties) }
@@ -45,10 +45,10 @@ internal class UpdateProfileActionTest : AppcuesScopeTest {
     fun `update profile SHOULD NOT trigger Appcues identify WHEN no props are in config`() = runTest {
         // GIVEN
         val appcues: Appcues = get()
-        val action = UpdateProfileAction(null, get())
+        val action = UpdateProfileAction(null, get(), appcues)
 
         // WHEN
-        action.execute(appcues)
+        action.execute()
 
         // THEN
         coVerify { appcues wasNot Called }

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -52,7 +52,7 @@ internal fun mockExperience(onPresent: (() -> Unit)? = null) =
         priority = NORMAL,
         publishedAt = 1652895835000,
         experiment = null,
-        completionActions = arrayListOf(TrackEventAction(hashMapOf())),
+        completionActions = arrayListOf(TrackEventAction(hashMapOf(), appcues = mockk(relaxed = true))),
         trigger = ExperienceTrigger.ShowCall,
     )
 

--- a/docs/VersionMigration.md
+++ b/docs/VersionMigration.md
@@ -26,3 +26,4 @@ There are a number of breaking changes from 1.x to 2.0, mostly related to the ex
 - `StepDecoratingTrait` method `fun BoxScope.DecorateStep(stepDecoratingPadding: StepDecoratingPadding)` changed to `fun BoxScope.DecorateStep(containerPadding: PaddingValues, safeAreaInsets: PaddingValues, stickyContentPadding: StickyContentPadding)`.
 - `StepDecoratingPadding` renamed to `StickyContentPadding`.
 - `ModalTrait` is now `PresentingTrait`. it is responsible for presenting the container that will hold the modal type presentation (AppcuesActivity).
+- `ExperienceAction` method `suspend fun execute(appcues: Appcues)` changed to `suspend fun execute()`.


### PR DESCRIPTION
At the moment Appcues instance is not required on ExperienceAction.execute call, when necessary we can let it be declared as a constructor of the implementing class.

This changes removes appcues from the execute method