### PR TITLE
Add an element targeting approach for Composables

### DIFF
--- a/appcues/src/main/java/com/appcues/ElementTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/ElementTargetingStrategy.kt
@@ -1,6 +1,10 @@
 package com.appcues
 
 import android.view.View
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import com.appcues.debugger.screencapture.appcuesViewTagProperty
 import com.squareup.moshi.JsonClass
 import java.util.UUID
 
@@ -136,3 +140,15 @@ internal fun ViewElement.viewsMatching(target: ElementSelector): List<Pair<ViewE
 
     return views
 }
+
+/**
+ * Identify this composable as a view to be available to Appcues targeted element experiences.
+ *
+ * @param tag the view tag, which should uniquely identify this element within the full Composition being rendered.
+ */
+@Stable
+public fun Modifier.appcuesView(tag: String): Modifier = semantics(
+    properties = {
+        appcuesViewTagProperty = tag
+    }
+)


### PR DESCRIPTION
This approach uses a custom Modifier to set a SemanticsProperty. We can then traverse the [Semantics tree](https://developer.android.com/jetpack/compose/semantics), very similar to how Compose UI testing works, to gather up layout info an selectors for views defined in compose. This is a low-code solution approach for element targeting with Jetpack Compose views.

The one complexity this brings is the usage of Reflection to extract the `AndroidComposeView` (host view container) instance and the `semanticsOwner` field within. Compose makes `SemanticsOwner` and `SemanticsNode` classes public, but does not provide any way to get access to them or instantiate them (internal constructors). So this appears to be the only mechanism at this point. This code is wrapped in exception handling to suppress issues should something unexpected changes in the future with this internal structure in Compose.

A simple example usage of this Modifier would look like
```kotlin
Button(modifier = Modifier.appcuesView("myButton"), onClick = { }) {
    Text("Hello World")
}
```

The view `tag` "myButton" is then available for usage in a selector, and an element targeted experience using the `@appcues/target-element` trait.

Here is an example of a tooltip targeting a Composable button in a test app

![Screenshot 2023-05-09 at 4 53 03 PM](https://github.com/appcues/appcues-android-sdk/assets/19266448/ef29fc0d-fe9e-4eda-87db-fda42c839f79)

Futhermore, Composables can nest Android `View` instances within, [via interop](https://developer.android.com/jetpack/compose/migrate/interoperability-apis/views-in-compose). Those can also be discovered and used in our screen capture and element targeting flows. Here is an example of the same test app with a nested `View` inside of the main app Composable, and a tooltip pointing to that Button view:

![Screenshot 2023-05-10 at 11 19 08 AM](https://github.com/appcues/appcues-android-sdk/assets/19266448/e9c330e5-d4a0-45ab-aaef-66824ca2ca6c)
