### PR TITLE
Update example app embed screen tracking name

### DIFF
--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/EmbedFragment.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/EmbedFragment.kt
@@ -35,7 +35,7 @@ class EmbedFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        appcues.screen("Embed Harness")
+        appcues.screen("Embed Container")
     }
 
     override fun onDestroyView() {

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/MainActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/MainActivity.kt
@@ -70,7 +70,7 @@ class MainActivity : AppCompatActivity() {
                     "events" -> binding.navView.selectedItemId = id.navigation_events
                     "profile" -> binding.navView.selectedItemId = id.navigation_profile
                     "group" -> binding.navView.selectedItemId = id.navigation_group
-                    "embeds" -> binding.navView.selectedItemId = id.navigation_embed
+                    "embed" -> binding.navView.selectedItemId = id.navigation_embed
                 }
             }
         }


### PR DESCRIPTION
`Embed Harness` --> `Embed Container` 

Making this match with [iOS](https://github.com/appcues/appcues-ios-sdk/blob/main/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedViewController.swift#L30) to avoid any test confusion

also using `/embed` instead of `/embeds` for the deep link route, for same reason