### PR TITLE
Avoid crash in example app for delayed button visibility

### DIFF
--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/EventsFragment.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/EventsFragment.kt
@@ -83,7 +83,9 @@ class EventsFragment : Fragment() {
         lifecycleScope.launch {
             @Suppress("MagicNumber")
             delay(2_000)
-            binding.buttonEvent3.isVisible = true
+            // the view may have been destroyed during the 2 seconds
+            // so do a null safe check on the view binding
+            _binding?.let { it.buttonEvent3.isVisible = true }
         }
     }
 


### PR DESCRIPTION
This is a fix up related to the recent example app change in https://github.com/appcues/appcues-android-sdk/pull/462

I noticed that if you navigate away from the Events tab before the 2 second timer is up, the View may have been destroyed, and the view binding null - which could then lead to a null reference in the coroutine where it is trying to delay show the view.