### PR TITLE
✨ Added AppcuesFrameView to replace generic ViewGroup

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -3,7 +3,6 @@ package com.appcues
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.view.ViewGroup
 import com.appcues.action.ActionRegistry
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ActivityScreenTracking
@@ -237,13 +236,13 @@ public class Appcues internal constructor(koinScope: Scope) {
     }
 
     /**
-     * register an embed view for given frameId.
+     * Register an AppcuesFrameView for a given frameId.
      *
-     * @param frameId unique string set in builder that is used to identify this embed view with qualified experiences
-     * @param view frame used to inflate the embedded experience
+     * @param frameId unique string set in builder that is used to identify this AppcuesFrameView with qualified experiences
+     * @param frame frame used to inflate the embedded experience
      */
-    public fun registerEmbed(frameId: String, view: ViewGroup) {
-        renderContextManager.registerEmbedFrame(frameId, view)
+    public fun registerEmbed(frameId: String, frame: AppcuesFrameView) {
+        renderContextManager.registerEmbedFrame(frameId, frame)
     }
 
     /**

--- a/appcues/src/main/java/com/appcues/AppcuesViews.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesViews.kt
@@ -1,0 +1,100 @@
+package com.appcues
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import androidx.compose.ui.platform.ComposeView
+
+/**
+ * AppcuesFrameView should is used when customers want to define a specific place for inflating Embed content
+ * in their app. By placing an AppcuesFrameView in their layout, then can later register this view with a frameId.
+ *
+ * appcues.registerEmbed("frame1", appcuesFrameView)
+ */
+public class AppcuesFrameView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val composeView = ComposeView(context)
+
+    internal fun setupComposeView(): ComposeView {
+        // when index is -1 it means the view is not added yet
+        if (indexOfChild(composeView) == -1) {
+            addView(composeView)
+        }
+
+        return composeView
+    }
+
+    internal fun clearComposition() {
+        removeView(composeView)
+        composeView.setContent { }
+    }
+
+    // Below: enforce restrictions on adding child views to this ViewGroup
+    private fun checkAddView(child: View?) {
+        if (child != composeView) {
+            throw UnsupportedOperationException("Cannot add views to ${javaClass.simpleName}.")
+        }
+    }
+
+    override fun addView(child: View?) {
+        checkAddView(child)
+        super.addView(child)
+    }
+
+    override fun addView(child: View?, index: Int) {
+        checkAddView(child)
+        super.addView(child, index)
+    }
+
+    override fun addView(child: View?, width: Int, height: Int) {
+        checkAddView(child)
+        super.addView(child, width, height)
+    }
+
+    override fun addView(child: View?, params: android.view.ViewGroup.LayoutParams?) {
+        checkAddView(child)
+        super.addView(child, params)
+    }
+
+    override fun addView(child: View?, index: Int, params: android.view.ViewGroup.LayoutParams?) {
+        checkAddView(child)
+        super.addView(child, index, params)
+    }
+
+    override fun addViewInLayout(child: View?, index: Int, params: android.view.ViewGroup.LayoutParams?): Boolean {
+        checkAddView(child)
+        return super.addViewInLayout(child, index, params)
+    }
+
+    override fun addViewInLayout(
+        child: View?,
+        index: Int,
+        params: android.view.ViewGroup.LayoutParams?,
+        preventRequestLayout: Boolean
+    ): Boolean {
+        checkAddView(child)
+        return super.addViewInLayout(child, index, params, preventRequestLayout)
+    }
+}
+
+internal class AppcuesOverlayView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    internal val composeView = ComposeView(context)
+
+    init {
+        addView(composeView)
+    }
+
+    internal fun clearComposition() {
+        composeView.setContent { }
+    }
+}

--- a/appcues/src/main/java/com/appcues/RenderContextManager.kt
+++ b/appcues/src/main/java/com/appcues/RenderContextManager.kt
@@ -1,19 +1,18 @@
 package com.appcues
 
-import android.view.ViewGroup
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.RenderContext.Embed
 import java.lang.ref.WeakReference
 
 internal class RenderContextManager {
 
-    private val slots: HashMap<RenderContext, WeakReference<ViewGroup>> = hashMapOf()
+    private val slots: HashMap<RenderContext, WeakReference<AppcuesFrameView>> = hashMapOf()
 
-    fun registerEmbedFrame(frameId: String, view: ViewGroup) {
-        slots[Embed(frameId)] = WeakReference(view)
+    fun registerEmbedFrame(frameId: String, frame: AppcuesFrameView) {
+        slots[Embed(frameId)] = WeakReference(frame)
     }
 
-    fun getEmbedView(renderContext: RenderContext): ViewGroup? {
+    fun getEmbedFrame(renderContext: RenderContext): AppcuesFrameView? {
         return when (renderContext) {
             is Embed -> slots[renderContext]?.get()
             else -> null

--- a/appcues/src/main/java/com/appcues/ui/presentation/EmbedViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/EmbedViewPresenter.kt
@@ -13,16 +13,12 @@ internal class EmbedViewPresenter(
 ) : ViewPresenter(scope, renderContext) {
 
     override fun ViewGroup.setupView(): ComposeView? {
-        val embedView = renderContextManager.getEmbedView(renderContext) ?: return null
-
-        return ComposeView(context).also {
-            embedView.addView(it)
-        }
+        return renderContextManager.getEmbedFrame(renderContext)?.setupComposeView()
     }
 
     override fun ViewGroup.removeView() {
         post {
-            renderContextManager.getEmbedView(renderContext)?.removeAllViews()
+            renderContextManager.getEmbedFrame(renderContext)?.clearComposition()
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/presentation/OverlayViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/OverlayViewPresenter.kt
@@ -7,41 +7,48 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
+import com.appcues.AppcuesOverlayView
 import com.appcues.R
 import com.appcues.data.model.RenderContext
 import org.koin.core.scope.Scope
 
 internal class OverlayViewPresenter(scope: Scope, renderContext: RenderContext) : ViewPresenter(scope, renderContext) {
 
-    override fun ViewGroup.setupView(): ComposeView? {
+    override fun ViewGroup.setupView(): ComposeView {
         // remove customers view on accessibility stack
         setAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
 
-        return if (findViewById<View>(R.id.appcues_overlay_view) == null) {
+        val overlayView = if (findViewById<View>(R.id.appcues_overlay_view) == null) {
             // create and add the view
-            ComposeView(context).apply {
+            AppcuesOverlayView(context).apply {
                 id = R.id.appcues_overlay_view
                 layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT).also {
                     // adds margin top and bottom according to visible status and navigation bar
                     ViewCompat.getRootWindowInsets(this)?.getInsets(WindowInsetsCompat.Type.systemBars())
                         ?.let { insets -> it.setMargins(insets.left, insets.top, insets.right, insets.bottom) }
                 }
-            }.also { composeView ->
+            }.also { overlayView ->
                 // if debugger view exists, ensure we are positioned behind it.
                 findViewById<View>(R.id.appcues_debugger_view)
-                    ?.let { addView(composeView, indexOfChild(it)) }
-                    ?: addView(composeView)
+                    ?.let { addView(overlayView, indexOfChild(it)) }
+                    ?: addView(overlayView)
             }
         } else {
             // this is just a fallback that should never hit, but as a good practice if the view is already there
             // for some reason, we can just use it.
             findViewById(R.id.appcues_overlay_view)
         }
+
+        return overlayView.composeView
     }
 
     override fun ViewGroup.removeView() {
         post {
-            removeView(findViewById(R.id.appcues_overlay_view))
+            findViewById<AppcuesOverlayView?>(R.id.appcues_overlay_view)?.let {
+                it.clearComposition()
+
+                removeView(it)
+            }
 
             // add customers view back to accessibility stack
             setAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES)

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -2,7 +2,6 @@ package com.appcues.ui.presentation
 
 import android.app.Activity
 import android.view.ViewGroup
-import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -58,8 +57,8 @@ internal abstract class ViewPresenter(
 
             composeView.setContent {
                 AppcuesComposition(
-                    viewModel = remember { viewModel },
-                    shakeGestureListener = remember { gestureListener },
+                    viewModel = viewModel,
+                    shakeGestureListener = gestureListener,
                     logcues = scope.get(),
                     chromeClient = EmbedChromeClient(this),
                 )

--- a/samples/kotlin-android-app/src/main/res/layout/fragment_embed.xml
+++ b/samples/kotlin-android-app/src/main/res/layout/fragment_embed.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <FrameLayout
+        <com.appcues.AppcuesFrameView
             android:id="@+id/embedFrame1"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -19,7 +19,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <FrameLayout
+        <com.appcues.AppcuesFrameView
             android:id="@+id/embedFrame2"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -28,7 +28,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/embedFrame1" />
 
-        <FrameLayout
+        <com.appcues.AppcuesFrameView
             android:id="@+id/embedFrame3"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -37,7 +37,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/embedFrame2" />
 
-        <FrameLayout
+        <com.appcues.AppcuesFrameView
             android:id="@+id/embedFrame4"
             android:layout_width="0dp"
             android:layout_height="wrap_content"


### PR DESCRIPTION
An additional PR to the original embed trait PR.

this one is aiming to replace the generic ViewGroup with a specific AppcuesFrameView, the reasoning behind it is to limit customer options here, not letting them adding ANY type of ViewGroup, in addition this is extending from AbstractComposeView, with similar implementation as ComposeView, which should be perfect for our use case.

deriving two classes, one internal and the other (AppcuesFrameView) public for use during appcues.registerEmbed("frame", appcuesFrameView)