### PR TITLE
Add support for multi window scenarios in element targeting + overlay

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
+    implementation "androidx.savedstate:savedstate:1.2.0"
     // Image Loader
     implementation "io.coil-kt:coil-compose:$coil_version"
     implementation "io.coil-kt:coil-gif:$coil_version"

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
@@ -21,6 +21,7 @@ import com.appcues.debugger.screencapture.AndroidViewSelector.Companion.SELECTOR
 import com.appcues.debugger.screencapture.AndroidViewSelector.Companion.SELECTOR_TAG
 import com.appcues.isAppcuesView
 import com.appcues.monitor.AppcuesActivityMonitor
+import com.appcues.ui.getParentView
 
 internal class AndroidViewSelector(
     private val properties: Map<String, String?>,
@@ -85,7 +86,7 @@ internal class AndroidViewSelector(
 internal class AndroidTargetingStrategy : ElementTargetingStrategy {
 
     override fun captureLayout(): ViewElement? {
-        return AppcuesActivityMonitor.activity?.window?.decorView?.rootView?.asCaptureView()
+        return AppcuesActivityMonitor.activity?.getParentView()?.asCaptureView()
     }
 
     override fun inflateSelectorFrom(properties: Map<String, String>): ElementSelector? {

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
@@ -14,6 +14,7 @@ import com.appcues.data.remote.customerapi.response.PreUploadScreenshotResponse
 import com.appcues.data.remote.imageupload.ImageUploadRemoteSource
 import com.appcues.data.remote.sdksettings.SdkSettingsRemoteSource
 import com.appcues.monitor.AppcuesActivityMonitor
+import com.appcues.ui.getParentView
 import com.appcues.util.ContextResources
 import com.appcues.util.ResultOf
 import com.appcues.util.ResultOf.Failure
@@ -29,7 +30,7 @@ internal class ScreenCaptureProcessor(
     private val imageUploadRemoteSource: ImageUploadRemoteSource,
 ) {
     fun captureScreen(): Capture? {
-        return AppcuesActivityMonitor.activity?.window?.decorView?.rootView?.let {
+        return AppcuesActivityMonitor.activity?.getParentView()?.let {
             prepare(it)
 
             val timestamp = Date()

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetElementTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetElementTrait.kt
@@ -13,6 +13,7 @@ import com.appcues.findMatches
 import com.appcues.monitor.AppcuesActivityMonitor
 import com.appcues.trait.AppcuesTraitException
 import com.appcues.trait.MetadataSettingTrait
+import com.appcues.ui.getParentView
 
 internal class TargetElementTrait(
     override val config: AppcuesConfigMap,
@@ -29,7 +30,7 @@ internal class TargetElementTrait(
     override fun produceMetadata(): Map<String, Any?> {
         val view = viewMatchingSelector()
 
-        val rootView = AppcuesActivityMonitor.activity?.window?.decorView?.rootView
+        val rootView = AppcuesActivityMonitor.activity?.getParentView()
             ?: throw AppcuesTraitException("could not find root view")
 
         val displayMetrics = rootView.context.resources.displayMetrics

--- a/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
@@ -27,6 +27,7 @@ import com.appcues.monitor.AppcuesActivityMonitor.ActivityMonitorListener
 import com.appcues.ui.composables.AppcuesComposition
 import com.appcues.ui.primitive.EmbedChromeClient
 import org.koin.core.scope.Scope
+import java.lang.reflect.Method
 
 internal class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLifecycleObserver, ActivityMonitorListener {
 
@@ -140,33 +141,50 @@ internal class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLife
 }
 
 internal fun Activity.getParentView(): ViewGroup {
-    // if there is any difference in API levels we can handle it here
-    if (VERSION.SDK_INT >= VERSION_CODES.Q) {
-        val views = WindowInspector.getGlobalWindowViews()
 
-        val decorView = views.last()
-        if (decorView != window.decorView) {
-            // This is the case of some other decorView showing on top - like a modal
-            // dialog. In this case, we need to apply the fixups below to ensure that our
-            // content can render correctly inside of this other view
-            if (ViewTreeLifecycleOwner.get(decorView) == null) {
-                val lifecycleOwner = window.decorView.findViewTreeLifecycleOwner()
-                ViewTreeLifecycleOwner.set(decorView, lifecycleOwner)
-            }
-
-            if (ViewTreeViewModelStoreOwner.get(decorView) == null) {
-                val viewModelStoreOwner = window.decorView.findViewTreeViewModelStoreOwner()
-                ViewTreeViewModelStoreOwner.set(decorView, viewModelStoreOwner)
-            }
-
-            if (decorView.findViewTreeSavedStateRegistryOwner() == null) {
-                val savedStateRegistryOwner = window.decorView.findViewTreeSavedStateRegistryOwner()
-                decorView.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
-            }
-        }
-
-        return decorView.rootView as ViewGroup
+    // try to find the most applicable decorView to inject Appcues content into. Typically there is just a single
+    // decorView on the Activity window. However, if something like a dialog modal has been shown, this can add another
+    // window with another decorView on top of the Activity. If we want to support showing content above that layer, we need
+    // to find the top most decorView like below.
+    
+    val decorView = if (VERSION.SDK_INT >= VERSION_CODES.Q) {
+        // this is the preferred method on API 29+ with the new WindowInspector function
+        WindowInspector.getGlobalWindowViews().last()
     } else {
-        return window.decorView.rootView as ViewGroup
+        @Suppress("SwallowedException", "TooGenericExceptionCaught")
+        try {
+            // this is the less desirable method for API 21-28, using reflection to try to get the root views
+            val windowManagerClass = Class.forName("android.view.WindowManagerGlobal")
+            val windowManager = windowManagerClass.getMethod("getInstance").invoke(null)
+            val getViewRootNames: Method = windowManagerClass.getMethod("getViewRootNames")
+            val getRootView: Method = windowManagerClass.getMethod("getRootView", String::class.java)
+            val rootViewNames = getViewRootNames.invoke(windowManager) as Array<Any?>
+            val rootViews = rootViewNames.map { getRootView(windowManager, it) as View }
+            rootViews.last()
+        } catch (e: Exception) {
+            // if all else fails, use the decorView on the window, which is typically the only one
+            window.decorView
+        }
     }
+
+    // This is the case of some other decorView showing on top - like a modal
+    // dialog. In this case, we need to apply the fix-ups below to ensure that our
+    // content can render correctly inside of this other view. In each case, we use
+    // the applicable value from the Activity default window.
+    if (ViewTreeLifecycleOwner.get(decorView) == null) {
+        val lifecycleOwner = window.decorView.findViewTreeLifecycleOwner()
+        ViewTreeLifecycleOwner.set(decorView, lifecycleOwner)
+    }
+
+    if (ViewTreeViewModelStoreOwner.get(decorView) == null) {
+        val viewModelStoreOwner = window.decorView.findViewTreeViewModelStoreOwner()
+        ViewTreeViewModelStoreOwner.set(decorView, viewModelStoreOwner)
+    }
+
+    if (decorView.findViewTreeSavedStateRegistryOwner() == null) {
+        val savedStateRegistryOwner = window.decorView.findViewTreeSavedStateRegistryOwner()
+        decorView.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
+    }
+
+    return decorView.rootView as ViewGroup
 }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
@@ -161,7 +161,7 @@ internal fun Activity.getParentView(): ViewGroup {
             val rootViewNames = getViewRootNames.invoke(windowManager) as Array<Any?>
             val rootViews = rootViewNames.map { getRootView(windowManager, it) as View }
             rootViews.last()
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             // if all else fails, use the decorView on the window, which is typically the only one
             window.decorView
         }


### PR DESCRIPTION
This handles situations where simply taking the
```kotlin
activity.window.decorView.rootView
```
to be the root view for injecting overlay content  is not sufficient.

If a dialog view / modal is being shown in the customer application, this will cause another window and decorView to show up in the view hierarchy. We need to actually get all of the top level windows in the Activity and find the topmost item (last) and use this for screen capture, element targeting, and content overlay.

This [post](https://stackoverflow.com/a/19776489) had some helpful tips about how to get this info, which is not always straightforward. We use a multi-layer approach, where API 29+ can use a [handy WindowInspector function](https://developer.android.com/reference/android/view/inspector/WindowInspector#getGlobalWindowViews()) to get this info easily. Below that level, we have to make a _safeguarded_ attempt at reflection to get this info. If all else fails, we just use the main window for the Activity like before. This is not ideal, but the vast majority of the time it is correct.