### PR TITLE
Support screenshot capture from plugins

### DIFF
--- a/appcues/src/main/java/com/appcues/ElementTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/ElementTargetingStrategy.kt
@@ -1,12 +1,36 @@
 package com.appcues
 
+import android.graphics.Bitmap
+import android.util.Size
 import android.view.View
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
+import androidx.core.graphics.Insets
 import com.appcues.debugger.screencapture.appcuesViewTagProperty
 import com.squareup.moshi.JsonClass
 import java.util.UUID
+
+/**
+ * Contains the information about the screenshot image capture.
+ */
+public data class Screenshot(
+    /**
+     * The image data for the screenshot.
+     */
+    val bitmap: Bitmap,
+
+    /**
+     * The size of the screenshot image in Dp, including any visible system bars.
+     */
+    val size: Size,
+
+    /**
+     * The insets in Dp to apply for any visible system bars, used to define the area
+     * eligible for targeting content.
+     */
+    val insets: Insets,
+)
 
 /**
  * Defines an element targeting strategy type, which can be used to capture view layout
@@ -29,6 +53,18 @@ public interface ElementTargetingStrategy {
      *         the given properties. If no applicable properties are found, the return value should be `nil`.
      */
     public fun inflateSelectorFrom(properties: Map<String, String>): ElementSelector?
+
+    /**
+     * Capture the screenshot image for the currently rendered screen of the application.
+     *
+     * This is an optional override to support specialized screen capture from plugins, if needed.
+     * However, normally the default screenshot capturing the root view of the application will suffice,
+     * in which case this function can be omitted.
+     *
+     * @return: The screenshot data for the current screen, or null if not available. If null, the
+     *          default screenshot of the current root view of the application will be used.
+     */
+    public fun captureScreenshot(): Screenshot? = null
 }
 
 /**

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/Capture.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/Capture.kt
@@ -2,11 +2,9 @@ package com.appcues.debugger.screencapture
 
 import android.graphics.Bitmap
 import android.os.Build.VERSION
-import android.view.View
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import com.appcues.BuildConfig
 import com.appcues.R
+import com.appcues.Screenshot
 import com.appcues.ViewElement
 import com.appcues.util.ContextResources
 import com.squareup.moshi.Json
@@ -56,19 +54,14 @@ internal data class Capture(
     )
 }
 
-internal fun ContextResources.generateCaptureMetadata(rootView: View): Capture.Metadata {
-    val density = displayMetrics.density
-    val width = rootView.width.toDp(density)
-    val height = rootView.height.toDp(density)
-    val insets = ViewCompat.getRootWindowInsets(rootView)?.getInsets(WindowInsetsCompat.Type.systemBars())
-
+internal fun ContextResources.generateCaptureMetadata(screenshot: Screenshot): Capture.Metadata {
     return Capture.Metadata(
         appName = getAppName(),
         appBuild = getAppBuild().toString(),
         appVersion = getAppVersion(),
         deviceModel = getDeviceName(),
-        deviceWidth = width,
-        deviceHeight = height,
+        deviceWidth = screenshot.size.width,
+        deviceHeight = screenshot.size.height,
         deviceOrientation = orientation,
         deviceType = getString(R.string.appcues_device_type),
         bundlePackageId = getPackageName(),
@@ -77,10 +70,10 @@ internal fun ContextResources.generateCaptureMetadata(rootView: View): Capture.M
         osName = "android",
         osVersion = "${VERSION.SDK_INT}",
         insets = Capture.Insets(
-            left = insets?.left?.toDp(density) ?: 0,
-            right = insets?.right?.toDp(density) ?: 0,
-            top = insets?.top?.toDp(density) ?: 0,
-            bottom = insets?.bottom?.toDp(density) ?: 0,
+            left = screenshot.insets.left,
+            right = screenshot.insets.right,
+            top = screenshot.insets.top,
+            bottom = screenshot.insets.bottom,
         )
     )
 }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
@@ -89,8 +89,6 @@ internal class AppcuesOverlayViewManager(private val scope: Scope) : DefaultLife
                 parentView.addView(binding.root)
             }
 
-            val insets = ViewCompat.getRootWindowInsets(parentView)?.getInsets(WindowInsetsCompat.Type.systemBars())
-
             binding.root.layoutParams =
                 android.widget.FrameLayout.LayoutParams(
                     android.widget.FrameLayout.LayoutParams.MATCH_PARENT,


### PR DESCRIPTION
This is the extra extensibility point I think we'd need to support a Flutter plugin screen capture. The Flutter plugin could then provide the bitmap and sizing information needed that we cannot access directly from the normal screen capture method.