### PR TITLE
Handle errors in font loading in UI tests

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -96,7 +96,10 @@ private fun FontFamily.Companion.getFontResource(context: Context, fontName: Str
                 // and we can progress with the creation of the Font and FontFamily
                 context.resources.getFont(fontId)
                 FontFamily(Font(fontId))
-            } catch (ex: NotFoundException) {
+            } catch (_: NotFoundException) {
+                null
+            } catch (_: NullPointerException) {
+                // this can happen in our snapshot unit tests when the font is not available
                 null
             }
         }


### PR DESCRIPTION
This one small change is needed for [Paparazzi](https://github.com/cashapp/paparazzi) snapshot tests to run on our example components.

A mock `Context` is available in the testing framework, and can load Font resources in general, but if a Font is not found and it gets down into the line in this change around
```
context.resources.getFont(fontId)
```
It will throw a `NullPointerException`, rather than what we typically see in a real Android emulator/device with a `NotFoundException`.

There are a couple of test cases that trigger this, due to using a Font name that is built-in on iOS, but not present on Android - Menlo-Italic.
* [button-typography.json](https://github.com/appcues/appcues-mobile-experience-spec/blob/main/component-examples/button-typography.json)
* [text-typography.json](https://github.com/appcues/appcues-mobile-experience-spec/blob/main/component-examples/text-typography.json)