### PR TITLE
🐛 Removing FillMaxSize from consumeAllTouch

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesFrame.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesFrame.kt
@@ -1,6 +1,5 @@
 package com.appcues
 
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
@@ -11,7 +10,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 @Composable
 public fun AppcuesFrame(modifier: Modifier = Modifier, appcues: Appcues, frameId: String) {
     AndroidView(
-        modifier = modifier.then(Modifier.wrapContentHeight(unbounded = true)),
+        modifier = modifier,
         factory = { context ->
             AppcuesFrameView(context).apply {
                 appcues.registerEmbed(frameId, this)

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -3,7 +3,6 @@ package com.appcues.ui.composables
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -57,10 +56,11 @@ internal fun AppcuesComposition(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun MainSurface() {
     Box(
-        modifier = Modifier.consumeAllTouchEvents(),
+        modifier = Modifier.pointerInteropFilter { false },
         contentAlignment = Alignment.Center
     ) {
         val viewModel = LocalViewModel.current
@@ -86,13 +86,6 @@ private fun MainSurface() {
         }
     }
 }
-
-@OptIn(ExperimentalComposeUiApi::class)
-private fun Modifier.consumeAllTouchEvents(): Modifier = then(
-    Modifier
-        .fillMaxSize()
-        .pointerInteropFilter { false }
-)
 
 @Composable
 private fun BoxScope.ComposeLastRenderingState(state: Rendering) {


### PR DESCRIPTION
Small fix around sizing of AppcuesComposition, specifically targeting embeds