### PR TITLE
♻️  change target-interaction to use all of keyhole configs

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/extensions/RectExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/extensions/RectExt.kt
@@ -1,0 +1,16 @@
+package com.appcues.trait.extensions
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import kotlin.math.max
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+internal fun Rect.getRectEncompassesRadius(blurRadius: Float): Float {
+    return max((sqrt(width.pow(2) + height.pow(2)) / 2) + blurRadius, 0f)
+}
+
+internal fun Rect?.inflateOrEmpty(spreadRadius: Double): Rect {
+    return this?.inflate(spreadRadius.toFloat()) ?: Rect(Offset(0f, 0f), Size(0f, 0f))
+}


### PR DESCRIPTION
This changes introduces new metadataSettings property that holds all keyhole configs so it can be consulted by other traits like `@appcues/target-interaction`.

with this target-interaction will support RECT/CIRCLE, cornerRadius and spreadRadius