### PR TITLE
Revert public visibility on the View.isAppcuesView() extension

### DIFF
--- a/appcues/src/main/java/com/appcues/ElementTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/ElementTargetingStrategy.kt
@@ -105,7 +105,12 @@ data class ViewElement(
     val children: List<ViewElement>?,
 )
 
-internal fun View.isAppcuesView(): Boolean {
+/**
+ * Determine if a View was created by the Appcues SDK, such as the Debugger View, for example.
+ *
+ * @return True if this view was created by the Appcues SDK.
+ */
+fun View.isAppcuesView(): Boolean {
     return this.id == R.id.appcues_debugger_view
 }
 


### PR DESCRIPTION
This function could be used in the future by custom element targeting strategies.