### PR TITLE
Add Retrofit Proguard rules to avoid issue with AGP8 and R8 full mode

### DIFF
--- a/appcues/consumer-rules.pro
+++ b/appcues/consumer-rules.pro
@@ -1,1 +1,12 @@
 -keep class com.appcues.data.remote.**.response.** { *; }
+
+# For AGP 8 issue with Retrofit and R8 https://github.com/square/retrofit/issues/3751#issuecomment-1192043644
+
+ # Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+ -keep,allowobfuscation,allowshrinking interface retrofit2.Call
+ -keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+ # With R8 full mode generic signatures are stripped for classes that are not
+ # kept. Suspend functions are wrapped in continuations where the type argument
+ # is used.
+ -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation


### PR DESCRIPTION
Workaround for issue with release minification https://github.com/square/retrofit/issues/3751#issuecomment-1192043644