### PR TITLE
✨ Preview for embeds

### DIFF
--- a/appcues/src/main/java/com/appcues/data/model/RenderContext.kt
+++ b/appcues/src/main/java/com/appcues/data/model/RenderContext.kt
@@ -1,6 +1,16 @@
 package com.appcues.data.model
 
+import com.appcues.data.model.RenderContext.Embed
+import com.appcues.data.model.RenderContext.Modal
+
 internal sealed class RenderContext {
     data class Embed(val frameId: String) : RenderContext()
     object Modal : RenderContext()
+}
+
+internal fun RenderContext.getFrameId(): String {
+    return when (this) {
+        is Embed -> frameId
+        Modal -> String()
+    }
 }

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -2,6 +2,10 @@
 <resources>
     <!-- SDK -->
     <string name="appcues_skippable_trait_dismiss">dismiss</string>
+    <string name="appcues_preview_embed_message">Please navigate to the screen with frame %1$s to preview %2$s.</string>
+    <string name="appcues_preview_flow_not_found">Mobile flow not found.</string>
+    <string name="appcues_preview_flow_failed">Mobile flow preview failed.</string>
+    <string name="appcues_preview_flow_failed_reason">Preview of %1$s failed: %2$s</string>
 
     <!-- Debugger Fab -->
     <string name="appcues_debugger_fab_on_debugger_click_label">Appcues debugger details</string>
@@ -46,7 +50,7 @@
     <string name="appcues_debugger_recent_events_filter_screen">Screen</string>
     <string name="appcues_debugger_recent_events_filter_session">Session</string>
     <string name="appcues_debugger_recent_events_filter_all">All</string>
-    
+
     <string name="appcues_debugger_event_type_group_update_title">Group Update</string>
     <string name="appcues_debugger_event_type_profile_update_title">Profile Update</string>
 

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -93,17 +93,17 @@ internal class AppcuesRepositoryTest {
         // WHEN
         val result = repository.getExperiencePreview("1234")
         // THEN
-        assertThat(result).isEqualTo(mappedExperience)
+        assertThat(result).isInstanceOf(Success::class.java)
     }
 
     @Test
-    fun `getExperiencePreview SHOULD return null WHEN appcuesRemoteSource fails`() = runTest {
+    fun `getExperiencePreview SHOULD return PreviewError WHEN appcuesRemoteSource fails`() = runTest {
         // GIVEN
         coEvery { appcuesRemoteSource.getExperiencePreview("1234", any()) } returns Failure(HttpError())
         // WHEN
         val result = repository.getExperiencePreview("1234")
         // THEN
-        assertThat(result).isNull()
+        assertThat(result).isInstanceOf(Failure::class.java)
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -14,6 +14,7 @@ import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.State.Idling
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.StateMachine
+import com.appcues.ui.ExperienceRenderer.RenderingResult
 import com.appcues.util.ResultOf.Success
 import com.google.common.truth.Truth.assertThat
 import io.mockk.Called
@@ -107,7 +108,7 @@ internal class ExperienceRendererTest {
         val showResult = experienceRenderer.show(experience)
 
         // THEN
-        assertThat(showResult).isFalse()
+        assertThat(showResult).isInstanceOf(RenderingResult.WontDisplay::class.java)
         coVerify { stateMachine.handleAction(StartExperience(experience)) wasNot Called }
     }
 
@@ -133,7 +134,7 @@ internal class ExperienceRendererTest {
         val showResult = experienceRenderer.show(experience)
 
         // THEN
-        assertThat(showResult).isTrue()
+        assertThat(showResult).isInstanceOf(RenderingResult.Success::class.java)
         coVerify { stateMachine.handleAction(StartExperience(experience)) }
     }
 

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.1'
 }
 
-task versionTxt()  {
+task versionTxt() {
     doLast {
         new File(projectDir.parentFile.parentFile, "sample_version.txt").text = "$android.defaultConfig.versionCode ($android.defaultConfig.versionName)"
     }


### PR DESCRIPTION
Preview logic for embeds.

storing embeds preview in a different dictionary that is no cleared on new screen event calls. also ensuring it is always using a prestine state machine or else we could get into some scenarios where the state machine doesnt have a view and its not dismissing the existing experience before showing the new previewd one.