### PR TITLE
♻️  ExperienceRenderer depending on RenderContext to access StateMachine

### DIFF
--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -21,11 +21,18 @@ internal object ActionKoin : KoinScopePlugin {
         factory { CloseAction(config = it.getOrNull(), experienceRenderer = get()) }
         factory { LinkAction(config = it.getOrNull(), linkOpener = get(), appcues = get()) }
         factory { TrackEventAction(config = it.getOrNull(), appcues = get()) }
-        factory { ContinueAction(config = it.getOrNull(), stateMachine = get()) }
-        factory { LaunchExperienceAction(config = it.getOrNull(), stateMachine = get(), experienceRenderer = get()) }
+        factory { ContinueAction(config = it.getOrNull(), experienceRenderer = get()) }
+        factory { LaunchExperienceAction(config = it.getOrNull(), experienceRenderer = get()) }
         factory { UpdateProfileAction(config = it.getOrNull(), storage = get(), appcues = get()) }
-        factory { SubmitFormAction(config = it.getOrNull(), analyticsTracker = get(), stateMachine = get()) }
-        factory { StepInteractionAction(config = it.getOrNull(), interaction = it.get(), analyticsTracker = get(), stateMachine = get()) }
+        factory { SubmitFormAction(config = it.getOrNull(), analyticsTracker = get(), experienceRenderer = get()) }
+        factory {
+            StepInteractionAction(
+                config = it.getOrNull(),
+                interaction = it.get(),
+                analyticsTracker = get(),
+                experienceRenderer = get()
+            )
+        }
         factory { RequestReviewAction(config = it.getOrNull(), context = get(), koinScope = get()) }
     }
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/CloseAction.kt
@@ -3,6 +3,7 @@ package com.appcues.action.appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.action.MetadataSettingsAction
 import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.RenderContext
 import com.appcues.data.model.getConfigOrDefault
 import com.appcues.ui.ExperienceRenderer
 
@@ -23,6 +24,6 @@ internal class CloseAction(
     override val destination = "end-experience"
 
     override suspend fun execute() {
-        experienceRenderer.dismissCurrentExperience(markComplete = markComplete, destroyed = false)
+        experienceRenderer.dismiss(RenderContext.Modal, markComplete = markComplete, destroyed = false)
     }
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/ContinueAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/ContinueAction.kt
@@ -3,16 +3,16 @@ package com.appcues.action.appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.action.MetadataSettingsAction
 import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.RenderContext
 import com.appcues.data.model.getConfig
 import com.appcues.data.model.getConfigInt
-import com.appcues.statemachine.Action.StartStep
-import com.appcues.statemachine.StateMachine
 import com.appcues.statemachine.StepReference
+import com.appcues.ui.ExperienceRenderer
 import java.util.UUID
 
 internal class ContinueAction(
     override val config: AppcuesConfigMap,
-    private val stateMachine: StateMachine
+    private val experienceRenderer: ExperienceRenderer,
 ) : ExperienceAction, MetadataSettingsAction {
 
     companion object {
@@ -37,6 +37,6 @@ internal class ContinueAction(
     override val destination: String = stepReference.destination
 
     override suspend fun execute() {
-        stateMachine.handleAction(StartStep(stepReference))
+        experienceRenderer.show(RenderContext.Modal, stepReference)
     }
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
@@ -4,14 +4,13 @@ import com.appcues.action.ExperienceAction
 import com.appcues.action.MetadataSettingsAction
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.model.RenderContext
 import com.appcues.data.model.getConfig
-import com.appcues.statemachine.StateMachine
 import com.appcues.ui.ExperienceRenderer
 import java.util.UUID
 
 internal class LaunchExperienceAction(
     override val config: AppcuesConfigMap,
-    private val stateMachine: StateMachine,
     private val experienceRenderer: ExperienceRenderer,
 ) : ExperienceAction, MetadataSettingsAction {
 
@@ -20,14 +19,12 @@ internal class LaunchExperienceAction(
     constructor(
         completedExperienceId: String,
         launchExperienceId: String,
-        stateMachine: StateMachine,
         experienceRenderer: ExperienceRenderer,
     ) : this(
         config = hashMapOf<String, Any>(
             "completedExperienceID" to completedExperienceId,
             "experienceID" to launchExperienceId,
         ),
-        stateMachine = stateMachine,
         experienceRenderer = experienceRenderer
     )
 
@@ -59,7 +56,7 @@ internal class LaunchExperienceAction(
             // flow - capture the current experience from the state machine as the experience that is launching the new flow.
             // note: it's possible that the current experience was closed out before this triggered, in which case this
             // fromExperience ID value would be null.
-            val fromExperience = stateMachine.state.currentExperience
+            val fromExperience = experienceRenderer.getState(RenderContext.Modal).currentExperience
             ExperienceTrigger.LaunchExperienceAction(fromExperience?.id)
         }
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/StepInteractionAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/StepInteractionAction.kt
@@ -5,13 +5,14 @@ import com.appcues.analytics.AnalyticsTracker
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
 import com.appcues.data.model.AppcuesConfigMap
-import com.appcues.statemachine.StateMachine
+import com.appcues.data.model.RenderContext
+import com.appcues.ui.ExperienceRenderer
 
 internal class StepInteractionAction(
     override val config: AppcuesConfigMap,
     val interaction: StepInteractionData,
     private val analyticsTracker: AnalyticsTracker,
-    private val stateMachine: StateMachine,
+    private val experienceRenderer: ExperienceRenderer,
 ) : ExperienceAction {
 
     class StepInteractionData(
@@ -34,8 +35,9 @@ internal class StepInteractionAction(
     }
 
     override suspend fun execute() {
-        val experience = stateMachine.state.currentExperience
-        val stepIndex = stateMachine.state.currentStepIndex
+        val state = experienceRenderer.getState(RenderContext.Modal)
+        val experience = state.currentExperience
+        val stepIndex = state.currentStepIndex
 
         if (experience != null && stepIndex != null && experience.published) {
             val interactionEvent = StepInteraction(

--- a/appcues/src/main/java/com/appcues/action/appcues/SubmitFormAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/SubmitFormAction.kt
@@ -8,12 +8,13 @@ import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.FORM_SUBMITTED
 import com.appcues.analytics.formattedAsProfileUpdate
 import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.RenderContext
 import com.appcues.data.model.getConfigOrDefault
-import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer
 
 internal class SubmitFormAction(
     override val config: AppcuesConfigMap,
-    private val stateMachine: StateMachine,
+    private val experienceRenderer: ExperienceRenderer,
     private val analyticsTracker: AnalyticsTracker,
 ) : ExperienceActionQueueTransforming {
 
@@ -30,8 +31,9 @@ internal class SubmitFormAction(
             return queue
         }
 
-        val experience = stateMachine.state.currentExperience
-        val stepIndex = stateMachine.state.currentStepIndex
+        val state = experienceRenderer.getState(RenderContext.Modal)
+        val experience = state.currentExperience
+        val stepIndex = state.currentStepIndex
 
         if (experience != null && stepIndex != null) {
             val formState = experience.flatSteps[stepIndex].formState
@@ -48,8 +50,9 @@ internal class SubmitFormAction(
 
     // reports analytics for step interaction, for the form submission
     override suspend fun execute() {
-        val experience = stateMachine.state.currentExperience
-        val stepIndex = stateMachine.state.currentStepIndex
+        val state = experienceRenderer.getState(RenderContext.Modal)
+        val experience = state.currentExperience
+        val stepIndex = state.currentStepIndex
 
         if (experience != null && stepIndex != null) {
             val formState = experience.flatSteps[stepIndex].formState

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsKoin.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsKoin.kt
@@ -22,7 +22,7 @@ internal object AnalyticsKoin : KoinScopePlugin {
         }
         scoped { ActivityRequestBuilder(config = get(), storage = get(), decorator = get()) }
         scoped { ExperienceLifecycleTracker(scope = this) }
-        scoped { AnalyticsPolicy(sessionMonitor = get(), appcuesCoroutineScope = get(), stateMachine = get(), logcues = get()) }
+        scoped { AnalyticsPolicy(sessionMonitor = get(), appcuesCoroutineScope = get(), experienceRenderer = get(), logcues = get()) }
         scoped { ActivityScreenTracking(context = get(), analyticsTracker = get(), logcues = get()) }
         scoped<QueueScheduler> { AnalyticsQueueScheduler() }
         scoped {

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsPolicy.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsPolicy.kt
@@ -5,16 +5,17 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.SessionMonitor
+import com.appcues.data.model.RenderContext
 import com.appcues.logging.Logcues
 import com.appcues.statemachine.State.BeginningExperience
 import com.appcues.statemachine.State.EndingExperience
-import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer
 import kotlinx.coroutines.launch
 
 internal class AnalyticsPolicy(
     private val sessionMonitor: SessionMonitor,
     appcuesCoroutineScope: AppcuesCoroutineScope,
-    private val stateMachine: StateMachine,
+    private val experienceRenderer: ExperienceRenderer,
     private val logcues: Logcues,
 ) : DefaultLifecycleObserver {
 
@@ -28,7 +29,7 @@ internal class AnalyticsPolicy(
     init {
         appcuesCoroutineScope.launch {
             ProcessLifecycleOwner.get().lifecycle.addObserver(this@AnalyticsPolicy)
-            stateMachine.stateFlow.collect {
+            experienceRenderer.getStateFlow(RenderContext.Modal).collect {
                 when (it) {
                     is BeginningExperience -> {
                         experienceActiveCount++

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -112,7 +112,6 @@ internal class ExperienceMapper(
                         LaunchExperienceAction(
                             completedExperienceId = from.id.toString(),
                             launchExperienceId = it,
-                            stateMachine = scope.get(),
                             experienceRenderer = scope.get(),
                         )
                     )

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.analytics.AnalyticsTracker
+import com.appcues.data.model.RenderContext
 import com.appcues.debugger.DebugMode.Debugger
 import com.appcues.debugger.DebugMode.ScreenCapture
 import com.appcues.debugger.DebuggerViewModel.ToastState.Rendering
@@ -225,7 +226,7 @@ internal class DebuggerViewModel(
 
     fun captureScreen(debuggerState: MutableDebuggerState) {
         appcuesCoroutineScope.launch {
-            experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
+            experienceRenderer.dismiss(RenderContext.Modal, markComplete = false, destroyed = false)
 
             withContext(Dispatchers.Main) {
                 // capture screen

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.R
 import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.RenderContext
 import com.appcues.data.model.getConfig
 import com.appcues.data.model.getConfigOrDefault
 import com.appcues.data.model.getConfigStyle
@@ -64,6 +65,7 @@ internal class SkippableTrait(
 ) : ContainerDecoratingTrait, BackdropDecoratingTrait {
 
     companion object {
+
         const val TYPE = "@appcues/skippable"
 
         private const val CONFIG_BUTTON_APPEARANCE = "buttonAppearance"
@@ -153,7 +155,7 @@ internal class SkippableTrait(
                     .pointerInput(Unit) {
                         detectTapGestures {
                             appcuesCoroutineScope.launch {
-                                experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
+                                experienceRenderer.dismiss(RenderContext.Modal, markComplete = false, destroyed = false)
                             }
                         }
                     },
@@ -293,7 +295,7 @@ internal class SkippableTrait(
                 clickable(
                     onClick = {
                         appcuesCoroutineScope.launch {
-                            experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
+                            experienceRenderer.dismiss(RenderContext.Modal, markComplete = false, destroyed = false)
                         }
                     },
                     role = Role.Button,

--- a/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
@@ -13,6 +13,7 @@ import com.appcues.rules.MainDispatcherRule
 import com.appcues.statemachine.State
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer
 import com.google.common.truth.Truth.assertThat
 import io.mockk.Called
 import io.mockk.mockk
@@ -145,10 +146,11 @@ internal class ActionProcessorTest : KoinTest {
                                 config = params.getOrNull(),
                                 interaction = params.get(),
                                 analyticsTracker = get(),
-                                stateMachine = get(),
+                                experienceRenderer = get(),
                             )
                         }
                         scoped { StateMachine(get(), get(), get(), initState) }
+                        scoped { ExperienceRenderer(scope) }
                     }
                 }
             )

--- a/appcues/src/test/java/com/appcues/action/appcues/CloseActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/CloseActionTest.kt
@@ -1,6 +1,7 @@
 package com.appcues.action.appcues
 
 import com.appcues.AppcuesScopeTest
+import com.appcues.data.model.RenderContext
 import com.appcues.rules.KoinScopeRule
 import com.appcues.ui.ExperienceRenderer
 import com.google.common.truth.Truth.assertThat
@@ -32,7 +33,7 @@ internal class CloseActionTest : AppcuesScopeTest {
         action.execute()
 
         // THEN
-        coVerify { experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false) }
+        coVerify { experienceRenderer.dismiss(RenderContext.Modal, markComplete = false, destroyed = false) }
     }
 
     @Test
@@ -45,6 +46,6 @@ internal class CloseActionTest : AppcuesScopeTest {
         action.execute()
 
         // THEN
-        coVerify { experienceRenderer.dismissCurrentExperience(markComplete = true, destroyed = false) }
+        coVerify { experienceRenderer.dismiss(RenderContext.Modal, markComplete = true, destroyed = false) }
     }
 }

--- a/appcues/src/test/java/com/appcues/action/appcues/ContinueActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/ContinueActionTest.kt
@@ -1,19 +1,19 @@
 package com.appcues.action.appcues
 
 import com.appcues.AppcuesScopeTest
+import com.appcues.data.model.RenderContext
 import com.appcues.rules.KoinScopeRule
-import com.appcues.statemachine.Action.StartStep
-import com.appcues.statemachine.StateMachine
 import com.appcues.statemachine.StepReference.StepId
 import com.appcues.statemachine.StepReference.StepIndex
 import com.appcues.statemachine.StepReference.StepOffset
+import com.appcues.ui.ExperienceRenderer
 import com.google.common.truth.Truth
 import io.mockk.coVerify
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
-import org.koin.core.component.get
 import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -30,53 +30,53 @@ internal class ContinueActionTest : AppcuesScopeTest {
     @Test
     fun `continue SHOULD trigger StateMachine StartStep with index WHEN config has index`() = runTest {
         // GIVEN
-        val stateMachine: StateMachine = get()
-        val action = ContinueAction(mapOf("index" to 1), stateMachine)
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true)
+        val action = ContinueAction(mapOf("index" to 1), experienceRenderer)
 
         // WHEN
         action.execute()
 
         // THEN
-        coVerify { stateMachine.handleAction(StartStep(StepIndex(1))) }
+        coVerify { experienceRenderer.show(RenderContext.Modal, StepIndex(1)) }
     }
 
     @Test
     fun `continue SHOULD trigger StateMachine StartStep with offset WHEN config has offset`() = runTest {
         // GIVEN
-        val stateMachine: StateMachine = get()
-        val action = ContinueAction(mapOf("offset" to -1), stateMachine)
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true)
+        val action = ContinueAction(mapOf("offset" to -1), experienceRenderer)
 
         // WHEN
         action.execute()
 
         // THEN
-        coVerify { stateMachine.handleAction(StartStep(StepOffset(-1))) }
+        coVerify { experienceRenderer.show(RenderContext.Modal, StepOffset(-1)) }
     }
 
     @Test
     fun `continue SHOULD trigger StateMachine StartStep with step id WHEN config has step id`() = runTest {
         // GIVEN
         val stepId = UUID.randomUUID()
-        val stateMachine: StateMachine = get()
-        val action = ContinueAction(mapOf("stepID" to stepId.toString()), stateMachine)
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true)
+        val action = ContinueAction(mapOf("stepID" to stepId.toString()), experienceRenderer)
 
         // WHEN
         action.execute()
 
         // THEN
-        coVerify { stateMachine.handleAction(StartStep(StepId(stepId))) }
+        coVerify { experienceRenderer.show(RenderContext.Modal, StepId(stepId)) }
     }
 
     @Test
     fun `continue SHOULD trigger StateMachine StartStep with offset 1 by default`() = runTest {
         // GIVEN
-        val stateMachine: StateMachine = get()
-        val action = ContinueAction(mapOf(), stateMachine)
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true)
+        val action = ContinueAction(mapOf(), experienceRenderer)
 
         // WHEN
         action.execute()
 
         // THEN
-        coVerify { stateMachine.handleAction(StartStep(StepOffset(1))) }
+        coVerify { experienceRenderer.show(RenderContext.Modal, StepOffset(1)) }
     }
 }

--- a/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
@@ -2,10 +2,10 @@ package com.appcues.action.appcues
 
 import com.appcues.AppcuesScopeTest
 import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.model.RenderContext
 import com.appcues.mocks.mockExperience
 import com.appcues.rules.KoinScopeRule
 import com.appcues.statemachine.State.RenderingStep
-import com.appcues.statemachine.StateMachine
 import com.appcues.ui.ExperienceRenderer
 import com.google.common.truth.Truth
 import io.mockk.Called
@@ -35,14 +35,11 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
         // GIVEN
         val experienceId = UUID.randomUUID()
         val experienceIdString = experienceId.toString()
-        val experienceRenderer: ExperienceRenderer = get()
         val currentExperience = mockExperience()
-        val stateMachine = mockk<StateMachine>(relaxed = true) {
-            // this is so we can validate the launch trigger matches the fromExperienceID for the current experience
-            // that executed the action
-            every { this@mockk.state } returns RenderingStep(currentExperience, 0, true)
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true) {
+            every { this@mockk.getState(RenderContext.Modal) } returns RenderingStep(currentExperience, 0, true)
         }
-        val action = LaunchExperienceAction(mapOf("experienceID" to experienceIdString), stateMachine, get())
+        val action = LaunchExperienceAction(mapOf("experienceID" to experienceIdString), experienceRenderer)
 
         // WHEN
         action.execute()
@@ -55,7 +52,7 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
     fun `launch experience SHOULD NOT call ExperienceRenderer show WHEN no experience ID is in config`() = runTest {
         // GIVEN
         val experienceRenderer: ExperienceRenderer = get()
-        val action = LaunchExperienceAction(mapOf(), get(), get())
+        val action = LaunchExperienceAction(mapOf(), experienceRenderer)
 
         // WHEN
         action.execute()

--- a/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
@@ -22,7 +22,7 @@ import com.appcues.data.model.StepContainer
 import com.appcues.data.model.styling.ComponentSelectMode.MULTIPLE
 import com.appcues.rules.KoinScopeRule
 import com.appcues.statemachine.State
-import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
@@ -56,11 +56,11 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.currentExperience } answers { experience }
             every { this@mockk.currentStepIndex } answers { 0 }
         }
-        val stateMachine: StateMachine = mockk(relaxed = true) {
-            every { this@mockk.state } answers { state }
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true) {
+            every { this@mockk.getState(RenderContext.Modal) } returns state
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
-        val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
+        val action = SubmitFormAction(emptyMap(), experienceRenderer, analyticsTracker)
         val analyticEvent = StepInteraction(experience, 0, FORM_SUBMITTED)
 
         // WHEN
@@ -89,11 +89,11 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.currentExperience } answers { experience }
             every { this@mockk.currentStepIndex } answers { 0 }
         }
-        val stateMachine: StateMachine = mockk(relaxed = true) {
-            every { this@mockk.state } answers { state }
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true) {
+            every { this@mockk.getState(RenderContext.Modal) } returns state
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
-        val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
+        val action = SubmitFormAction(emptyMap(), experienceRenderer, analyticsTracker)
 
         // WHEN
         formState.setValue(textInput, "text")
@@ -119,11 +119,11 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.currentExperience } answers { experience }
             every { this@mockk.currentStepIndex } answers { 0 }
         }
-        val stateMachine: StateMachine = mockk(relaxed = true) {
-            every { this@mockk.state } answers { state }
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true) {
+            every { this@mockk.getState(RenderContext.Modal) } returns state
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
-        val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
+        val action = SubmitFormAction(emptyMap(), experienceRenderer, analyticsTracker)
         val analyticEvent = StepInteraction(experience, 0, FORM_SUBMITTED)
 
         // WHEN
@@ -146,13 +146,13 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.currentExperience } answers { experience }
             every { this@mockk.currentStepIndex } answers { 0 }
         }
-        val stateMachine: StateMachine = mockk(relaxed = true) {
-            every { this@mockk.state } answers { state }
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true) {
+            every { this@mockk.getState(RenderContext.Modal) } returns state
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
         val appcues: Appcues = mockk(relaxed = true)
         val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
-        val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
+        val action = SubmitFormAction(emptyMap(), experienceRenderer, analyticsTracker)
         val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val initialQueue = listOf(action0, action, action1, action2)
@@ -176,13 +176,13 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.currentExperience } answers { experience }
             every { this@mockk.currentStepIndex } answers { 0 }
         }
-        val stateMachine: StateMachine = mockk(relaxed = true) {
-            every { this@mockk.state } answers { state }
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true) {
+            every { this@mockk.getState(RenderContext.Modal) } returns state
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
         val appcues: Appcues = mockk(relaxed = true)
         val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
-        val action = SubmitFormAction(emptyMap(), stateMachine, analyticsTracker)
+        val action = SubmitFormAction(emptyMap(), experienceRenderer, analyticsTracker)
         val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val initialQueue = listOf(action0, action, action1, action2)
@@ -212,13 +212,13 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
             every { this@mockk.currentExperience } answers { experience }
             every { this@mockk.currentStepIndex } answers { 0 }
         }
-        val stateMachine: StateMachine = mockk(relaxed = true) {
-            every { this@mockk.state } answers { state }
+        val experienceRenderer: ExperienceRenderer = mockk(relaxed = true) {
+            every { this@mockk.getState(RenderContext.Modal) } returns state
         }
         val analyticsTracker: AnalyticsTracker = mockk(relaxed = true)
         val appcues: Appcues = mockk(relaxed = true)
         val action0 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
-        val action = SubmitFormAction(mapOf("skipValidation" to true), stateMachine, analyticsTracker)
+        val action = SubmitFormAction(mapOf("skipValidation" to true), experienceRenderer, analyticsTracker)
         val action1 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val action2 = TrackEventAction(mapOf("eventName" to "My Custom Event"), appcues)
         val initialQueue = listOf(action0, action, action1, action2)

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -4,6 +4,7 @@ import com.appcues.AppcuesConfig
 import com.appcues.analytics.AnalyticsEvent
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.data.model.Experiment
+import com.appcues.data.model.RenderContext
 import com.appcues.mocks.mockExperience
 import com.appcues.mocks.mockExperienceExperiment
 import com.appcues.statemachine.Action.EndExperience
@@ -33,6 +34,7 @@ import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class ExperienceRendererTest {
+
     @After
     fun shutdown() {
         stopKoin()
@@ -49,7 +51,7 @@ internal class ExperienceRendererTest {
         val experienceRenderer = ExperienceRenderer(scope)
 
         // WHEN
-        experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
+        experienceRenderer.dismiss(RenderContext.Modal, markComplete = false, destroyed = false)
 
         // THEN
         coVerify { stateMachine.handleAction(EndExperience(markComplete = false, destroyed = false)) }
@@ -66,7 +68,7 @@ internal class ExperienceRendererTest {
         val experienceRenderer = ExperienceRenderer(scope)
 
         // WHEN
-        experienceRenderer.dismissCurrentExperience(markComplete = false, destroyed = false)
+        experienceRenderer.dismiss(RenderContext.Modal, markComplete = false, destroyed = false)
 
         // THEN
         coVerify { stateMachine.handleAction(EndExperience(markComplete = false, destroyed = false)) }
@@ -114,7 +116,6 @@ internal class ExperienceRendererTest {
             coEvery { this@mockk.handleAction(any()) } answers { Success(Idling) }
         }
         val scope = initScope(stateMachine)
-        val analyticsTracker: AnalyticsTracker = scope.get()
         val experienceRenderer = ExperienceRenderer(scope)
 
         // WHEN
@@ -196,7 +197,8 @@ internal class ExperienceRendererTest {
                     "experimentGoalId" to "my-goal",
                     "experimentContentType" to "my-content-type",
                 ),
-                false)
+                false
+            )
         }
     }
 
@@ -205,7 +207,7 @@ internal class ExperienceRendererTest {
         KoinPlatformTools.defaultContext().getOrNull()?.close()
         val scopeId = UUID.randomUUID().toString()
         return startKoin {
-            val scope = koin.getOrCreateScope(scopeId = scopeId, qualifier = named(scopeId))
+            koin.getOrCreateScope(scopeId = scopeId, qualifier = named(scopeId))
             modules(
                 module {
                     scope(named(scopeId)) {


### PR DESCRIPTION
Changes included.

* Centralizing access to StateMachine by calling ExperienceRenderer
* Adding property RenderContext to ExperienceRenderer calls tied to StateMachine