### PR TITLE
Add delay loaded button to test element targeting retry

### DIFF
--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/EventsFragment.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/EventsFragment.kt
@@ -9,11 +9,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import com.appcues.samples.kotlin.ExampleApplication
 import com.appcues.samples.kotlin.R
 import com.appcues.samples.kotlin.databinding.FragmentEventsBinding
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class EventsFragment : Fragment() {
 
@@ -38,6 +42,10 @@ class EventsFragment : Fragment() {
 
         binding.buttonEvent2.setOnClickListener {
             appcues.track("event2")
+        }
+
+        binding.buttonEvent3.setOnClickListener {
+            appcues.track("event3")
         }
 
         return binding.root
@@ -69,7 +77,14 @@ class EventsFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
+        binding.buttonEvent3.isVisible = false
         appcues.screen("Trigger Events")
+
+        lifecycleScope.launch {
+            @Suppress("MagicNumber")
+            delay(2_000)
+            binding.buttonEvent3.isVisible = true
+        }
     }
 
     override fun onDestroyView() {

--- a/samples/kotlin-android-app/src/main/res/layout/fragment_events.xml
+++ b/samples/kotlin-android-app/src/main/res/layout/fragment_events.xml
@@ -34,4 +34,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonEvent1" />
 
+    <Button
+        android:id="@+id/buttonEvent3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="24dp"
+        android:contentDescription="@string/content_description_event_3"
+        android:tag="btnEvent3"
+        android:text="@string/trigger_event_3_button"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonEvent2" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/samples/kotlin-android-app/src/main/res/values/strings.xml
+++ b/samples/kotlin-android-app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="fragment_group">Update Group</string>
     <string name="trigger_event_1_button">Trigger Event 1</string>
     <string name="trigger_event_2_button">Trigger Event 2</string>
+    <string name="trigger_event_3_button">Trigger Event 3</string>
     <string name="launch_modal_button">Launch Modal</string>
     <string name="given_name_label">Given Name</string>
     <string name="family_name_label">Family Name</string>
@@ -24,6 +25,7 @@
     <string name="anonymous_user_button">Anonymous User</string>
     <string name="content_description_event_1">Trigger Event 1</string>
     <string name="content_description_event_2">Trigger Event 2</string>
+    <string name="content_description_event_3">Trigger Event 3</string>
     <string name="content_description_save_profile">Save Profile</string>
     <string name="content_description_save_group">Save Group</string>
     <string name="content_description_tab_events">Events Tab</string>


### PR DESCRIPTION
Matching update to iOS proposal here https://github.com/appcues/appcues-ios-sdk/pull/444

Updates sample app to support testing delay loaded elements with element targeted patterns, using a third button on the events page that becomes visible 2 seconds after initial load.

https://github.com/appcues/appcues-android-sdk/assets/19266448/8ccdf3c1-758c-400a-aec5-13cb528cd210

