### PR TITLE
Add support for XML resource ID based selectors

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
@@ -1,5 +1,6 @@
 package com.appcues.debugger.screencapture
 
+import android.content.res.Resources.NotFoundException
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
@@ -13,27 +14,34 @@ import com.appcues.monitor.AppcuesActivityMonitor
 internal data class AndroidViewSelector(
     var contentDescription: String? = null,
     var tag: String? = null,
+    var resourceName: String? = null
 ) : ElementSelector {
     val isValid: Boolean
-        get() = contentDescription != null || tag != null
+        get() = contentDescription != null || tag != null || resourceName != null
 
     override fun toMap(): Map<String, String> {
         return mapOf(
             "contentDescription" to contentDescription,
             "tag" to tag,
+            "resourceName" to resourceName,
         ).filterValues { it != null }.mapValues { it.value as String }
     }
 
+    @Suppress("MagicNumber")
     override fun evaluateMatch(target: ElementSelector): Int {
         var weight = 0
 
         (target as? AndroidViewSelector)?.let {
-            if (it.contentDescription != null && it.contentDescription == contentDescription) {
-                weight += 1
+            if (it.resourceName != null && it.resourceName == resourceName) {
+                weight += 1_000
             }
 
             if (it.tag != null && it.tag == tag) {
-                weight += 1
+                weight += 100
+            }
+
+            if (it.contentDescription != null && it.contentDescription == contentDescription) {
+                weight += 10
             }
         }
 
@@ -51,6 +59,7 @@ internal class AndroidTargetingStrategy : ElementTargetingStrategy {
         val selector = AndroidViewSelector(
             contentDescription = properties["contentDescription"],
             tag = properties["tag"],
+            resourceName = properties["resourceName"],
         )
         return if (selector.isValid) selector else null
     }
@@ -100,11 +109,17 @@ private fun View.asCaptureView(): ViewElement? {
         children = children,
     )
 }
-
 internal fun View.selector(): ElementSelector? {
+    @Suppress("SwallowedException")
+    val resourceName: String? = try {
+        if (this.isClickable) resources.getResourceEntryName(id) else null
+    } catch (ex: NotFoundException) {
+        null
+    }
     val selector = AndroidViewSelector(
         contentDescription = this.contentDescription?.toString(),
-        tag = tag?.toString()
+        tag = tag?.toString(),
+        resourceName = resourceName,
     )
 
     return if (selector.isValid) selector else null


### PR DESCRIPTION
A pretty simple update in our selector structure, this adds `resourceName`, using the resource ID string representation from how the view was defined in XML layouts, as a property you can use for target element selection.

This approach would only add that property if the `View.isClickable` was `true` - for commonly interactive elements like buttons, tabs, menus. It would avoid a lot of the extra noise in the screenshot for container elements or internal system views, but still make a lot of common tooltip targets selectable "for free".  I'm wondering if there is a better filter to use here than `isClickable` still?