### PR TITLE
♻️  Support Multiple state machines tied to each RenderContext

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -18,7 +18,6 @@ internal object AppcuesKoin : KoinScopePlugin {
             val config: AppcuesConfig = get()
             Logcues(config.loggingLevel)
         }
-        scoped { StateMachine(appcuesCoroutineScope = get(), config = get(), actionProcessor = get()) }
         scoped { Storage(context = get(), config = get()) }
         scoped {
             DeepLinkHandler(
@@ -42,10 +41,8 @@ internal object AppcuesKoin : KoinScopePlugin {
             )
         }
         scoped { LinkOpener(get()) }
-        scoped {
-            AnalyticsPublisher(
-                storage = get()
-            )
-        }
+        scoped { AnalyticsPublisher(storage = get()) }
+
+        factory { StateMachine(appcuesCoroutineScope = get(), config = get(), actionProcessor = get()) }
     }
 }

--- a/appcues/src/main/java/com/appcues/SessionMonitor.kt
+++ b/appcues/src/main/java/com/appcues/SessionMonitor.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.appcues.analytics.AnalyticsEvent
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.analytics.SdkMetrics
+import com.appcues.analytics.track
 import com.appcues.logging.Logcues
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinScopeComponent

--- a/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
@@ -59,7 +59,7 @@ internal class LaunchExperienceAction(
             // flow - capture the current experience from the state machine as the experience that is launching the new flow.
             // note: it's possible that the current experience was closed out before this triggered, in which case this
             // fromExperience ID value would be null.
-            val fromExperience = experienceRenderer.getState(renderContext).currentExperience
+            val fromExperience = experienceRenderer.getState(renderContext)?.currentExperience
             ExperienceTrigger.LaunchExperienceAction(fromExperience?.id)
         }
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/StepInteractionAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/StepInteractionAction.kt
@@ -36,9 +36,9 @@ internal class StepInteractionAction(
     }
 
     override suspend fun execute() {
-        val state = experienceRenderer.getState(renderContext)
-        val experience = state.currentExperience
-        val stepIndex = state.currentStepIndex
+        val (experience, stepIndex) = experienceRenderer.getState(renderContext).let {
+            it?.currentExperience to it?.currentStepIndex
+        }
 
         if (experience != null && stepIndex != null && experience.published) {
             val interactionEvent = StepInteraction(

--- a/appcues/src/main/java/com/appcues/action/appcues/SubmitFormAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/SubmitFormAction.kt
@@ -32,9 +32,9 @@ internal class SubmitFormAction(
             return queue
         }
 
-        val state = experienceRenderer.getState(renderContext)
-        val experience = state.currentExperience
-        val stepIndex = state.currentStepIndex
+        val (experience, stepIndex) = experienceRenderer.getState(renderContext).let {
+            it?.currentExperience to it?.currentStepIndex
+        }
 
         if (experience != null && stepIndex != null) {
             val formState = experience.flatSteps[stepIndex].formState
@@ -51,9 +51,9 @@ internal class SubmitFormAction(
 
     // reports analytics for step interaction, for the form submission
     override suspend fun execute() {
-        val state = experienceRenderer.getState(renderContext)
-        val experience = state.currentExperience
-        val stepIndex = state.currentStepIndex
+        val (experience, stepIndex) = experienceRenderer.getState(renderContext).let {
+            it?.currentExperience to it?.currentStepIndex
+        }
 
         if (experience != null && stepIndex != null) {
             val formState = experience.flatSteps[stepIndex].formState

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsKoin.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsKoin.kt
@@ -37,7 +37,6 @@ internal object AnalyticsKoin : KoinScopePlugin {
             AnalyticsTracker(
                 appcuesCoroutineScope = get(),
                 activityBuilder = get(),
-                experienceLifecycleTracker = get(),
                 analyticsPolicy = get(),
                 analyticsQueueProcessor = get(),
             )

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsPolicy.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsPolicy.kt
@@ -29,7 +29,7 @@ internal class AnalyticsPolicy(
     init {
         appcuesCoroutineScope.launch {
             ProcessLifecycleOwner.get().lifecycle.addObserver(this@AnalyticsPolicy)
-            experienceRenderer.getStateFlow(RenderContext.Modal).collect {
+            experienceRenderer.getStateFlow(RenderContext.Modal)?.collect {
                 when (it) {
                     is BeginningExperience -> {
                         experienceActiveCount++

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.launch
 internal class AnalyticsTracker(
     private val appcuesCoroutineScope: AppcuesCoroutineScope,
     private val activityBuilder: ActivityRequestBuilder,
-    private val experienceLifecycleTracker: ExperienceLifecycleTracker,
     private val analyticsPolicy: AnalyticsPolicy,
     private val analyticsQueueProcessor: AnalyticsQueueProcessor,
 ) {
@@ -22,12 +21,6 @@ internal class AnalyticsTracker(
     private val _analyticsFlow = MutableSharedFlow<TrackingData>(1)
     val analyticsFlow: SharedFlow<TrackingData>
         get() = _analyticsFlow
-
-    init {
-        appcuesCoroutineScope.launch {
-            experienceLifecycleTracker.start()
-        }
-    }
 
     fun identify(properties: Map<String, Any>? = null, interactive: Boolean = true) {
         if (!analyticsPolicy.canIdentify()) return
@@ -41,11 +34,6 @@ internal class AnalyticsTracker(
                 analyticsQueueProcessor.queue(it)
             }
         }
-    }
-
-    // convenience helper for internal events
-    fun track(event: AnalyticsEvent, properties: Map<String, Any>? = null, interactive: Boolean = true) {
-        track(event.eventName, properties, interactive, true)
     }
 
     fun track(name: String, properties: Map<String, Any>? = null, interactive: Boolean = true, isInternal: Boolean = false) {

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTrackerExt.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTrackerExt.kt
@@ -1,0 +1,22 @@
+package com.appcues.analytics
+
+import com.appcues.data.model.Experiment
+import com.appcues.util.appcuesFormatted
+
+internal fun AnalyticsTracker.track(event: AnalyticsEvent, properties: Map<String, Any>? = null, interactive: Boolean = true) {
+    track(event.eventName, properties, interactive, true)
+}
+
+internal fun AnalyticsTracker.track(experiment: Experiment) {
+    track(
+        event = AnalyticsEvent.ExperimentEntered,
+        properties = mapOf(
+            "experimentId" to experiment.id.appcuesFormatted(),
+            "experimentGroup" to experiment.group,
+            "experimentExperienceId" to experiment.experienceId.appcuesFormatted(),
+            "experimentGoalId" to experiment.goalId,
+            "experimentContentType" to experiment.contentType,
+        ),
+        interactive = false
+    )
+}

--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -1,12 +1,16 @@
 package com.appcues.statemachine
 
 import com.appcues.data.model.Experience
+import com.appcues.data.model.RenderContext
 import java.util.UUID
 
 internal sealed class Error(open val message: String) {
+
     val id: UUID = UUID.randomUUID()
 
-    data class ExperienceAlreadyActive(val ignoredExperience: Experience, override val message: String) : Error(message)
+    object ExperienceAlreadyActive : Error("Experience already active")
+
+    data class RenderContextNotActive(val renderContext: RenderContext) : Error("RenderContext $renderContext is not active.")
     data class ExperienceError(val experience: Experience, override val message: String) : Error(message)
     data class StepError(val experience: Experience, val stepIndex: Int, override val message: String) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -95,11 +95,13 @@ internal class StateMachine(
                     // recursive call on continuations to get the final return value
                     handleActionInternal(sideEffect.action)
                 }
+
                 is ReportErrorEffect -> {
                     _errorFlow.emit(sideEffect.error)
                     // return a failure if this call to `handleAction` ended with a reported error
                     Failure(sideEffect.error)
                 }
+
                 is PresentContainerEffect -> {
                     // first, process any pre-step actions that need to be handled before the container is presented.
                     // for example - navigating to another screen in the app
@@ -115,9 +117,11 @@ internal class StateMachine(
                         handleActionInternal(ReportError(ExperienceError(sideEffect.experience, message), true))
                     }
                 }
+
                 is AwaitEffect -> {
                     sideEffect.completion.await()
                 }
+
                 is ProcessActions -> {
                     actionProcessor.process(sideEffect.actions)
                     Success(_state)
@@ -132,7 +136,7 @@ internal class StateMachine(
     private fun State.take(action: Action): Transition {
         return takeValidStateTransitions(this, action) ?: when (action) {
             // start experience action when experience is already active
-            is StartExperience -> ErrorLoggingTransition(ExperienceAlreadyActive(action.experience, "Experience already active"), false)
+            is StartExperience -> ErrorLoggingTransition(ExperienceAlreadyActive, false)
             // report error action
             is ReportError -> ErrorLoggingTransition(action.error, action.fatal)
             // undefined transition - no-op

--- a/appcues/src/test/java/com/appcues/SessionMonitorTest.kt
+++ b/appcues/src/test/java/com/appcues/SessionMonitorTest.kt
@@ -5,6 +5,7 @@ import com.appcues.analytics.AnalyticsEvent.SessionResumed
 import com.appcues.analytics.AnalyticsEvent.SessionStarted
 import com.appcues.analytics.AnalyticsEvent.SessionSuspended
 import com.appcues.analytics.AnalyticsTracker
+import com.appcues.analytics.track
 import com.appcues.logging.Logcues
 import com.appcues.rules.KoinScopeRule
 import com.appcues.rules.MainDispatcherRule

--- a/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
@@ -6,6 +6,7 @@ import com.appcues.AppcuesCoroutineScope
 import com.appcues.action.appcues.StepInteractionAction
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.BUTTON_TAPPED
+import com.appcues.analytics.ExperienceLifecycleTracker
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.RenderContext
 import com.appcues.logging.Logcues
@@ -74,8 +75,11 @@ internal class ActionProcessorTest : KoinTest {
         val experience = mockExperience()
         val initialState = RenderingStep(experience, 0, true)
         val scope = initScope(initialState)
+        val experienceRenderer = scope.get<ExperienceRenderer>()
         val actionProcessor = scope.get<ActionProcessor>()
         val analyticsTracker: AnalyticsTracker = scope.get()
+
+        experienceRenderer.show(experience)
 
         val action1 = TestAction(false)
         val stepAction1 = TestStepInteractionAction("test", "a")
@@ -153,8 +157,10 @@ internal class ActionProcessorTest : KoinTest {
                                 experienceRenderer = get(),
                             )
                         }
-                        scoped { StateMachine(get(), get(), get(), initState) }
+                        factory { StateMachine(get(), get(), get(), initState) }
                         scoped { ExperienceRenderer(scope) }
+                        scoped { RenderContext.Modal }
+                        scoped { mockk<ExperienceLifecycleTracker>(relaxed = true) }
                     }
                 }
             )

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
@@ -1,0 +1,95 @@
+package com.appcues.analytics
+
+import com.appcues.AnalyticType
+import com.appcues.AppcuesCoroutineScope
+import com.appcues.LoggingLevel.NONE
+import com.appcues.analytics.AnalyticsEvent.SessionStarted
+import com.appcues.data.model.Experiment
+import com.appcues.data.remote.appcues.request.ActivityRequest
+import com.appcues.logging.Logcues
+import com.appcues.rules.MainDispatcherRule
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.launch
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.UUID
+
+internal class AnalyticsTrackerExtTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val coroutineScope = AppcuesCoroutineScope(Logcues(NONE))
+    private val activityBuilder: ActivityRequestBuilder = mockk()
+    private val analyticsPolicy: AnalyticsPolicy = mockk()
+    private val analyticsQueueProcessor: AnalyticsQueueProcessor = mockk(relaxed = true)
+
+    private val analyticsFlowUpdates: ArrayList<TrackingData> = arrayListOf()
+
+    private lateinit var analyticsTracker: AnalyticsTracker
+
+    @Before
+    fun setup() {
+        analyticsTracker = AnalyticsTracker(
+            appcuesCoroutineScope = coroutineScope,
+            activityBuilder = activityBuilder,
+            analyticsPolicy = analyticsPolicy,
+            analyticsQueueProcessor = analyticsQueueProcessor,
+        )
+
+        coroutineScope.launch {
+            analyticsTracker.analyticsFlow.collect {
+                analyticsFlowUpdates.add(it)
+            }
+        }
+    }
+
+    @Test
+    fun `track internal event SHOULD update analyticsFlow with internal event`() {
+        // given
+        every { analyticsPolicy.canTrackEvent() } returns true
+        val activity: ActivityRequest = mockk(relaxed = true)
+        every { activityBuilder.track(any(), any()) } returns activity
+        // when
+        analyticsTracker.track(SessionStarted)
+        // then
+        assertThat(analyticsFlowUpdates.first().isInternal).isTrue()
+        assertThat(analyticsFlowUpdates.first().type).isEqualTo(AnalyticType.EVENT)
+        assertThat(analyticsFlowUpdates.first().request).isEqualTo(activity)
+    }
+
+    @Test
+    fun `track experiment SHOULD call track with correct properties set in the map`() {
+        // GIVEN
+        val activity: ActivityRequest = mockk(relaxed = true)
+        every { activityBuilder.track(any(), any()) } returns activity
+        every { analyticsPolicy.canTrackEvent() } returns true
+        val experiment = Experiment(
+            id = UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"),
+            group = "control",
+            experienceId = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
+            goalId = "my-goal",
+            contentType = "my-content-type"
+        )
+        // WHEN
+        analyticsTracker.track(experiment)
+        // THEN
+        verify {
+            analyticsTracker.track(
+                AnalyticsEvent.ExperimentEntered,
+                mapOf(
+                    "experimentId" to "06f9bf87-1921-4919-be55-429b278bf578",
+                    "experimentGroup" to "control",
+                    "experimentExperienceId" to "d84c9d01-aa27-4cbb-b832-ee03720e04fc",
+                    "experimentGoalId" to "my-goal",
+                    "experimentContentType" to "my-content-type",
+                ),
+                false
+            )
+        }
+    }
+}

--- a/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
@@ -148,7 +148,7 @@ internal class ExperienceLifecycleTrackerTest : KoinTest {
         }
 
         coroutineScope.launch {
-            scope.get<ExperienceLifecycleTracker>().start(UnconfinedTestDispatcher())
+            scope.get<ExperienceLifecycleTracker>().start(machine, UnconfinedTestDispatcher())
         }
 
         return scope

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -4,6 +4,7 @@ import com.appcues.action.appcues.TrackEventAction
 import com.appcues.data.model.Action
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.data.model.ExperiencePriority.LOW
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceTrigger
 import com.appcues.data.model.Experiment
@@ -51,7 +52,7 @@ internal fun mockExperience(onPresent: (() -> Unit)? = null) =
             )
         ),
         published = true,
-        priority = NORMAL,
+        priority = LOW,
         publishedAt = 1652895835000,
         experiment = null,
         completionActions = arrayListOf(TrackEventAction(hashMapOf(), appcues = mockk(relaxed = true))),


### PR DESCRIPTION
A couple of changes here in order to support multiple state machines being created for each render context.

* Updated ExperienceRenderer: Added the dictionary with state machine slots, whenever a new RenderContext comes, if we dont have a state machine for it yet then we create, this will happen for any type of RenderContext, supposedly making it a generic logic that should work to any type of RenderContext now and in the future.

* Updated ExperienceLifecycleTracker: now during start it receives the state machine so it can observe states and errors. the start happens once for each state machine when its fabricated during ExperienceRenderer show method.

* Various changes to accommodate multiple state machines


Different from my last approach, we are not deleting any renderContext and its state machine from the map, they should just move to Idling and sit there unused.

Worth noting that all this is running Unit tests and UI test 🆗 