### PR TITLE
Add embed related experience renderer tests

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -176,8 +176,12 @@ public class Appcues internal constructor(koinScope: Scope) {
         storage.isAnonymous = true
         storage.groupId = null
 
-        experienceRenderer.resetAll()
         debuggerManager.reset()
+
+        appcuesCoroutineScope.launch {
+            // stopping running experiences runs async, as it may require dismissal of UI.
+            experienceRenderer.resetAll()
+        }
     }
 
     /**
@@ -278,7 +282,10 @@ public class Appcues internal constructor(koinScope: Scope) {
     public fun stop() {
         debuggerManager.stop()
         activityScreenTracking.stop()
-        experienceRenderer.resetAll()
+        appcuesCoroutineScope.launch {
+            // stopping running experiences runs async, as it may require dismissal of UI.
+            experienceRenderer.resetAll()
+        }
     }
 
     /**

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -223,19 +223,17 @@ internal class StateMachine(
         }
     }
 
-    fun stop(dismiss: Boolean) {
-        appcuesCoroutineScope.launch {
-            handleAction(
-                EndExperience(
-                    markComplete = false,
-                    // destroyed means the UI was already dismissed, so invert the dismiss direction passed in
-                    // for this use case - when !destroyed, the state machine will wait on the UI to dismiss and
-                    // signal to move to next step
-                    destroyed = !dismiss,
-                    // special case - no complete/dismiss analytics tracked on a force stop
-                    trackAnalytics = false
-                )
+    suspend fun stop(dismiss: Boolean) {
+        handleAction(
+            EndExperience(
+                markComplete = false,
+                // destroyed means the UI was already dismissed, so invert the dismiss direction passed in
+                // for this use case - when !destroyed, the state machine will wait on the UI to dismiss and
+                // signal to move to next step
+                destroyed = !dismiss,
+                // special case - no complete/dismiss analytics tracked on a force stop
+                trackAnalytics = false
             )
-        }
+        )
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -242,14 +242,14 @@ internal class ExperienceRenderer(
             ?: Failure(RenderContextNotActive(renderContext))
     }
 
-    fun resetAll() {
+    suspend fun resetAll() {
         previewExperiences.clear()
         potentiallyRenderableExperiences.clear()
         stateMachines.resetAll()
     }
 
     // Reset only the owned `stateMachine` instance in conformance to `StateMachineOwning`.
-    override fun reset() {
+    override suspend fun reset() {
         stateMachine?.stop(true)
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
+++ b/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
@@ -8,14 +8,14 @@ import java.lang.ref.WeakReference
 internal interface StateMachineOwning {
     var renderContext: RenderContext?
     var stateMachine: StateMachine?
-    fun reset()
+    suspend fun reset()
 }
 
 internal class AppcuesFrameStateMachineOwner(frame: AppcuesFrameView) : StateMachineOwning {
     val frame: WeakReference<AppcuesFrameView> = WeakReference(frame)
     override var renderContext: RenderContext? = null
     override var stateMachine: StateMachine? = null
-    override fun reset() {
+    override suspend fun reset() {
         frame.get()?.reset()
         // do not need to dismiss here, as the frame UI is already removed for embed
         stateMachine?.stop(false)
@@ -54,7 +54,7 @@ internal class StateMachineDirectory {
         owner.renderContext = context
     }
 
-    fun resetAll() {
+    suspend fun resetAll() {
         stateMachines.values.forEach {
             it.reset()
         }

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -271,7 +271,7 @@ internal class AppcuesTest : AppcuesScopeTest {
         // THEN
         verify { debuggerManager.stop() }
         verify { activityScreenTracking.stop() }
-        verify { experienceRenderer.resetAll() }
+        coVerify { experienceRenderer.resetAll() }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -7,6 +7,7 @@ import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
 import com.appcues.data.model.ExperiencePriority.LOW
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.model.ExperienceTrigger.ShowCall
 import com.appcues.data.model.Experiment
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.Step
@@ -21,7 +22,7 @@ internal fun mockPresentingTrait(onPresent: (() -> Unit)? = null): PresentingTra
 }
 
 // an experience with a group having 3 steps, then a single step group
-internal fun mockExperience(onPresent: (() -> Unit)? = null) =
+internal fun mockExperience(trigger: ExperienceTrigger = ShowCall, onPresent: (() -> Unit)? = null) =
     Experience(
         id = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
         name = "Mock Experience",
@@ -56,7 +57,7 @@ internal fun mockExperience(onPresent: (() -> Unit)? = null) =
         publishedAt = 1652895835000,
         experiment = null,
         completionActions = arrayListOf(TrackEventAction(hashMapOf(), appcues = mockk(relaxed = true))),
-        trigger = ExperienceTrigger.ShowCall,
+        trigger = trigger,
     )
 
 internal fun mockStep(id: UUID) =
@@ -98,6 +99,32 @@ internal fun mockExperienceExperiment(experiment: Experiment) =
         experiment = experiment,
         completionActions = emptyList(),
         trigger = ExperienceTrigger.ShowCall,
+    )
+
+internal fun mockEmbedExperiment(frameId: String, onPresent: (() -> Unit)? = null) =
+    Experience(
+        id = UUID.fromString("15d713ce-5a8f-42d0-9f2c-85b6f1327f45"),
+        name = "Mock Embed Experience",
+        type = "mobile",
+        renderContext = RenderContext.Embed(frameId),
+        stepContainers = listOf(
+            StepContainer(
+                id = UUID.fromString("60b49c12-c49b-47ac-8ed3-ba4e9a55e694"),
+                steps = listOf(
+                    mockStep(UUID.fromString("01d8a05a-3a55-4ecc-872d-d140cd628902")),
+                ),
+                presentingTrait = mockPresentingTrait(onPresent),
+                contentHolderTrait = mockk(relaxed = true),
+                contentWrappingTrait = mockk(relaxed = true),
+                actions = emptyMap(),
+            )
+        ),
+        published = true,
+        priority = NORMAL,
+        publishedAt = 1652895835000,
+        experiment = null,
+        completionActions = emptyList(),
+        trigger = ExperienceTrigger.Qualification("screen_view"),
     )
 
 // An experience with two step containers, each with one step. The given list of actions are applied to both


### PR DESCRIPTION
Wrote some tests to validate the basic behaviors around embed registration / qualification / rendering.

Also, proposing a change here to make `StateMachineOwning` use a `suspend` function for `reset()` - why? I believe I've discovered that if a frame is re-registered rapidly, you could have a situation where the previous state machine usage is still dismissing - an async behavior that could require some dismissal of UI, while the new render is attempting to start. I think this could lead to an edge case of rendering issues where one experience cannot start while the other is ending. I think it is safest to have the caller wait on the `reset()`, rather than having it spawn its own internal coroutine, then continue with the new render attempt.