### PR TITLE
Ensure no empty strings are present in selector property values

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
@@ -36,10 +36,10 @@ internal class AndroidViewSelector(
         const val SELECTOR_APPCUES_ID = "appcuesID"
     }
 
-    private val contentDescription: String? = properties[SELECTOR_CONTENT_DESCRIPTION]
-    private val tag: String? = properties[SELECTOR_TAG]
-    private val resourceName: String? = properties[SELECTOR_RESOURCE_NAME]
-    private val appcuesId: String? = properties[SELECTOR_APPCUES_ID]
+    private val contentDescription: String? = properties[SELECTOR_CONTENT_DESCRIPTION]?.ifEmpty { null }
+    private val tag: String? = properties[SELECTOR_TAG]?.ifEmpty { null }
+    private val resourceName: String? = properties[SELECTOR_RESOURCE_NAME]?.ifEmpty { null }
+    private val appcuesId: String? = properties[SELECTOR_APPCUES_ID]?.ifEmpty { null }
 
     val isValid: Boolean
         get() = contentDescription != null || tag != null || resourceName != null || appcuesId != null
@@ -54,7 +54,7 @@ internal class AndroidViewSelector(
         }
 
     override fun toMap(): Map<String, String> {
-        return properties.filterValues { it != null }.mapValues { it.value as String }
+        return properties.filterValues { !it.isNullOrEmpty() }.mapValues { it.value as String }
     }
 
     @Suppress("MagicNumber")

--- a/appcues/src/test/java/com/appcues/debugger/screencapture/ElementSelectorTest.kt
+++ b/appcues/src/test/java/com/appcues/debugger/screencapture/ElementSelectorTest.kt
@@ -1,0 +1,22 @@
+package com.appcues.debugger.screencapture
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class ElementSelectorTest {
+    @Test
+    fun `empty selector properties SHOULD NOT create a valid selector`() {
+        // given
+        val selector = AndroidViewSelector(
+            mapOf(
+                AndroidViewSelector.SELECTOR_APPCUES_ID to "",
+                AndroidViewSelector.SELECTOR_TAG to "",
+                AndroidViewSelector.SELECTOR_CONTENT_DESCRIPTION to "",
+                AndroidViewSelector.SELECTOR_RESOURCE_NAME to ""
+            )
+        )
+        // then
+        assertThat(selector.isValid).isFalse()
+        assertThat(selector.toMap()).isEmpty()
+    }
+}


### PR DESCRIPTION
Some customer data showed selectors with `""` values - we should ignore these and not create selectors that will not provide any unique value. Matching iOS change in https://github.com/appcues/appcues-ios-sdk/pull/431 and react native in https://github.com/appcues/appcues-react-native-module/pull/99