### PR TITLE
Update to Gradle 8 and other related updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: large
-      tag: 2022.04.1 # https://circleci.com/developer/machine/image/android
+      tag: 2023.07.1 # https://circleci.com/developer/machine/image/android
     steps:
       - install_with_cache      
       - run:

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -12,15 +12,17 @@ apply from: 'codecov.gradle'
 apply from: 'dokka.gradle'
 
 ext.room_version = '2.4.3'
-ext.compose_version = '1.3.0'
-ext.compose_compiler_version = '1.3.2'
-ext.accompanist_version = '0.27.0'
+ext.compose_version = '1.4.3'
+ext.compose_compiler_version = '1.4.7'
+ext.accompanist_version = '0.30.1'
 ext.koin_version = '3.1.6'
 ext.coil_version = '2.2.2'
 ext.moshi_version = '1.14.0'
 
 android {
     compileSdk 33
+
+    namespace "com.appcues"
 
     defaultConfig {
         minSdk 21
@@ -48,16 +50,17 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
         freeCompilerArgs += ["-opt-in=kotlin.RequiresOptIn", "-Xexplicit-api=strict"]
     }
 
     buildFeatures {
+        buildConfig true
         compose true
         viewBinding true
     }

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -15,7 +15,7 @@ ext.room_version = '2.4.3'
 ext.compose_version = '1.4.3'
 ext.compose_compiler_version = '1.4.7'
 ext.accompanist_version = '0.30.1'
-ext.koin_version = '3.4.0'
+ext.koin_version = '3.4.2'
 ext.coil_version = '2.2.2'
 ext.moshi_version = '1.14.0'
 

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -15,7 +15,7 @@ ext.room_version = '2.4.3'
 ext.compose_version = '1.4.3'
 ext.compose_compiler_version = '1.4.7'
 ext.accompanist_version = '0.30.1'
-ext.koin_version = '3.1.6'
+ext.koin_version = '3.4.0'
 ext.coil_version = '2.2.2'
 ext.moshi_version = '1.14.0'
 

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -114,8 +114,6 @@ dependencies {
     // Dependency Injection
     implementation "io.insert-koin:koin-core:$koin_version"
     implementation "io.insert-koin:koin-android:$koin_version"
-    // View Pager
-    implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     // Webview
     implementation "com.google.accompanist:accompanist-webview:$accompanist_version"
     // Navigation Animated

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -123,9 +123,9 @@ dependencies {
     implementation 'com.google.android.play:review-ktx:2.0.1'
 
     testImplementation "junit:junit:4.13.2"
-    testImplementation "io.mockk:mockk:1.12.2"
-    testImplementation "com.google.truth:truth:1.1.3"
-    testImplementation "com.squareup.okhttp3:mockwebserver:4.10.0"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
-    testImplementation "io.insert-koin:koin-test-junit4:3.1.4"
+    testImplementation "io.mockk:mockk:1.13.5"
+    testImplementation "com.google.truth:truth:1.1.5"
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2"
+    testImplementation "io.insert-koin:koin-test-junit4:3.1.6"
 }

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     implementation "io.coil-kt:coil-svg:$coil_version"
     // RESTApi
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
     implementation "com.squareup.okhttp3:logging-interceptor:4.9.0"
     implementation "com.squareup.moshi:moshi:$moshi_version"

--- a/appcues/codecov.gradle
+++ b/appcues/codecov.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.9"
 }
 
 // https://medium.com/jamf-engineering/android-kotlin-code-coverage-with-jacoco-sonar-and-gradle-plugin-6-x-3933ed503a6e

--- a/appcues/publish-maven.gradle
+++ b/appcues/publish-maven.gradle
@@ -32,6 +32,12 @@ android {
     defaultConfig {
         buildConfigField "String", "SDK_VERSION", "\"${versionName}\""
     }
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 // Because the components are created only during the afterEvaluate phase, you must
@@ -48,9 +54,6 @@ afterEvaluate {
                 groupId = appcuesProperties.getProperty("GROUP_ID")
                 artifactId = appcuesProperties.getProperty("ARTIFACT_ID")
                 version = versionName
-
-                artifact sourcesJar
-                artifact javadocJar
 
                 pom {
                     name = appcuesProperties.getProperty("NAME")

--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.appcues">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/appcues/src/main/java/com/appcues/action/ActionKoin.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionKoin.kt
@@ -19,16 +19,16 @@ internal object ActionKoin : KoinScopePlugin {
         scoped { ActionProcessor(get()) }
 
         // access to internal in context actions
-        factory { CloseAction(it.getOrNull(), it.get(), get()) }
-        factory { ContinueAction(it.getOrNull(), it.get(), get()) }
-        factory { LaunchExperienceAction(it.getOrNull(), it.get(), get()) }
-        factory { StepInteractionAction(it.getOrNull(), it.get(), it.get(), get(), get()) }
-        factory { SubmitFormAction(it.getOrNull(), it.get(), get(), get()) }
+        factory { CloseAction(it[0], it[1], get()) }
+        factory { ContinueAction(it[0], it[1], get()) }
+        factory { LaunchExperienceAction(it[0], it[1], get()) }
+        factory { StepInteractionAction(it[0], it[1], get(), get()) }
+        factory { SubmitFormAction(it[0], it[1], get(), get()) }
 
         // other
-        factory { LinkAction(it.getOrNull(), get(), get()) }
-        factory { TrackEventAction(it.getOrNull(), get()) }
-        factory { UpdateProfileAction(it.getOrNull(), get(), get()) }
-        factory { RequestReviewAction(it.getOrNull(), get(), get()) }
+        factory { LinkAction(config = it[0], get(), get()) }
+        factory { TrackEventAction(it[0], get()) }
+        factory { UpdateProfileAction(it[0], get(), get()) }
+        factory { RequestReviewAction(it[0], get(), get()) }
     }
 }

--- a/appcues/src/main/java/com/appcues/action/appcues/StepInteractionAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/StepInteractionAction.kt
@@ -9,12 +9,14 @@ import com.appcues.data.model.RenderContext
 import com.appcues.ui.ExperienceRenderer
 
 internal class StepInteractionAction(
-    override val config: AppcuesConfigMap,
     private val renderContext: RenderContext,
     private val interaction: StepInteractionData,
     private val analyticsTracker: AnalyticsTracker,
     private val experienceRenderer: ExperienceRenderer,
 ) : ExperienceAction {
+
+    // required in ExperienceAction interface but not used in this action
+    override val config: AppcuesConfigMap = null
 
     class StepInteractionData(
         val interactionType: InteractionType,

--- a/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
+++ b/appcues/src/main/java/com/appcues/trait/TraitKoin.kt
@@ -20,17 +20,17 @@ internal object TraitKoin : KoinScopePlugin {
     override fun ScopeDSL.install() {
         scoped { TraitRegistry(get(), get()) }
 
-        factory { params -> BackdropTrait(params.getOrNull()) }
-        factory { params -> StepAnimationTrait(params.getOrNull()) }
-        factory { params -> TargetElementTrait(params.getOrNull()) }
-        factory { params -> TargetRectangleTrait(params.getOrNull()) }
-        factory { params -> BackdropKeyholeTrait(params.getOrNull()) }
-        factory { params -> ModalTrait(params.getOrNull(), params.get(), get()) }
-        factory { params -> TooltipTrait(params.getOrNull(), params.get(), get()) }
-        factory { params -> SkippableTrait(params.getOrNull(), params.get(), get(), get()) }
-        factory { params -> CarouselTrait(params.getOrNull()) }
-        factory { params -> PagingDotsTrait(params.getOrNull()) }
-        factory { params -> TargetInteractionTrait(params.getOrNull(), params.get(), get(), get()) }
-        factory { params -> BackgroundContentTrait(params.getOrNull(), params.get()) }
+        factory { BackdropTrait(it[0]) }
+        factory { StepAnimationTrait(it[0]) }
+        factory { TargetElementTrait(it[0]) }
+        factory { TargetRectangleTrait(it[0]) }
+        factory { BackdropKeyholeTrait(it[0]) }
+        factory { ModalTrait(it[0], it[1], get()) }
+        factory { TooltipTrait(it[0], it[1], get()) }
+        factory { SkippableTrait(it[0], it[1], get(), get()) }
+        factory { CarouselTrait(it[0]) }
+        factory { PagingDotsTrait(it[0]) }
+        factory { TargetInteractionTrait(it[0], it[1], get(), get()) }
+        factory { BackgroundContentTrait(it[0], it[1]) }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt
@@ -7,10 +7,10 @@ import android.os.Build.VERSION_CODES
 import android.view.View
 import android.view.ViewGroup
 import android.view.inspector.WindowInspector
-import androidx.lifecycle.ViewTreeLifecycleOwner
-import androidx.lifecycle.ViewTreeViewModelStoreOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import java.lang.reflect.Method
@@ -48,14 +48,14 @@ internal fun Activity.getParentView(): ViewGroup {
     // dialog. In this case, we need to apply the fix-ups below to ensure that our
     // content can render correctly inside of this other view. In each case, we use
     // the applicable value from the Activity default window.
-    if (ViewTreeLifecycleOwner.get(decorView) == null) {
+    if (decorView.findViewTreeLifecycleOwner() == null) {
         val lifecycleOwner = window.decorView.findViewTreeLifecycleOwner()
-        ViewTreeLifecycleOwner.set(decorView, lifecycleOwner)
+        decorView.setViewTreeLifecycleOwner(lifecycleOwner)
     }
 
-    if (ViewTreeViewModelStoreOwner.get(decorView) == null) {
+    if (decorView.findViewTreeViewModelStoreOwner() == null) {
         val viewModelStoreOwner = window.decorView.findViewTreeViewModelStoreOwner()
-        ViewTreeViewModelStoreOwner.set(decorView, viewModelStoreOwner)
+        decorView.setViewTreeViewModelStoreOwner(viewModelStoreOwner)
     }
 
     if (decorView.findViewTreeSavedStateRegistryOwner() == null) {

--- a/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
@@ -150,9 +150,8 @@ internal class ActionProcessorTest : KoinTest {
                         scoped { ActionProcessor(get()) }
                         scoped { params ->
                             StepInteractionAction(
-                                config = params.getOrNull(),
                                 renderContext = RenderContext.Modal,
-                                interaction = params.get(),
+                                interaction = params[1],
                                 analyticsTracker = get(),
                                 experienceRenderer = get(),
                             )

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -140,6 +140,10 @@ internal class AppcuesRepositoryTest {
         val activityStorage = ActivityStorage(UUID.randomUUID(), "123", "userId", "data", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
 
+        // two lines below added related to https://github.com/mockk/mockk/issues/321
+        coEvery { appcuesRemoteSource.postActivity(any(), any(), any()) } returns Success(mockk(relaxed = true))
+        coEvery { appcuesRemoteSource.qualify(any(), any(), any(), any()) } returns Success(mockk(relaxed = true))
+
         // WHEN
         repository.trackActivity(request)
 
@@ -183,6 +187,9 @@ internal class AppcuesRepositoryTest {
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
         coEvery { appcuesRemoteSource.postActivity("userId", null, "data") } returns Failure(NetworkError())
 
+        // line below added related to https://github.com/mockk/mockk/issues/321
+        coEvery { appcuesRemoteSource.qualify(any(), any(), any(), any()) } returns Success(mockk(relaxed = true))
+
         // WHEN
         repository.trackActivity(request)
 
@@ -197,6 +204,9 @@ internal class AppcuesRepositoryTest {
         val activityStorage = ActivityStorage(UUID.randomUUID(), "123", "userId", "data", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
         coEvery { appcuesRemoteSource.postActivity("userId", null, "data") } returns Failure(HttpError())
+
+        // line below added related to https://github.com/mockk/mockk/issues/321
+        coEvery { appcuesRemoteSource.qualify(any(), any(), any(), any()) } returns Success(mockk(relaxed = true))
 
         // WHEN
         repository.trackActivity(request)
@@ -214,6 +224,10 @@ internal class AppcuesRepositoryTest {
         val activityStorage3 = ActivityStorage(UUID.randomUUID(), "123", "userId", "data3", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage1, activityStorage2, activityStorage3)
         config.activityStorageMaxSize = 2
+
+        // two lines below added related to https://github.com/mockk/mockk/issues/321
+        coEvery { appcuesRemoteSource.postActivity(any(), any(), any()) } returns Success(mockk(relaxed = true))
+        coEvery { appcuesRemoteSource.qualify(any(), any(), any(), any()) } returns Success(mockk(relaxed = true))
 
         // WHEN
         repository.trackActivity(request)
@@ -235,6 +249,10 @@ internal class AppcuesRepositoryTest {
         val activityStorage3 = ActivityStorage(UUID.randomUUID(), "123", "userId", "data3", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage1, activityStorage2, activityStorage3)
         config.activityStorageMaxAge = 3
+
+        // two lines below added related to https://github.com/mockk/mockk/issues/321
+        coEvery { appcuesRemoteSource.postActivity(any(), any(), any()) } returns Success(mockk(relaxed = true))
+        coEvery { appcuesRemoteSource.qualify(any(), any(), any(), any()) } returns Success(mockk(relaxed = true))
 
         // WHEN
         repository.trackActivity(request)
@@ -298,6 +316,10 @@ internal class AppcuesRepositoryTest {
         val request = ActivityRequest(accountId = "123", userId = "userId", userSignature = "user-signature")
         val cacheItem = ActivityStorage(UUID.randomUUID(), "123", "userId", "data1", "user-signature-cache")
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(cacheItem)
+
+        // two lines below added related to https://github.com/mockk/mockk/issues/321
+        coEvery { appcuesRemoteSource.postActivity(any(), any(), any()) } returns Success(mockk(relaxed = true))
+        coEvery { appcuesRemoteSource.qualify(any(), any(), any(), any()) } returns Success(mockk(relaxed = true))
 
         // WHEN
         repository.trackActivity(request)

--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,16 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
-        classpath "org.jacoco:org.jacoco.core:0.8.7"
-        classpath "org.jetbrains.dokka:kotlin-as-java-plugin:1.7.20"
+        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21"
+        classpath "org.jacoco:org.jacoco.core:0.8.9"
+        classpath "org.jetbrains.dokka:kotlin-as-java-plugin:1.8.20"
     }
 }
 
 plugins {
     id "io.gitlab.arturbosch.detekt" version "1.21.0"
-    id "org.jetbrains.dokka" version "1.7.20"
+    id "org.jetbrains.dokka" version "1.8.20"
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,3 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0.
-# To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true
-# in the `gradle.properties` file or use the new publishing DSL.
-android.disableAutomaticComponentCreation=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 28 10:03:27 BRT 2021
+#Mon Jul 17 14:34:18 EDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -6,6 +6,8 @@ plugins {
 android {
     compileSdk 33
 
+    namespace "com.appcues.samples.kotlin"
+
     signingConfigs {
         release {
             keyAlias System.getenv("KEYSTORE_ALIAS")
@@ -46,6 +48,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig true
         viewBinding true
     }
 }

--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.appcues.samples.kotlin">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name=".ExampleApplication"


### PR DESCRIPTION
Updates related to the latest Android Studio Flamingo default versions, getting into compatibility with other tools releasing similar updates. A lot of these are cascading updates from the Gradle 8 change really, for example the Kotlin version which then requires a Compose Compiler / Compose update.

* Android Gradle Plugin 7.2.2 -> 8.0.2
* JDK 11 -> 17
* Kotlin 1.7.20 - 1.8.21
* Compose 1.3.0 -> 1.4.3
* Compose Compiler 1.3.2 -> 1.4.7
* Accompanist 0.27.0 -> 0.30.1

As part of Compose 1.4.3 - now using the official Pager for our carousel and removed the usage of the Accompanist Pager.

Ended up also needing to explicitly declare OkHttp 4.11.0 as a dependency to[ resolve a minification issue with the 4.10.0 version](https://github.com/square/okhttp/issues/7777) that was previously being implicitly included through other dependencies (Retrofit / Coil),

Also updated Koin 3.1.6 -> 3.4.2 to stay current (customer request). We had held back due to an Expo (react native) conflict, but this [appears to be updated now as well](https://github.com/expo/expo/commit/681f12047dfd3015c951bf54e2a2ba7f839d5b1f). There is a breaking issue with [how Koin handles parameters](https://github.com/InsertKoinIO/koin/issues/1607), so a change was made to use indexed based param lookup so that our code works on both Koin old and new versions.

Also other build/util tools and test lib updates
* Dokka (api doc gen) 1.7.20 -> 1.8.20
* Jacoco (test coverage report gen) 0.8.7 -> 0.8.9
* Updated unit test dependencies and verified tests (required a few small test code updates)

Working on related UI test updates in the spec library, Shot now supports JDK 17 and all the updates so hopefully that all works out.
