### PR TITLE
✨ Added target-interaction trait

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -3,6 +3,8 @@ package com.appcues.analytics
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.BUTTON_LONG_PRESSED
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.BUTTON_TAPPED
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.FORM_SUBMITTED
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.TARGET_LONG_PRESSED
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.TARGET_TAPPED
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.statemachine.Error
@@ -21,6 +23,8 @@ internal sealed class ExperienceLifecycleEvent(
         const val FORM_SUBMITTED_INTERACTION_TYPE = "Form Submitted"
         const val BUTTON_TAPPED_INTERACTION_TYPE = "Button Tapped"
         const val BUTTON_LONG_PRESSED_INTERACTION_TYPE = "Button Long Pressed"
+        const val TARGET_TAPPED_INTERACTION_TYPE = "Target Tapped"
+        const val TARGET_LONG_PRESSED_INTERACTION_TYPE = "Target Long Pressed"
     }
 
     data class StepSeen(
@@ -36,7 +40,7 @@ internal sealed class ExperienceLifecycleEvent(
     ) : ExperienceLifecycleEvent(experience, AnalyticsEvent.ExperienceStepInteraction) {
 
         enum class InteractionType {
-            FORM_SUBMITTED, BUTTON_TAPPED, BUTTON_LONG_PRESSED
+            FORM_SUBMITTED, BUTTON_TAPPED, BUTTON_LONG_PRESSED, TARGET_TAPPED, TARGET_LONG_PRESSED
         }
     }
 
@@ -133,6 +137,8 @@ internal sealed class ExperienceLifecycleEvent(
                             FORM_SUBMITTED -> step.formState
                             BUTTON_TAPPED -> interactionProperties
                             BUTTON_LONG_PRESSED -> interactionProperties
+                            TARGET_TAPPED -> interactionProperties
+                            TARGET_LONG_PRESSED -> interactionProperties
                         },
                     )
                 }
@@ -145,6 +151,8 @@ internal sealed class ExperienceLifecycleEvent(
             FORM_SUBMITTED -> FORM_SUBMITTED_INTERACTION_TYPE
             BUTTON_TAPPED -> BUTTON_TAPPED_INTERACTION_TYPE
             BUTTON_LONG_PRESSED -> BUTTON_LONG_PRESSED_INTERACTION_TYPE
+            TARGET_TAPPED -> TARGET_TAPPED_INTERACTION_TYPE
+            TARGET_LONG_PRESSED -> TARGET_LONG_PRESSED_INTERACTION_TYPE
         }
 }
 

--- a/appcues/src/main/java/com/appcues/data/mapper/action/ActionsMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/action/ActionsMapper.kt
@@ -13,7 +13,7 @@ internal class ActionsMapper(
     fun map(actions: Map<UUID, List<ActionResponse>>?, primitiveId: UUID): List<Action> {
         return arrayListOf<Action>().apply {
             // get possible action list based on id, then map to Action model
-            actions?.get(primitiveId)?.forEach { actionResponse -> actionResponse.toAction()?.let { add(it) } }
+            actions?.get(primitiveId)?.forEach { actionResponse -> actionResponse.toAction(actionRegistry)?.let { add(it) } }
         }
     }
 
@@ -22,22 +22,22 @@ internal class ActionsMapper(
 
         return hashMapOf<UUID, List<Action>>().apply {
             from.forEach { entry ->
-                entry.value.mapNotNull { actionResponse -> actionResponse.toAction() }.also { set(entry.key, it) }
+                entry.value.mapNotNull { actionResponse -> actionResponse.toAction(actionRegistry) }.also { set(entry.key, it) }
             }
         }
     }
+}
 
-    private fun ActionResponse.toAction(): Action? {
-        return actionRegistry[type]?.let {
-            Action(
-                on = when (on) {
-                    "tap" -> Action.Trigger.TAP
-                    "longPress" -> Action.Trigger.LONG_PRESS
-                    "navigate" -> Action.Trigger.NAVIGATE
-                    else -> throw AppcuesMappingException("on property $on is unknown")
-                },
-                experienceAction = it.invoke(config)
-            )
-        }
+internal fun ActionResponse.toAction(actionRegistry: ActionRegistry): Action? {
+    return actionRegistry[type]?.let {
+        Action(
+            on = when (on) {
+                "tap" -> Action.Trigger.TAP
+                "longPress" -> Action.Trigger.LONG_PRESS
+                "navigate" -> Action.Trigger.NAVIGATE
+                else -> throw AppcuesMappingException("on property $on is unknown")
+            },
+            experienceAction = it.invoke(config)
+        )
     }
 }

--- a/appcues/src/main/java/com/appcues/data/model/AppcuesConfigMapExt.kt
+++ b/appcues/src/main/java/com/appcues/data/model/AppcuesConfigMapExt.kt
@@ -1,11 +1,14 @@
 package com.appcues.data.model
 
+import com.appcues.action.ActionRegistry
 import com.appcues.data.MoshiConfiguration
+import com.appcues.data.mapper.action.toAction
 import com.appcues.data.mapper.step.primitives.mapPrimitive
 import com.appcues.data.mapper.styling.mapComponentColor
 import com.appcues.data.mapper.styling.mapComponentStyle
 import com.appcues.data.model.styling.ComponentColor
 import com.appcues.data.model.styling.ComponentStyle
+import com.appcues.data.remote.appcues.response.action.ActionResponse
 import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse
 import com.appcues.data.remote.appcues.response.styling.StyleColorResponse
 import com.appcues.data.remote.appcues.response.styling.StyleResponse
@@ -23,10 +26,7 @@ internal inline fun <reified T : Any?> AppcuesConfigMap.getConfig(key: String): 
     // if hash config is null, return default
     if (this == null) return null
     // get value by key else return default
-    return get(key)?.let {
-        // if is instance of T return it else return default
-        if (it is T) it else null
-    }
+    return get(key) as? T
 }
 
 internal fun AppcuesConfigMap.getConfigInt(key: String): Int? {
@@ -52,6 +52,11 @@ internal fun AppcuesConfigMap.getConfigPrimitive(key: String): ExperiencePrimiti
     return getConfig<Any>(key)?.let {
         MoshiConfiguration.fromAny<PrimitiveResponse>(it)?.mapPrimitive()
     }
+}
+
+internal fun AppcuesConfigMap.getConfigActions(key: String, actionRegistry: ActionRegistry): List<Action> {
+    return getConfig<List<Any>>(key)?.map { MoshiConfiguration.fromAny<ActionResponse>(it) }
+        ?.mapNotNull { response -> response?.toAction(actionRegistry) } ?: arrayListOf()
 }
 
 internal fun AppcuesConfigMap.getConfigColor(key: String): ComponentColor? {

--- a/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
@@ -10,6 +10,7 @@ import com.appcues.trait.appcues.PagingDotsTrait
 import com.appcues.trait.appcues.SkippableTrait
 import com.appcues.trait.appcues.StepAnimationTrait
 import com.appcues.trait.appcues.TargetElementTrait
+import com.appcues.trait.appcues.TargetInteractionTrait
 import com.appcues.trait.appcues.TargetRectangleTrait
 import com.appcues.trait.appcues.TooltipTrait
 import org.koin.dsl.ScopeDSL
@@ -17,83 +18,19 @@ import org.koin.dsl.ScopeDSL
 internal object TraitKoin : KoinScopePlugin {
 
     override fun ScopeDSL.install() {
-        scoped {
-            TraitRegistry(
-                scope = get(),
-                logcues = get()
-            )
-        }
+        scoped { TraitRegistry(get(), get()) }
 
-        factory { params ->
-            BackdropTrait(
-                config = params.getOrNull(),
-            )
-        }
-
-        factory { params ->
-            StepAnimationTrait(
-                config = params.getOrNull(),
-            )
-        }
-
-        factory { params ->
-            TargetElementTrait(
-                config = params.getOrNull(),
-            )
-        }
-
-        factory { params ->
-            TargetRectangleTrait(
-                config = params.getOrNull(),
-            )
-        }
-
-        factory { params ->
-            BackdropKeyholeTrait(
-                config = params.getOrNull(),
-            )
-        }
-
-        factory { params ->
-            ModalTrait(
-                config = params.getOrNull(),
-                scope = get(),
-                context = get(),
-            )
-        }
-
-        factory { params ->
-            TooltipTrait(
-                config = params.getOrNull(),
-                scope = get(),
-            )
-        }
-
-        factory { params ->
-            SkippableTrait(
-                config = params.getOrNull(),
-                experienceRenderer = get(),
-                appcuesCoroutineScope = get(),
-            )
-        }
-
-        factory { params ->
-            CarouselTrait(
-                config = params.getOrNull(),
-            )
-        }
-
-        factory { params ->
-            PagingDotsTrait(
-                config = params.getOrNull(),
-            )
-        }
-
-        factory { params ->
-            BackgroundContentTrait(
-                config = params.getOrNull(),
-                level = params.get(),
-            )
-        }
+        factory { params -> BackdropTrait(params.getOrNull()) }
+        factory { params -> StepAnimationTrait(params.getOrNull()) }
+        factory { params -> TargetElementTrait(params.getOrNull()) }
+        factory { params -> TargetRectangleTrait(params.getOrNull()) }
+        factory { params -> BackdropKeyholeTrait(params.getOrNull()) }
+        factory { params -> ModalTrait(params.getOrNull(), get(), get()) }
+        factory { params -> TooltipTrait(params.getOrNull(), get()) }
+        factory { params -> SkippableTrait(params.getOrNull(), get(), get()) }
+        factory { params -> CarouselTrait(params.getOrNull()) }
+        factory { params -> PagingDotsTrait(params.getOrNull()) }
+        factory { params -> TargetInteractionTrait(params.getOrNull(), get(), get()) }
+        factory { params -> BackgroundContentTrait(params.getOrNull(), params.get()) }
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/TraitRegistry.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitRegistry.kt
@@ -11,6 +11,7 @@ import com.appcues.trait.appcues.PagingDotsTrait
 import com.appcues.trait.appcues.SkippableTrait
 import com.appcues.trait.appcues.StepAnimationTrait
 import com.appcues.trait.appcues.TargetElementTrait
+import com.appcues.trait.appcues.TargetInteractionTrait
 import com.appcues.trait.appcues.TargetRectangleTrait
 import com.appcues.trait.appcues.TooltipTrait
 import org.koin.core.component.KoinScopeComponent
@@ -39,6 +40,7 @@ internal class TraitRegistry(
         register(SkippableTrait.TYPE) { config, _ -> get<SkippableTrait> { parametersOf(config) } }
         register(CarouselTrait.TYPE) { config, _ -> get<CarouselTrait> { parametersOf(config) } }
         register(PagingDotsTrait.TYPE) { config, _ -> get<PagingDotsTrait> { parametersOf(config) } }
+        register(TargetInteractionTrait.TYPE) { config, _ -> get<TargetInteractionTrait> { parametersOf(config) } }
         register(BackgroundContentTrait.TYPE) { config, level -> get<BackgroundContentTrait> { parametersOf(config, level) } }
     }
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetInteractionTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetInteractionTrait.kt
@@ -1,0 +1,89 @@
+package com.appcues.trait.appcues
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import com.appcues.action.ActionProcessor
+import com.appcues.action.ActionRegistry
+import com.appcues.action.ExperienceAction
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.TARGET_LONG_PRESSED
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.TARGET_TAPPED
+import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.getConfigActions
+import com.appcues.trait.BackdropDecoratingTrait
+import com.appcues.trait.extensions.getRect
+import com.appcues.trait.extensions.rememberTargetRectangleInfo
+import com.appcues.ui.composables.AppcuesActionsDelegate
+import com.appcues.ui.composables.LocalAppcuesStepMetadata
+import com.appcues.ui.extensions.toLongPressMotionOrNull
+import com.appcues.ui.extensions.toTapMotionOrEmpty
+import com.appcues.ui.utils.rememberAppcuesWindowInfo
+
+internal class TargetInteractionTrait(
+    override val config: AppcuesConfigMap,
+    private val actionProcessor: ActionProcessor,
+    actionRegistry: ActionRegistry,
+) : BackdropDecoratingTrait {
+
+    companion object {
+
+        const val TYPE = "@appcues/target-interaction"
+
+        private const val VIEW_DESCRIPTION = "Target Rectangle"
+    }
+
+    private val actions = config.getConfigActions("actions", actionRegistry)
+
+    private val actionDelegate = object : AppcuesActionsDelegate {
+        override fun onActions(actions: List<ExperienceAction>, interactionType: InteractionType, viewDescription: String?) {
+            actionProcessor.process(actions, interactionType, viewDescription)
+        }
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
+        // calling content before our composable makes so we are on top of all other backdrop traits
+        // wrapping content call
+        content()
+
+        val targetRectInfo = rememberTargetRectangleInfo(LocalAppcuesStepMetadata.current)
+        // only draws when target rectangle info exists
+        targetRectInfo.getRect(rememberAppcuesWindowInfo())?.let { rect ->
+            val sizeDp = DpSize(rect.width.dp, rect.height.dp)
+            val offsetDp = DpOffset(rect.left.dp, rect.top.dp)
+
+            Box(
+                modifier = Modifier
+                    .size(sizeDp)
+                    .offset(x = offsetDp.x, y = offsetDp.y)
+                    // add click listener but without any ripple effect.
+                    .then(
+                        if (actions.isNotEmpty()) {
+                            Modifier.combinedClickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onLongClick = actions.toLongPressMotionOrNull(actionDelegate, TARGET_LONG_PRESSED, VIEW_DESCRIPTION),
+                                onClick = actions.toTapMotionOrEmpty(actionDelegate, TARGET_TAPPED, VIEW_DESCRIPTION),
+                            )
+                        }
+                        // when no actions are listed, the default behavior is to
+                        else Modifier.pointerInput(Unit) { detectTapGestures { } }
+                    )
+            )
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/ModifierExt.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.BUTTON_LONG_PRESSED
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.BUTTON_TAPPED
 import com.appcues.data.model.Action
@@ -272,14 +273,15 @@ private fun Modifier.actions(
                 indication = gestureProperties.indication,
                 enabled = gestureProperties.enabled,
                 role = gestureProperties.role,
-                onLongClick = toLongPressMotionOrNull(gestureProperties.actionsDelegate, viewDescription),
-                onClick = toTapMotionOrEmpty(gestureProperties.actionsDelegate, viewDescription),
+                onLongClick = toLongPressMotionOrNull(gestureProperties.actionsDelegate, BUTTON_LONG_PRESSED, viewDescription),
+                onClick = toTapMotionOrEmpty(gestureProperties.actionsDelegate, BUTTON_TAPPED, viewDescription),
             )
     }
 )
 
-private fun List<Action>.toTapMotionOrEmpty(
+internal fun List<Action>.toTapMotionOrEmpty(
     actionsDelegate: AppcuesActionsDelegate,
+    interactionType: InteractionType,
     viewDescription: String?
 ): (() -> Unit) {
     // filter only TAP motions
@@ -294,15 +296,16 @@ private fun List<Action>.toTapMotionOrEmpty(
             {
                 actionsDelegate.onActions(
                     actions = this,
-                    interactionType = BUTTON_TAPPED,
+                    interactionType = interactionType,
                     viewDescription = viewDescription
                 )
             }
         } ?: { }
 }
 
-private fun List<Action>.toLongPressMotionOrNull(
+internal fun List<Action>.toLongPressMotionOrNull(
     actionsDelegate: AppcuesActionsDelegate,
+    interactionType: InteractionType,
     viewDescription: String?
 ): (() -> Unit)? {
     // filter only LONG_PRESS motions
@@ -317,7 +320,7 @@ private fun List<Action>.toLongPressMotionOrNull(
             {
                 actionsDelegate.onActions(
                     actions = this,
-                    interactionType = BUTTON_LONG_PRESSED,
+                    interactionType = interactionType,
                     viewDescription = viewDescription
                 )
             }


### PR DESCRIPTION
This adds an implementation of @appcues/target-interaction (https://github.com/appcues/appcues-mobile-experience-spec/pull/175). This trait can be used to create a transparent View that lays over the target rectangle, from metadata, to captures taps and long presses. 

Additionally this trait can also provide with a list of actions that should be executed when those actions occur.

```json
{
    "type": "@appcues/target-interaction",
    "config": {
        "actions": [
            {
                "on": "tap",
                "type": "@appcues/continue",
                "config": {
                    "offset": 1
                }
            }
        ]
    }
}
```