### PR TITLE
✨ Added renderContext property to Experience model

### DIFF
--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -10,6 +10,7 @@ internal data class Experience(
     val published: Boolean,
     val priority: ExperiencePriority,
     val type: String?,
+    val renderContext: RenderContext,
     val publishedAt: Long?,
     val experiment: Experiment?,
     val completionActions: List<ExperienceAction>,

--- a/appcues/src/main/java/com/appcues/data/model/RenderContext.kt
+++ b/appcues/src/main/java/com/appcues/data/model/RenderContext.kt
@@ -1,0 +1,6 @@
+package com.appcues.data.model
+
+internal sealed class RenderContext {
+    data class Embed(val frameId: String) : RenderContext()
+    object Modal : RenderContext()
+}

--- a/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
@@ -16,6 +16,7 @@ import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.model.RenderContext
 import com.appcues.data.model.Step
 import com.appcues.data.model.StepContainer
 import com.appcues.data.model.styling.ComponentSelectMode.MULTIPLE
@@ -282,6 +283,7 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         published = true,
         priority = NORMAL,
         type = "mobile",
+        renderContext = RenderContext.Modal,
         publishedAt = Date().time,
         completionActions = listOf(),
         trigger = ExperienceTrigger.ShowCall,

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -7,6 +7,7 @@ import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceTrigger
 import com.appcues.data.model.Experiment
+import com.appcues.data.model.RenderContext
 import com.appcues.data.model.Step
 import com.appcues.data.model.StepContainer
 import com.appcues.trait.PresentingTrait
@@ -24,6 +25,7 @@ internal fun mockExperience(onPresent: (() -> Unit)? = null) =
         id = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
         name = "Mock Experience",
         type = "mobile",
+        renderContext = RenderContext.Modal,
         stepContainers = listOf(
             StepContainer(
                 id = UUID.fromString("e062bd81-b736-44c4-abba-633dfff966aa"),
@@ -76,6 +78,7 @@ internal fun mockExperienceExperiment(experiment: Experiment) =
         id = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
         name = "Mock Experience with Experiment",
         type = "mobile",
+        renderContext = RenderContext.Modal,
         stepContainers = listOf(
             StepContainer(
                 id = UUID.fromString("60b49c12-c49b-47ac-8ed3-ba4e9a55e694"),
@@ -104,6 +107,7 @@ internal fun mockExperienceNavigateActions(actions: List<Action>, presentingTrai
         id = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
         name = "Mock Experience with Experiment",
         type = "mobile",
+        renderContext = RenderContext.Modal,
         stepContainers = listOf(
             StepContainer(
                 id = UUID.fromString("60b49c12-c49b-47ac-8ed3-ba4e9a55e694"),

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -9,6 +9,7 @@ import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceTrigger
 import com.appcues.data.model.ExperienceTrigger.Qualification
+import com.appcues.data.model.RenderContext
 import com.appcues.mocks.mockExperience
 import com.appcues.mocks.mockExperienceNavigateActions
 import com.appcues.rules.KoinScopeRule
@@ -336,6 +337,7 @@ internal class StateMachineTest : AppcuesScopeTest {
             published = true,
             priority = NORMAL,
             type = "mobile",
+            renderContext = RenderContext.Modal,
             publishedAt = 1652895835000,
             completionActions = arrayListOf(),
             experiment = null,
@@ -363,6 +365,7 @@ internal class StateMachineTest : AppcuesScopeTest {
             published = true,
             priority = NORMAL,
             type = "mobile",
+            renderContext = RenderContext.Modal,
             publishedAt = 1652895835000,
             completionActions = arrayListOf(),
             experiment = null,


### PR DESCRIPTION
added new property renderContext and logic around building this property.

looking for @appcues/embedded trait in experience.traits and in case one is found, get "frameID" from config map to set as the RenderContext.Embed frameId, else returning Modal as default type