### PR TITLE
Add retry capability for target element matching

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/AppcuesTraitException.kt
+++ b/appcues/src/main/java/com/appcues/trait/AppcuesTraitException.kt
@@ -3,4 +3,13 @@ package com.appcues.trait
 /**
  * A type of exception that can occur during the application of an ExperienceTrait.
  */
-public class AppcuesTraitException(message: String) : Exception(message)
+public class AppcuesTraitException(
+    message: String,
+
+    /**
+     *  When set, this value can indicate a number of milliseconds after which re-application
+     *  of traits can be attempted, to try to auto-recover from this error.
+     */
+    public val retryMilliseconds: Int? = null,
+
+) : Exception(message)

--- a/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
@@ -60,8 +60,12 @@ internal class AppcuesOverlayViewManager(
         AppcuesActivityMonitor.activity?.removeOverlayView()
     }
 
+    private fun setOverlayVisible(isVisible: Boolean) {
+        AppcuesActivityMonitor.activity?.updateOverlayVisibility(isVisible)
+    }
+
     private fun Activity.addOverlayView(): Boolean {
-        viewModel = AppcuesViewModel(scope, renderContext, ::onCompositionDismiss)
+        viewModel = AppcuesViewModel(scope, renderContext, ::onCompositionDismiss, ::setOverlayVisible)
         gestureListener = ShakeGestureListener(this)
 
         val parentView = getParentView()
@@ -116,6 +120,24 @@ internal class AppcuesOverlayViewManager(
                 viewModel.onFinish()
 
                 it.setAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES)
+            }
+        }
+    }
+
+    private fun Activity.updateOverlayVisibility(isVisible: Boolean) {
+        getParentView().let { parentView ->
+            parentView.post {
+                findViewById<ComposeView>(R.id.appcues_overlay_view)?.let {
+                    it.visibility = if (isVisible) ViewGroup.VISIBLE else ViewGroup.GONE
+                }
+                parentView.setAccessibility(
+                    if (isVisible) {
+                        // when our view is visible, the parent view is removed from the accessibility stack
+                        View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                    } else {
+                        View.IMPORTANT_FOR_ACCESSIBILITY_YES
+                    }
+                )
             }
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
+++ b/appcues/src/main/java/com/appcues/ui/AppcuesOverlayViewManager.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
+import androidx.core.view.isVisible
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -128,7 +129,7 @@ internal class AppcuesOverlayViewManager(
         getParentView().let { parentView ->
             parentView.post {
                 findViewById<ComposeView>(R.id.appcues_overlay_view)?.let {
-                    it.visibility = if (isVisible) ViewGroup.VISIBLE else ViewGroup.GONE
+                    it.isVisible = isVisible
                 }
                 parentView.setAccessibility(
                     if (isVisible) {

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -62,7 +62,11 @@ internal val LocalChromeClient = compositionLocalOf { AccompanistWebChromeClient
 
 internal val LocalAppcuesTraitExceptionHandler = compositionLocalOf { AppcuesTraitExceptionHandler {} }
 
+internal val LocalAppcuesOverlayVisibility = compositionLocalOf { AppcuesOverlayVisibility {} }
+
 internal data class AppcuesTraitExceptionHandler(val onTraitException: (AppcuesTraitException) -> Unit)
+
+internal data class AppcuesOverlayVisibility(val setVisible: (Boolean) -> Unit)
 
 internal enum class StackScope {
     ROW, COLUMN


### PR DESCRIPTION
There were a few complex bits to this, which I'll do my best to explain. The overall idea is this:
1. If a target-element is not found, it should allow some retry - by default after 300, 900, 1800, and 3000ms. If it still is not found after 3s, it will report a StepError and abort the flow (as before)
2. If the element is found, it will continue on and trigger the ExperienceStarted and StepSeen as appropriate
3. If the Activity is removed out from under us (deep link or user navigation) - it will report a new type of StepError `"Activity changed during render of step $index" - and abort the flow (free up the state machine)

To support this, the `@appcues/target-element` trait has an optional array of Ints (milliseconds) for `retryIntervals` that define the retry timeline (defaults as noted above). `AppcuesComposition` is where the real retry logic lives. In the `produceMetadata` function, it handles the `TraitException` and retry loop as necessary. A `TraitException` may optionally define the `retryMilliseconds` now, and this is used in the `TargetElementTrait` for the error types that _may_ be recoverable.

One detail here - when we go into the delay+retry, we must hide the overlay view layer so that the Application is not unresponsive to the user during the delay with that transparent view hanging on top. This is done through a callback, through the view model, and into the AppcuesOverlayViewManager. I need to check if this will have implications on changes being made for Embeds, which change some of how these view managers / presenters work.

The changes in `AppcuesViewModel` are largely around supporting the edge case #3 - making sure that we leave our `StateMachine` in a valid state, regardless of how the the Experience has been presented successfully, or failed.