### PR TITLE
Reset any rendering experiences / state machines on SDK reset

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -176,6 +176,7 @@ public class Appcues internal constructor(koinScope: Scope) {
         storage.isAnonymous = true
         storage.groupId = null
 
+        experienceRenderer.resetAll()
         debuggerManager.reset()
     }
 
@@ -277,7 +278,7 @@ public class Appcues internal constructor(koinScope: Scope) {
     public fun stop() {
         debuggerManager.stop()
         activityScreenTracking.stop()
-        experienceRenderer.stop()
+        experienceRenderer.resetAll()
     }
 
     /**
@@ -300,18 +301,12 @@ public class Appcues internal constructor(koinScope: Scope) {
 
         val mutableProperties = properties?.toMutableMap()
         val userChanged = storage.userId != userId
+        if (userChanged) {
+            reset()
+        }
         storage.userId = userId
         storage.isAnonymous = isAnonymous
         storage.userSignature = mutableProperties?.remove("appcues:user_id_signature") as? String
-        if (userChanged) {
-            // when the user changes, reset the session monitor and a new session will
-            // be created the first time analytics are tracked for the new user (the identify)
-            sessionMonitor.reset()
-
-            // group info is reset on new user
-            storage.groupId = null
-        }
-
         analyticsTracker.identify(mutableProperties)
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -62,13 +62,15 @@ internal class ExperienceLifecycleTracker(
                         }
                     }
                     is EndingExperience -> {
-                        if (it.markComplete) {
-                            // if ending on the last step OR an action requested it be considered complete explicitly,
-                            // track the experience_completed event
-                            trackLifecycleEvent(ExperienceCompleted(it.experience))
-                        } else {
-                            // otherwise its considered experience_dismissed (not completed)
-                            trackLifecycleEvent(ExperienceDismissed(it.experience, it.flatStepIndex))
+                        if (it.trackAnalytics) {
+                            if (it.markComplete) {
+                                // if ending on the last step OR an action requested it be considered complete explicitly,
+                                // track the experience_completed event
+                                trackLifecycleEvent(ExperienceCompleted(it.experience))
+                            } else {
+                                // otherwise its considered experience_dismissed (not completed)
+                                trackLifecycleEvent(ExperienceDismissed(it.experience, it.flatStepIndex))
+                            }
                         }
 
                         onEndedExperience(it.experience)

--- a/appcues/src/main/java/com/appcues/statemachine/Action.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Action.kt
@@ -6,7 +6,11 @@ internal sealed class Action {
     data class StartExperience(val experience: Experience) : Action()
     data class StartStep(val stepReference: StepReference) : Action()
     object RenderStep : Action()
-    data class EndExperience(val markComplete: Boolean, val destroyed: Boolean) : Action()
+    data class EndExperience(
+        val markComplete: Boolean,
+        val destroyed: Boolean,
+        val trackAnalytics: Boolean = true,
+    ) : Action()
     object Reset : Action()
     data class ReportError(val error: Error, val fatal: Boolean) : Action()
 }

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -28,7 +28,12 @@ internal sealed class State {
         val dismissAndContinue: (() -> Unit)?,
     ) : State()
 
-    data class EndingExperience(val experience: Experience, val flatStepIndex: Int, val markComplete: Boolean) : State()
+    data class EndingExperience(
+        val experience: Experience,
+        val flatStepIndex: Int,
+        val markComplete: Boolean,
+        val trackAnalytics: Boolean, // to disable analytics on force stop
+    ) : State()
 
     val currentExperience: Experience?
         get() = when (this) {

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -212,9 +212,19 @@ internal class StateMachine(
         }
     }
 
-    fun stop() {
+    fun stop(dismiss: Boolean) {
         appcuesCoroutineScope.launch {
-            handleAction(EndExperience(markComplete = false, destroyed = true))
+            handleAction(
+                EndExperience(
+                    markComplete = false,
+                    // destroyed means the UI was already dismissed, so invert the dismiss direction passed in
+                    // for this use case - when !destroyed, the state machine will wait on the UI to dismiss and
+                    // signal to move to next step
+                    destroyed = !dismiss,
+                    // special case - no complete/dismiss analytics tracked on a force stop
+                    trackAnalytics = false
+                )
+            )
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transitions.kt
@@ -142,7 +142,9 @@ internal interface Transitions {
     }
 
     fun EndingStep.fromEndingStepToEndingExperience(action: EndExperience): Transition {
-        return Transition(EndingExperience(experience, flatStepIndex, action.markComplete), ContinuationEffect(Reset))
+        return Transition(
+            EndingExperience(experience, flatStepIndex, action.markComplete, action.trackAnalytics), ContinuationEffect(Reset)
+        )
     }
 
     fun EndingStep.fromEndingStepToBeginningStep(

--- a/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
+++ b/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
@@ -8,12 +8,18 @@ import java.lang.ref.WeakReference
 internal interface StateMachineOwning {
     var renderContext: RenderContext?
     var stateMachine: StateMachine?
+    fun reset()
 }
 
 internal class AppcuesFrameStateMachineOwner(frame: AppcuesFrameView) : StateMachineOwning {
     val frame: WeakReference<AppcuesFrameView> = WeakReference(frame)
     override var renderContext: RenderContext? = null
     override var stateMachine: StateMachine? = null
+    override fun reset() {
+        frame.get()?.reset()
+        // do not need to dismiss here, as the frame UI is already removed for embed
+        stateMachine?.stop(false)
+    }
 }
 
 internal class StateMachineDirectory {
@@ -48,9 +54,9 @@ internal class StateMachineDirectory {
         owner.renderContext = context
     }
 
-    fun stop() {
+    fun resetAll() {
         stateMachines.values.forEach {
-            it.stateMachine?.stop()
+            it.reset()
         }
     }
 }

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -271,7 +271,7 @@ internal class AppcuesTest : AppcuesScopeTest {
         // THEN
         verify { debuggerManager.stop() }
         verify { activityScreenTracking.stop() }
-        verify { experienceRenderer.stop() }
+        verify { experienceRenderer.resetAll() }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -656,7 +656,7 @@ internal class StateMachineTest : AppcuesScopeTest {
     fun `EndingExperience SHOULD NOT transition WHEN action is something other than Reset or Pause`() = runTest {
         // GIVEN
         val experience = mockExperience()
-        val initialState = EndingExperience(experience, 1, false)
+        val initialState = EndingExperience(experience, 1, false, true)
         val stateMachine = initMachine(initialState)
         val action = RenderStep
 
@@ -672,7 +672,7 @@ internal class StateMachineTest : AppcuesScopeTest {
     fun `EndingExperience SHOULD call action processor WHEN experience is completed`() = runTest {
         // GIVEN
         val experience = mockExperience()
-        val initialState = EndingExperience(experience, 1, true)
+        val initialState = EndingExperience(experience, 1, true, true)
         val stateMachine = initMachine(initialState)
         val action = Reset
 
@@ -691,7 +691,7 @@ internal class StateMachineTest : AppcuesScopeTest {
     fun `EndingExperience SHOULD NOT call action processor WHEN experience is NOT completed`() = runTest {
         // GIVEN
         val experience = mockExperience()
-        val initialState = EndingExperience(experience, 1, false)
+        val initialState = EndingExperience(experience, 1, false, true)
         val stateMachine = initMachine(initialState)
         val action = Reset
 
@@ -711,7 +711,7 @@ internal class StateMachineTest : AppcuesScopeTest {
         val stateMachine = initMachine(RenderingStep(experience, 2, false))
 
         // WHEN
-        stateMachine.stop()
+        stateMachine.stop(true)
 
         // THEN
         assertThat(stateMachine.state).isEqualTo(Idling)
@@ -733,7 +733,7 @@ internal class StateMachineTest : AppcuesScopeTest {
         )
 
         // WHEN
-        stateMachine.stop()
+        stateMachine.stop(true)
 
         // THEN
         assertThat(completion.await(1.seconds)).isFalse()


### PR DESCRIPTION
Similar to the iOS update here https://github.com/appcues/appcues-ios-sdk/pull/446

`StateMachineOwning` has a `reset()` now which will stop any running state machine and dismiss any current experience in view. This also uses a new capability to end the experience without tracking analytics.

Also, small update in the `Appcues.identify()` to call `reset()` when the user ID changes - to ensure the same flow of events happens whether its a logout/reset or just a re-identify with new user - effectively the same as far as Appcues is concerned.