### PR TITLE
🐛 key Role may not exist in some compositions

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.getOrNull
 import androidx.core.view.children
 import com.appcues.ElementSelector
 import com.appcues.ElementTargetingStrategy
@@ -235,7 +236,7 @@ private fun SemanticsNode.selector(): AndroidViewSelector? {
     if (config.contains(AppcuesViewTagKey)) {
         return AndroidViewSelector(
             properties = mapOf(SELECTOR_APPCUES_ID to config[AppcuesViewTagKey]),
-            type = config[SemanticsProperties.Role].toString()
+            type = config.getOrNull(SemanticsProperties.Role)?.toString()
         )
     }
     return null


### PR DESCRIPTION
While testing the new sdk features with [this PR](https://github.com/appcues/mobile-experiments/pull/258) found that sometimes Role is not present, which is causing an exception and disabling basically compose element scans.

with this change if Role is not present, we use null, which is totally fine since role is just being used for displayName for now