### PR TITLE
🐛 Fix tooltip max height when it overflows available space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 vendor/
+/.idea/kotlinc.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,11 +4,6 @@
     <option name="RIGHT_MARGIN" value="140" />
     <option name="SOFT_MARGINS" value="140" />
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value />
-      </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -6,6 +6,11 @@
         <option value="$PROJECT_DIR$/gradle/tools/detekt/detekt-config.yml" />
       </set>
     </option>
+    <option name="configurationFiles">
+      <list>
+        <option value="$PROJECT_DIR$/gradle/tools/detekt/detekt-config.yml" />
+      </list>
+    </option>
     <option name="enableAllRules" value="true" />
     <option name="enableFormatting" value="true" />
   </component>

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPath.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPath.kt
@@ -74,8 +74,8 @@ private fun getTooltipPointerPath(
     // the value of length is the pointerLengthPx considering the direction it should
     val animatedVerticalLength = animateFloatAsState(
         when (tooltipSettings.tooltipPointerPosition) {
-            Top -> -tooltipSettings.pointerLengthPx
-            Bottom -> tooltipSettings.pointerLengthPx
+            is Top -> -tooltipSettings.pointerLengthPx
+            is Bottom -> tooltipSettings.pointerLengthPx
             else -> 0f
         },
         animationSpec
@@ -270,8 +270,8 @@ private fun getContainerPath(
         }
 
         val offset = when (tooltipSettings.tooltipPointerPosition) {
-            Top -> Offset(0f, tooltipSettings.pointerLengthPx)
-            Left -> Offset(tooltipSettings.pointerLengthPx, 0f)
+            is Top -> Offset(0f, tooltipSettings.pointerLengthPx)
+            is Left -> Offset(tooltipSettings.pointerLengthPx, 0f)
             else -> Offset(0f, 0f)
         }
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
@@ -42,6 +42,7 @@ internal data class ContainerCornerRadius(
 internal sealed class TooltipPointerPosition {
 
     abstract val isVertical: Boolean
+    abstract val maxHeight: Dp?
 
     private val _alignment = mutableStateOf(PointerAlignment())
     val alignment: State<PointerAlignment> = _alignment
@@ -66,7 +67,7 @@ internal sealed class TooltipPointerPosition {
      */
     abstract fun toContainerCornerRadius(cornerRadius: Dp): ContainerCornerRadius
 
-    object Top : TooltipPointerPosition() {
+    class Top(override val maxHeight: Dp? = null) : TooltipPointerPosition() {
 
         override val isVertical = true
 
@@ -82,7 +83,7 @@ internal sealed class TooltipPointerPosition {
         }
     }
 
-    object Bottom : TooltipPointerPosition() {
+    class Bottom(override val maxHeight: Dp? = null) : TooltipPointerPosition() {
 
         override val isVertical = true
 
@@ -101,6 +102,7 @@ internal sealed class TooltipPointerPosition {
     object Left : TooltipPointerPosition() {
 
         override val isVertical = false
+        override val maxHeight: Dp? = null
 
         override fun toContainerCornerRadius(cornerRadius: Dp): ContainerCornerRadius {
             val ignoreRounding = alignment.value.ignoreRounding
@@ -117,6 +119,7 @@ internal sealed class TooltipPointerPosition {
     object Right : TooltipPointerPosition() {
 
         override val isVertical = false
+        override val maxHeight: Dp? = null
 
         override fun toContainerCornerRadius(cornerRadius: Dp): ContainerCornerRadius {
             val ignoreRounding = alignment.value.ignoreRounding
@@ -133,6 +136,7 @@ internal sealed class TooltipPointerPosition {
     object None : TooltipPointerPosition() {
 
         override val isVertical = false
+        override val maxHeight: Dp? = null
 
         override fun toContainerCornerRadius(cornerRadius: Dp): ContainerCornerRadius {
             return ContainerCornerRadius(


### PR DESCRIPTION
Adding a maxHeight value to Top and Bottom tooltip position, that can contain a value when we fall under the two last scenarios, where there is no good place to position the tooltip, and then we calculate the preferred position considering all the limitations. Now along with that, reporting back the available maxHeight makes so that at least we have matching behavior for those edge cases between android and IOS.

![image](https://github.com/appcues/appcues-android-sdk/assets/5244805/6b4d74f1-541a-4daf-b2e3-8e9102571077)
![image](https://github.com/appcues/appcues-android-sdk/assets/5244805/0a1833a7-f0e4-4fd0-b53d-c6c1e0ce6235)
![image](https://github.com/appcues/appcues-android-sdk/assets/5244805/f74b327a-9d56-47f0-8a1e-1e4164c1fd99)


There were two bugs related to this issue, [#51484](https://app.shortcut.com/appcues/story/51484/ios-and-android-behavior-difference-with-large-pointer-length-on-tooltip) and [#53188](https://app.shortcut.com/appcues/story/53188/long-tooltip-content-overlaps-target-area)