### PR TITLE
Update session tracking

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -10,7 +10,7 @@ public data class AppcuesConfig internal constructor(
     internal val applicationId: String,
 ) {
     internal companion object {
-        const val SESSION_TIMEOUT_DEFAULT = 1800 // 30 minutes by default
+        const val SESSION_TIMEOUT_DEFAULT = 300 // 5 minutes by default
         const val ACTIVITY_STORAGE_MAX_SIZE = 25
     }
 
@@ -32,7 +32,7 @@ public data class AppcuesConfig internal constructor(
 
     /**
      *  Set the session timeout for the configuration, in seconds. This timeout value is used to determine if a new session is started
-     *  upon the application returning to the foreground. The default value is 1800 seconds (30 minutes).
+     *  after a period of inactivity, or upon the application returning to the foreground. The default value is 300 seconds (5 minutes).
      */
     var sessionTimeout: Int = SESSION_TIMEOUT_DEFAULT
         set(value) {

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsEvent.kt
@@ -3,9 +3,6 @@ package com.appcues.analytics
 internal enum class AnalyticsEvent(val eventName: String) {
     ScreenView("appcues:screen_view"),
     SessionStarted("appcues:session_started"),
-    SessionSuspended("appcues:session_suspended"),
-    SessionResumed("appcues:session_resumed"),
-    SessionReset("appcues:session_reset"),
     ExperienceStepSeen("appcues:v2:step_seen"),
     ExperienceStepInteraction("appcues:v2:step_interaction"),
     ExperienceStepCompleted("appcues:v2:step_completed"),

--- a/appcues/src/main/java/com/appcues/data/remote/DataRemoteKoin.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/DataRemoteKoin.kt
@@ -31,7 +31,6 @@ internal object DataRemoteKoin : KoinScopePlugin {
                 ).create(AppcuesService::class),
                 config = config,
                 storage = get(),
-                sessionMonitor = get(),
             )
         }
 

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/AppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/AppcuesRemoteSource.kt
@@ -1,7 +1,6 @@
 package com.appcues.data.remote.appcues
 
 import com.appcues.AppcuesConfig
-import com.appcues.SessionMonitor
 import com.appcues.Storage
 import com.appcues.analytics.SdkMetrics
 import com.appcues.data.remote.NetworkRequest
@@ -21,7 +20,6 @@ internal class AppcuesRemoteSource(
     private val service: AppcuesService,
     private val config: AppcuesConfig,
     private val storage: Storage,
-    private val sessionMonitor: SessionMonitor,
 ) {
     companion object {
         const val BASE_URL = "https://api.appcues.net/"
@@ -43,8 +41,8 @@ internal class AppcuesRemoteSource(
         experienceId: String,
         userSignature: String?,
     ): ResultOf<ExperienceResponse, RemoteError> =
-        // preview _can_ be personalized, so attempt to use the user info, if a valid session exists
-        if (sessionMonitor.isActive) {
+        // preview _can_ be personalized, so attempt to use the user info, if a valid userId exists
+        if (storage.userId.isNotEmpty()) {
             NetworkRequest.execute {
                 service.experiencePreview(config.accountId, storage.userId, experienceId, userSignature?.let { "Bearer $it" })
             }

--- a/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.launch
 import org.koin.core.scope.Scope
 import kotlin.coroutines.CoroutineContext
 
+@Suppress("TooManyFunctions")
 internal class AppcuesDebuggerManager(context: Context, private val koinScope: Scope) : Application.ActivityLifecycleCallbacks {
 
     private val coroutineScope: CoroutineScope = object : CoroutineScope {
@@ -70,6 +71,10 @@ internal class AppcuesDebuggerManager(context: Context, private val koinScope: S
         application.unregisterActivityLifecycleCallbacks(this)
         onBackPressCallback.remove()
         debuggerViewModel = null // remove the reference to the current VM - new one will be made on next start()
+    }
+
+    fun reset() {
+        debuggerViewModel?.reset()
     }
 
     override fun onActivityResumed(activity: Activity) {

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
@@ -6,7 +6,6 @@ import com.appcues.AnalyticType.IDENTIFY
 import com.appcues.AnalyticType.SCREEN
 import com.appcues.R
 import com.appcues.analytics.ActivityRequestBuilder
-import com.appcues.analytics.AnalyticsEvent
 import com.appcues.analytics.AutoPropertyDecorator
 import com.appcues.analytics.ExperienceLifecycleEvent
 import com.appcues.analytics.SdkMetrics
@@ -105,8 +104,6 @@ internal class DebuggerRecentEventsManager(
             val title = event.name.toEventTitle()?.let { contextResources.getString(it) }
             val displayName = getEventDisplayName(event, type, title)
 
-            clearEventsOnSessionReset(event)
-
             events.addFirst(
                 DebuggerEventItem(
                     id = lastEventId,
@@ -155,11 +152,8 @@ internal class DebuggerRecentEventsManager(
         }
     }
 
-    private fun clearEventsOnSessionReset(event: EventRequest) {
-        // When session reset we clear the current list and start a new one
-        if (event.name == AnalyticsEvent.SessionReset.eventName) {
-            events.clear()
-        }
+    fun reset() {
+        events.clear()
     }
 
     private fun getEventDisplayName(

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerStatusManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerStatusManager.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.withContext
 import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("TooManyFunctions")
 internal class DebuggerStatusManager(
     storage: Storage,
     private val appcuesConfig: AppcuesConfig,
@@ -87,13 +88,15 @@ internal class DebuggerStatusManager(
                     experienceName = null
                     experienceShowingStep = null
                 }
-                AnalyticsEvent.SessionReset.eventName -> {
-                    userIdentified = null
-                }
                 else -> Unit
             }
         }
 
+        updateData()
+    }
+
+    suspend fun reset() {
+        userIdentified = null
         updateData()
     }
 

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
@@ -293,6 +293,13 @@ internal class DebuggerViewModel(
         }
     }
 
+    fun reset() {
+        viewModelScope.launch {
+            debuggerStatusManager.reset()
+            debuggerRecentEventsManager.reset()
+        }
+    }
+
     private fun List<DebuggerEventItem>.hideEventsForFab(): List<DebuggerEventItem> {
         return toMutableList().onEach { it.showOnFab = false }
     }

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerExt.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerExt.kt
@@ -36,10 +36,7 @@ internal fun EventType?.toResourceId(): Int {
 
 internal fun String.toEventType(): EventType = when (this) {
     AnalyticsEvent.ScreenView.eventName -> SCREEN
-    AnalyticsEvent.SessionStarted.eventName,
-    AnalyticsEvent.SessionSuspended.eventName,
-    AnalyticsEvent.SessionResumed.eventName,
-    AnalyticsEvent.SessionReset.eventName -> SESSION
+    AnalyticsEvent.SessionStarted.eventName -> SESSION
     AnalyticsEvent.ExperienceStepSeen.eventName,
     AnalyticsEvent.ExperienceStepInteraction.eventName,
     AnalyticsEvent.ExperienceStepCompleted.eventName,
@@ -54,9 +51,6 @@ internal fun String.toEventType(): EventType = when (this) {
 
 internal fun String.toEventTitle(): Int? = when (this) {
     AnalyticsEvent.SessionStarted.eventName -> R.string.appcues_debugger_event_type_session_started_title
-    AnalyticsEvent.SessionSuspended.eventName -> R.string.appcues_debugger_event_type_session_suspended_title
-    AnalyticsEvent.SessionResumed.eventName -> R.string.appcues_debugger_event_type_session_resumed_title
-    AnalyticsEvent.SessionReset.eventName -> R.string.appcues_debugger_event_type_session_reset_title
     AnalyticsEvent.ExperienceStepSeen.eventName -> R.string.appcues_debugger_event_type_step_seen_title
     AnalyticsEvent.ExperienceStepInteraction.eventName -> R.string.appcues_debugger_event_type_step_interaction_title
     AnalyticsEvent.ExperienceStepCompleted.eventName -> R.string.appcues_debugger_event_type_step_completed_title

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -119,7 +119,7 @@ internal class ExperienceRenderer(
     }
 
     suspend fun show(experienceId: String, trigger: ExperienceTrigger): Boolean {
-        if (!sessionMonitor.checkSession("cannot show Experience $experienceId")) return false
+        if (sessionMonitor.sessionId == null) return false
 
         repository.getExperienceContent(experienceId, trigger)?.let {
             return show(it)

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -56,8 +56,6 @@ internal class AppcuesTest : AppcuesScopeTest {
 
         // THEN
         verify(exactly = 0) { tracker.identify(any()) }
-        // called once at startup automatically, which is ignored, but not again since no valid user
-        verify(exactly = 1) { sessionMonitor.start() }
     }
 
     @Test
@@ -75,8 +73,6 @@ internal class AppcuesTest : AppcuesScopeTest {
         // THEN
         assertThat(storage.userId).isEqualTo(userId)
         verify { tracker.identify(properties) }
-        // called once at startup automatically, which is ignored, then again for the new valid user/session
-        verify(exactly = 2) { sessionMonitor.start() }
     }
 
     @Test
@@ -217,8 +213,6 @@ internal class AppcuesTest : AppcuesScopeTest {
         // THEN
         assertThat(storage.userId).isEqualTo("anon:${storage.deviceId}")
         assertThat(storage.isAnonymous).isTrue()
-        // called once at startup automatically, which is ignored, then again for the new valid user/session
-        verify(exactly = 2) { sessionMonitor.start() }
         verify { tracker.identify(null) }
     }
 

--- a/appcues/src/test/java/com/appcues/SessionMonitorTest.kt
+++ b/appcues/src/test/java/com/appcues/SessionMonitorTest.kt
@@ -1,18 +1,8 @@
 package com.appcues
 
-import com.appcues.analytics.AnalyticsEvent.SessionReset
-import com.appcues.analytics.AnalyticsEvent.SessionResumed
-import com.appcues.analytics.AnalyticsEvent.SessionStarted
-import com.appcues.analytics.AnalyticsEvent.SessionSuspended
-import com.appcues.analytics.AnalyticsTracker
-import com.appcues.analytics.track
-import com.appcues.logging.Logcues
 import com.appcues.rules.KoinScopeRule
 import com.appcues.rules.MainDispatcherRule
 import com.google.common.truth.Truth.assertThat
-import io.mockk.Called
-import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Rule
 import org.junit.Test
@@ -28,216 +18,40 @@ internal class SessionMonitorTest : AppcuesScopeTest {
     val dispatcherRule = MainDispatcherRule()
 
     @Test
-    fun `start SHOULD NOT track a session start WHEN userID is empty`() {
+    fun `startNewSession SHOULD NOT create a session WHEN userID is empty`() {
         // GIVEN
-        val tracker: AnalyticsTracker = get()
         val sessionMonitor = SessionMonitor(scope)
 
         // WHEN
-        sessionMonitor.start()
+        sessionMonitor.startNewSession()
 
         // THEN
-        verify { tracker wasNot Called }
-        assertThat(sessionMonitor.isActive).isFalse()
+        assertThat(sessionMonitor.sessionId).isNull()
     }
 
     @Test
-    fun `start SHOULD track a session start WHEN userID is not empty`() {
+    fun `start SHOULD create a session WHEN userID is not empty`() {
         // GIVEN
         val storage: Storage = get()
-        val tracker: AnalyticsTracker = get()
         val sessionMonitor = SessionMonitor(scope)
         storage.userId = "userId"
 
         // WHEN
-        sessionMonitor.start()
+        sessionMonitor.startNewSession()
 
         // THEN
-        verify(exactly = 1) { tracker.track(SessionStarted, any(), true) }
         assertThat(sessionMonitor.sessionId).isNotNull()
-        assertThat(sessionMonitor.isActive).isTrue()
     }
 
     @Test
-    fun `reset SHOULD track a session reset`() {
+    fun `reset SHOULD clear the session`() {
         // GIVEN
-        val tracker: AnalyticsTracker = get()
         val sessionMonitor = SessionMonitor(scope)
 
         // WHEN
         sessionMonitor.reset()
 
         // THEN
-        verify(exactly = 1) { tracker.track(SessionReset, any(), true) }
         assertThat(sessionMonitor.sessionId).isNull()
-        assertThat(sessionMonitor.isActive).isFalse()
-    }
-
-    @Test
-    fun `onStart SHOULD not track an event WHEN onStop was not previously called`() {
-        // GIVEN
-        val tracker: AnalyticsTracker = get()
-        val sessionMonitor = SessionMonitor(scope)
-        val storage: Storage = get()
-        storage.userId = "userId"
-        sessionMonitor.start()
-
-        // WHEN
-        sessionMonitor.onStart(mockk())
-
-        // THEN
-        verify(exactly = 1) { tracker.track(SessionStarted, any(), any()) } // only the initial start
-        verify(exactly = 0) { tracker.track(SessionResumed, any(), any()) }
-    }
-
-    @Test
-    fun `onStart SHOULD not track an event WHEN no current session exists`() {
-        // GIVEN
-        val tracker: AnalyticsTracker = get()
-        val sessionMonitor = SessionMonitor(scope)
-
-        // WHEN
-        sessionMonitor.onStart(mockk())
-
-        // THEN
-        verify(exactly = 0) { tracker.track(SessionStarted, any(), any()) }
-        verify(exactly = 0) { tracker.track(SessionResumed, any(), any()) }
-    }
-
-    @Test
-    fun `onStop SHOULD track session suspended WHEN an active session exists`() {
-        // GIVEN
-        val tracker: AnalyticsTracker = get()
-        val sessionMonitor = SessionMonitor(scope)
-        val storage: Storage = get()
-        storage.userId = "userId"
-        sessionMonitor.start()
-
-        // WHEN
-        sessionMonitor.onStop(mockk())
-
-        // THEN
-        verify(exactly = 1) { tracker.track(SessionSuspended, any(), any()) }
-        verify(exactly = 1) { tracker.flushPendingActivity() }
-    }
-
-    @Test
-    fun `onStop SHOULD NOT track session suspended WHEN no active session exists`() {
-        // GIVEN
-        val tracker: AnalyticsTracker = get()
-        val sessionMonitor = SessionMonitor(scope)
-
-        // WHEN
-        sessionMonitor.onStop(mockk())
-
-        // THEN
-        verify { tracker wasNot Called }
-    }
-
-    @Test
-    fun `onStart SHOULD track session resumed WHEN session timeout not expired`() {
-        // GIVEN
-        val tracker: AnalyticsTracker = get()
-        val sessionMonitor = SessionMonitor(scope)
-        val storage: Storage = get()
-        storage.userId = "userId"
-        sessionMonitor.start()
-        sessionMonitor.onStop(mockk())
-
-        // WHEN
-        sessionMonitor.onStart(mockk())
-
-        // THEN
-        verify(exactly = 1) { tracker.track(SessionResumed, any(), any()) }
-    }
-
-    @Test
-    fun `onStart SHOULD not change session ID WHEN session timeout not expired`() {
-        // GIVEN
-        val tracker: AnalyticsTracker = get()
-        val sessionMonitor = SessionMonitor(scope)
-        val storage: Storage = get()
-        storage.userId = "userId"
-        sessionMonitor.start()
-        val sessionId = sessionMonitor.sessionId
-        sessionMonitor.onStop(mockk())
-
-        // WHEN
-        sessionMonitor.onStart(mockk())
-
-        // THEN
-        assertThat(sessionId).isNotNull()
-        assertThat(sessionId).isEqualTo(sessionMonitor.sessionId)
-    }
-
-    @Test
-    fun `onStart SHOULD track session started WHEN session timeout has expired`() {
-        // GIVEN
-        val tracker: AnalyticsTracker = get()
-        val storage: Storage = get()
-        storage.userId = "userId"
-        val config: AppcuesConfig = get()
-        config.sessionTimeout = -1
-        val sessionMonitor = SessionMonitor(scope)
-        sessionMonitor.start()
-        sessionMonitor.onStop(mockk())
-
-        // WHEN
-        sessionMonitor.onStart(mockk())
-
-        // THEN
-        verify(exactly = 2) { tracker.track(SessionStarted, any(), any()) }
-        verify(exactly = 0) { tracker.track(SessionResumed, any(), any()) }
-    }
-
-    @Test
-    fun `onStart SHOULD generate new session ID WHEN session timeout has expired`() {
-        // GIVEN
-        val tracker: AnalyticsTracker = get()
-        val storage: Storage = get()
-        storage.userId = "userId"
-        val config: AppcuesConfig = get()
-        config.sessionTimeout = -1
-        val sessionMonitor = SessionMonitor(scope)
-        sessionMonitor.start()
-        val sessionId = sessionMonitor.sessionId
-        sessionMonitor.onStop(mockk())
-
-        // WHEN
-        sessionMonitor.onStart(mockk())
-
-        // THEN
-        assertThat(sessionId).isNotNull()
-        assertThat(sessionMonitor.sessionId).isNotNull()
-        assertThat(sessionId).isNotEqualTo(sessionMonitor.sessionId)
-    }
-
-    @Test
-    fun `checkSession SHOULD log and return false WHEN there is no active session`() {
-        // GIVEN
-        val logcues: Logcues = get()
-        val sessionMonitor = SessionMonitor(scope)
-
-        // WHEN
-        val result = sessionMonitor.checkSession("test message")
-
-        // THEN
-        verify { logcues.info(any()) }
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `checkSession SHOULD return true WHEN there is an active session`() {
-        // GIVEN
-        val sessionMonitor = SessionMonitor(scope)
-        val storage: Storage = get()
-        storage.userId = "userId"
-        sessionMonitor.start()
-
-        // WHEN
-        val result = sessionMonitor.checkSession("test message")
-
-        // THEN
-        assertThat(result).isTrue()
     }
 }

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSourceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSourceTest.kt
@@ -35,7 +35,6 @@ internal class RetrofitAppcuesRemoteSourceTest {
             service = appcuesService,
             config = config,
             storage = storage,
-            sessionMonitor = sessionMonitor,
         )
     }
 
@@ -58,9 +57,9 @@ internal class RetrofitAppcuesRemoteSourceTest {
     }
 
     @Test
-    fun `getExperiencePreview SHOULD add Bearer token auth WHEN userSignature is not null AND session is active`() = runTest {
+    fun `getExperiencePreview SHOULD add Bearer token auth WHEN userSignature is not null AND userId exists`() = runTest {
         // Given
-        every { sessionMonitor.isActive } returns true
+        // userId set in storage in setUp()
 
         // When
         retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", "abc")
@@ -70,28 +69,15 @@ internal class RetrofitAppcuesRemoteSourceTest {
     }
 
     @Test
-    fun `getExperiencePreview SHOULD NOT add Bearer token auth WHEN userSignature is null AND session is active`() = runTest {
+    fun `getExperiencePreview SHOULD NOT add Bearer token auth WHEN userSignature is null AND userId exists`() = runTest {
         // Given
-        every { sessionMonitor.isActive } returns true
+        // userId set in storage in setUp()
 
         // When
         retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", null)
 
         // Then
         coVerify { appcuesService.experiencePreview("123", "test-user", "test-experience", null) }
-    }
-
-    @Test
-    fun `getExperiencePreview SHOULD NOT add Bearer token auth WHEN userSignature is not null AND session is not active`() = runTest {
-        // Given
-        every { sessionMonitor.isActive } returns false
-
-        // When
-        retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", "abc")
-
-        // Then
-        coVerify { appcuesService.experiencePreview("123", "test-experience") }
-        coVerify(exactly = 0) { appcuesService.experiencePreview("123", any(), "test-experience", "Bearer abc") }
     }
 
     @Test


### PR DESCRIPTION
At a high level: remove session events for suspend/resume/reset - only track `session_start`. Update the timeout default to 300 sec (was 1800), and check for timeout after any period of analytics inactivity, regardless of app background/foreground. No longer track background/foreground at all effectively.

`AnalyticsTracker` now completely owns the session management. On any attempt to track any analytics, it will (A) check if any session exists and (B) check if that session is expired. In either case, it will try to restart a new session. This can fail if there is no user identified. Session starts are thus completely based on some initial analytic being tracked (commonly the user identify at start), and the session duration depends on continued tracking with no period of inactivity longer than the timeout. There are no other session start calls made from outside of `AnalyticsTracker` (removed the Appcues.kt usage).

This ended up having some more layers than expected. The session event data was tied into the Debugger UI display (using reset events to refresh some things), and the unit tests had many spots that needed to be revised to fit the new / simpler paradigm.