### PR TITLE
🐛 Add all identify properties to all session events

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -23,6 +23,7 @@ internal class AutoPropertyDecorator(
 ) {
 
     companion object {
+
         const val IDENTITY_PROPERTY = "_identity"
         const val UPDATED_AT_PROPERTY = "_updatedAt"
     }
@@ -32,6 +33,7 @@ internal class AutoPropertyDecorator(
     private var previousScreen: String? = null
     private var sessionPageviews = 0
     private var sessionRandomId: Int = 0
+    private var sessionLatestUserProperties: Map<String, Any> = mapOf()
 
     private val contextProperties = hashMapOf<String, Any>(
         "app_id" to config.applicationId,
@@ -69,6 +71,7 @@ internal class AutoPropertyDecorator(
 
     val autoProperties: Map<String, Any>
         get() = hashMapOf<String, Any>().apply {
+            putAll(sessionLatestUserProperties)
             putAll(applicationProperties)
             // add userAgent if exists (userAgent is a mutable property loaded asynchronously) and can be null
             userAgent?.let { put("_userAgent", it) }
@@ -107,7 +110,9 @@ internal class AutoPropertyDecorator(
     }
 
     fun decorateIdentify(activity: ActivityRequest) = activity.copy(
-        profileUpdate = (activity.profileUpdate ?: hashMapOf()).apply {
+        profileUpdate = (activity.profileUpdate ?: hashMapOf()).also {
+            sessionLatestUserProperties = it
+        }.apply {
             putAll(autoProperties)
         }
     )

--- a/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
@@ -198,6 +198,25 @@ internal class AutoPropertyDecoratorTest {
     }
 
     @Test
+    fun `decorateIdentity SHOULD add session properties and send on other requests`() {
+        // given
+        val activityRequest = ActivityRequest(
+            userId = "test userId",
+            accountId = "test accountId",
+            profileUpdate = hashMapOf("test_property" to "test_value")
+        )
+        // when
+        with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
+            // then
+            assertThat(profileUpdate).hasSize(22)
+        }
+        // then when
+        with(autoPropertyDecorator.decorateTrack(EventRequest(name = SessionStarted.eventName))) {
+            assertThat(attributes["_identity"] as HashMap<*, *>).containsEntry("test_property", "test_value")
+        }
+    }
+
+    @Test
     fun `decorateIdentity SHOULD put custom properties into profileUpdate map`() {
         // given
         val activityRequest = ActivityRequest(

--- a/docs/Identifying.md
+++ b/docs/Identifying.md
@@ -10,6 +10,8 @@ In order to target content to the right users at the right time, you need to ide
 appcues.identify(userId, properties)
 ```
 
+It is recommended that the application identify a user at moments such as sign in, and also when the app starts up on a cold launch with existing log in credentials. This will ensure that any user properties tied to this user can be kept accurately up to date.
+
 The inverse of identifying is resetting. For example, if a user logs out of your app. Calling `reset()` will disable tracking of screens and events until a user is identified again.
 
 ### Identity Verification


### PR DESCRIPTION
matching the last change coming from a bug found when a customer wanted to export information in studio, IOS has this [PR](https://github.com/appcues/appcues-ios-sdk/pull/414). 

I think this is matching the new behavior, the unit test is also there showing its working.