### PR TITLE
Update build machine to latest Android for all jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,16 @@ orbs:
   codecov: codecov/codecov@3.1.1
 
 # -------------------------
+#        EXECUTORS
+# -------------------------
+executors:
+  android_compatible:
+    machine: 
+      image: android:2023.07.1 #https://circleci.com/developer/machine/image/android
+    resource_class: large
+    working_directory: ~/code
+
+# -------------------------
 #        REFERENCES
 # -------------------------
 references:
@@ -73,11 +83,7 @@ commands:
 # --------------------------
 jobs:
   validate_code:
-    working_directory: ~/code
-    executor:
-      name: android/android-machine
-      resource-class: large
-      tag: 2023.07.1 # https://circleci.com/developer/machine/image/android
+    executor: android_compatible
     steps:
       - install_with_cache      
       - run:
@@ -98,11 +104,7 @@ jobs:
           channel: team-mobile-bots
 
   deploy_sample:
-    working_directory: ~/code
-    executor:
-      name: android/android-machine
-      resource-class: large
-      tag: 2022.04.1 # https://circleci.com/developer/machine/image/android
+    executor: android_compatible
     steps:
       - install_with_cache      
       - run:
@@ -176,11 +178,7 @@ jobs:
           channel: team-mobile-bots  
 
   update_code_coverage:
-    working_directory: ~/code
-    executor:
-      name: android/android-machine
-      resource-class: large
-      tag: 2022.04.1 # https://circleci.com/developer/machine/image/android
+    executor: android_compatible
     steps:
       - install_with_cache      
       - run:


### PR DESCRIPTION
This approach should ensure that we always have a consistent Android build machine specified across all the jobs.

Previously, I accidentally only updated the machine in the `validate_code` section (PR validation) but missed the `update_code_coverage` section, resulting in the [build failure here](https://app.circleci.com/pipelines/github/appcues/appcues-android-sdk/1947/workflows/add1b292-d035-4905-9f30-96d75f410d24/jobs/1836).