### PR TITLE
♻️  ExperienceRenderer changes around how embeds are displayed

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -74,7 +74,6 @@ public class Appcues internal constructor(koinScope: Scope) {
     private val debuggerManager by koinScope.inject<AppcuesDebuggerManager>()
     private val appcuesCoroutineScope by koinScope.inject<AppcuesCoroutineScope>()
     private val analyticsPublisher by koinScope.inject<AnalyticsPublisher>()
-    private val renderContextManager by koinScope.inject<RenderContextManager>()
 
     /**
      * Set the listener to be notified about the display of Experience content.
@@ -242,7 +241,9 @@ public class Appcues internal constructor(koinScope: Scope) {
      * @param frame frame used to inflate the embedded experience
      */
     public fun registerEmbed(frameId: String, frame: AppcuesFrameView) {
-        renderContextManager.registerEmbedFrame(frameId, frame)
+        appcuesCoroutineScope.launch {
+            experienceRenderer.startFrame(frameId, frame)
+        }
     }
 
     /**

--- a/appcues/src/main/java/com/appcues/AppcuesKoin.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesKoin.kt
@@ -28,7 +28,7 @@ internal object AppcuesKoin : KoinScopePlugin {
             )
         }
         scoped { AppcuesDebuggerManager(context = get(), koinScope = this) }
-        scoped { RenderContextManager() }
+        scoped { RenderContextManager(scope = get()) }
         scoped { ContextResources(context = get()) }
         scoped { ExperienceRenderer(scope = get()) }
         scoped {

--- a/appcues/src/main/java/com/appcues/RenderContextManager.kt
+++ b/appcues/src/main/java/com/appcues/RenderContextManager.kt
@@ -1,25 +1,80 @@
 package com.appcues
 
+import com.appcues.analytics.ExperienceLifecycleTracker
+import com.appcues.data.model.Experience
+import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.model.ExperienceTrigger.Qualification
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.RenderContext.Embed
+import com.appcues.statemachine.StateMachine
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.component.get
+import org.koin.core.component.inject
+import org.koin.core.scope.Scope
 import java.lang.ref.WeakReference
 
-internal class RenderContextManager {
+internal class RenderContextManager(override val scope: Scope) : KoinScopeComponent {
 
-    private val slots: HashMap<RenderContext, WeakReference<AppcuesFrameView>> = hashMapOf()
+    private val lifecycleTracker by inject<ExperienceLifecycleTracker>()
+
+    private val frameSlots: HashMap<RenderContext, WeakReference<AppcuesFrameView>> = hashMapOf()
+
+    private val stateMachineSlots: HashMap<RenderContext, StateMachine> = hashMapOf()
+
+    private val potentiallyRenderableExperiences = hashMapOf<RenderContext, List<Experience>>()
 
     fun registerEmbedFrame(frameId: String, frame: AppcuesFrameView) {
-        slots[Embed(frameId)] = WeakReference(frame)
+        val renderContext = Embed(frameId)
+
+        // silently removing the existing state machine to ensure we get a new one when trying
+        // to start an experience for this render context
+        stateMachineSlots.remove(renderContext)
+        frameSlots[Embed(frameId)] = WeakReference(frame)
     }
 
     fun getEmbedFrame(renderContext: RenderContext): AppcuesFrameView? {
         return when (renderContext) {
-            is Embed -> slots[renderContext]?.get()
+            is Embed -> frameSlots[renderContext]?.get()
             else -> null
         }
     }
 
-    fun clear() {
-        slots.clear()
+    fun getOrCreateStateMachines(renderContext: RenderContext): StateMachine {
+        return stateMachineSlots[renderContext] ?: run {
+            get<StateMachine>()
+                .also { stateMachineSlots[renderContext] = it }
+                .also { lifecycleTracker.start(it, { potentiallyRenderableExperiences.remove(renderContext) }) }
+        }
+    }
+
+    fun getStateMachine(renderContext: RenderContext): StateMachine? {
+        return stateMachineSlots[renderContext]
+    }
+
+    fun putExperiences(experiences: List<Experience>, trigger: ExperienceTrigger) {
+        if (trigger is Qualification && trigger.reason == "screen_view") {
+            // clear list in case this was a screen_view qualification
+            potentiallyRenderableExperiences.clear()
+
+            stateMachineSlots.forEach { map ->
+                val renderContext = map.key
+                if (renderContext is Embed && getEmbedFrame(map.key) == null) {
+                    stateMachineSlots.remove(map.key)
+                }
+            }
+        }
+
+        // populate new experiences into the dictionary
+        experiences.filter { it.renderContext !is RenderContext.Modal }.groupBy { it.renderContext }.forEach {
+            potentiallyRenderableExperiences[it.key] = it.value
+        }
+    }
+
+    fun getPotentialExperiences(renderContext: RenderContext): List<Experience> {
+        return potentiallyRenderableExperiences[renderContext] ?: arrayListOf()
+    }
+
+    fun stop() {
+        stateMachineSlots.values.forEach { it.stop() }
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsEvent.kt
@@ -15,5 +15,6 @@ internal enum class AnalyticsEvent(val eventName: String) {
     ExperienceCompleted("appcues:v2:experience_completed"),
     ExperienceDismissed("appcues:v2:experience_dismissed"),
     ExperienceError("appcues:v2:experience_error"),
+    ExperienceRecovery("appcues:v2:experience_recovered"),
     ExperimentEntered("appcues:experiment_entered"),
 }

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTrackerExt.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTrackerExt.kt
@@ -1,7 +1,9 @@
 package com.appcues.analytics
 
+import com.appcues.data.model.Experience
 import com.appcues.data.model.Experiment
 import com.appcues.util.appcuesFormatted
+import java.util.UUID
 
 internal fun AnalyticsTracker.track(event: AnalyticsEvent, properties: Map<String, Any>? = null, interactive: Boolean = true) {
     track(event.eventName, properties, interactive, true)
@@ -19,4 +21,34 @@ internal fun AnalyticsTracker.track(experiment: Experiment) {
         ),
         interactive = false
     )
+}
+
+internal fun AnalyticsTracker.trackExperienceError(experience: Experience) {
+    val errorId = UUID.randomUUID()
+
+    track(
+        event = AnalyticsEvent.ExperienceError,
+        properties = mapOf(
+            "Id" to errorId.toString(),
+        ),
+        interactive = false
+    )
+
+    experience.renderErrorId = errorId
+}
+
+internal fun AnalyticsTracker.trackExperienceRecovery(experience: Experience) {
+    if (experience.renderErrorId == null) return
+
+    val errorId = experience.renderErrorId
+
+    track(
+        event = AnalyticsEvent.ExperienceRecovery,
+        properties = mapOf(
+            "Id" to errorId.toString(),
+        ),
+        interactive = false
+    )
+
+    experience.renderErrorId = null
 }

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -17,6 +17,7 @@ internal data class Experience(
     val trigger: ExperienceTrigger,
     val requestId: UUID? = null,
     val error: String? = null,
+    var renderErrorId: UUID? = null,
 ) {
 
     // a unique identifier for this instance of the Experience, for comparison purposes, in the

--- a/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
@@ -3,6 +3,7 @@ package com.appcues.action
 import com.appcues.Appcues
 import com.appcues.AppcuesConfig
 import com.appcues.AppcuesCoroutineScope
+import com.appcues.RenderContextManager
 import com.appcues.action.appcues.StepInteractionAction
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType.BUTTON_TAPPED
@@ -160,6 +161,7 @@ internal class ActionProcessorTest : KoinTest {
                         scoped { ExperienceRenderer(scope) }
                         scoped { RenderContext.Modal }
                         scoped { mockk<ExperienceLifecycleTracker>(relaxed = true) }
+                        scoped { RenderContextManager(scope = scope) }
                     }
                 }
             )

--- a/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
@@ -148,7 +148,7 @@ internal class ExperienceLifecycleTrackerTest : KoinTest {
         }
 
         coroutineScope.launch {
-            scope.get<ExperienceLifecycleTracker>().start(machine, UnconfinedTestDispatcher())
+            scope.get<ExperienceLifecycleTracker>().start(machine, {}, UnconfinedTestDispatcher())
         }
 
         return scope

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -1,6 +1,7 @@
 package com.appcues.ui
 
 import com.appcues.AppcuesConfig
+import com.appcues.RenderContextManager
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.analytics.ExperienceLifecycleTracker
 import com.appcues.analytics.track
@@ -194,14 +195,16 @@ internal class ExperienceRendererTest {
         KoinPlatformTools.defaultContext().getOrNull()?.close()
         val scopeId = UUID.randomUUID().toString()
         return startKoin {
-            koin.getOrCreateScope(scopeId = scopeId, qualifier = named(scopeId))
+            val scope = koin.getOrCreateScope(scopeId = scopeId, qualifier = named(scopeId))
             modules(
                 module {
                     scope(named(scopeId)) {
+                        scoped { scope }
                         factory { stateMachine }
                         scoped { AppcuesConfig("abc", "123") }
                         scoped { mockk<AnalyticsTracker>(relaxed = true) }
                         scoped { mockk<ExperienceLifecycleTracker>(relaxed = true) }
+                        scoped { RenderContextManager(scope) }
                     }
                 }
             )


### PR DESCRIPTION
the goal here is to cover some of the edge cases for embeds when its registered an re-registered.

the initial scenario I was going for is to have proxy experiences to show on Embeds tab, and then interacting with those and changing between tabs should be able to work well.

for next step I will be looking into RecyclerViews