### PR TITLE
⬆️  Update gradle tools to 8.0

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,11 +4,6 @@
     <option name="RIGHT_MARGIN" value="140" />
     <option name="SOFT_MARGINS" value="140" />
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value />
-      </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.20" />
+  </component>
+</project>

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -39,6 +39,7 @@ android {
     }
 
     resourcePrefix 'appcues_'
+    namespace 'com.appcues'
 
     buildTypes {
         release {
@@ -85,10 +86,6 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
-    // Workaround for an issue that will be fixed by google some day.
-    // https://issuetracker.google.com/issues/227767363
-    debugImplementation "androidx.customview:customview:1.2.0-alpha02"
-    debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0"
     // ----
     implementation "com.google.android.material:material:1.7.0"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'

--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.appcues">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath "com.android.tools.build:gradle:8.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
         classpath "org.jacoco:org.jacoco.core:0.8.7"
         classpath "org.jetbrains.dokka:kotlin-as-java-plugin:1.7.20"

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0.
-# To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true
-# in the `gradle.properties` file or use the new publishing DSL.
-android.disableAutomaticComponentCreation=true
+# Added properties after gradle tools update to 8.0
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Dec 28 10:03:27 BRT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -28,6 +28,8 @@ android {
         buildConfigField "String", "APPCUES_APPLICATION_ID", "\"PLACEHOLDER_APPLICATION_ID\""
     }
 
+    namespace 'com.appcues.samples.kotlin'
+
     buildTypes {
         release {
             signingConfig signingConfigs.release

--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.appcues.samples.kotlin">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name=".ExampleApplication"


### PR DESCRIPTION
Updating gradle tools to 8.0, for some reason now we need to run cmd commands on JDK 17, so if you are not on 17 yet, make sure to install it and update the path.

`brew install openjdk@17`

`echo 'export PATH="/opt/homebrew/opt/openjdk@17/bin:$PATH"' >> ~/.zshrc`