### PR TITLE
Ensure that all screen view responses clear the embed cache

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsQueueProcessor.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsQueueProcessor.kt
@@ -104,13 +104,15 @@ internal class AnalyticsQueueProcessor(
         appcuesCoroutineScope.launch {
             // this will respond with qualified experiences, if applicable
             repository.trackActivity(activity).also {
-                // we will try to show an experience from this list
-                if (it.isNotEmpty()) {
-                    experienceRenderer.show(it)
-                } else {
-                    // we know we are not rendering any experiences, so no metrics needed
-                    // can proactively clear this request out
-                    SdkMetrics.remove(activity.requestId)
+                it?.let { qualificationResult ->
+                    // we will try to show experience from this list
+                    experienceRenderer.show(qualificationResult)
+
+                    if (qualificationResult.experiences.isEmpty()) {
+                        // we know we are not rendering any experiences, so no metrics needed
+                        // can proactively clear this request out
+                        SdkMetrics.remove(activity.requestId)
+                    }
                 }
             }
         }

--- a/appcues/src/main/java/com/appcues/data/model/QualificationResult.kt
+++ b/appcues/src/main/java/com/appcues/data/model/QualificationResult.kt
@@ -1,0 +1,8 @@
+package com.appcues.data.model
+
+import com.appcues.data.model.ExperienceTrigger.Qualification
+
+internal data class QualificationResult(
+    val trigger: Qualification,
+    val experiences: List<Experience>
+)

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -10,7 +10,7 @@ import com.appcues.data.AppcuesRepository
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceTrigger
-import com.appcues.data.model.ExperienceTrigger.Qualification
+import com.appcues.data.model.QualificationResult
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.RenderContext.Modal
 import com.appcues.data.model.getFrameId
@@ -129,17 +129,15 @@ internal class ExperienceRenderer(
         return newExperience.priority == NORMAL && state != Idling
     }
 
-    suspend fun show(experiences: List<Experience>) {
-        val trigger = experiences.firstOrNull()?.trigger
-
-        if (trigger is Qualification && trigger.reason == "screen_view") {
+    suspend fun show(qualificationResult: QualificationResult) {
+        if (qualificationResult.trigger.reason == "screen_view") {
             // clear list in case this was a screen_view qualification
             potentiallyRenderableExperiences.clear()
             stateMachines.cleanup()
         }
 
         // Add new experiences, replacing any existing ones
-        potentiallyRenderableExperiences.putAll(experiences.groupBy { it.renderContext })
+        potentiallyRenderableExperiences.putAll(qualificationResult.experiences.groupBy { it.renderContext })
 
         // make a copy while we try to show them, so anything else editing the
         // main mapping won't hit a concurrent modification exception

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -128,8 +128,8 @@ internal class AppcuesRepositoryTest {
         // THEN
         coVerify { appcuesLocalSource.saveActivity(any()) }
         coVerify { appcuesRemoteSource.qualify("userId", any(), request.requestId, any()) }
-        assertThat(result.count()).isEqualTo(2)
-        assertThat(result.first()).isEqualTo(mappedExperience)
+        assertThat(result?.experiences?.count()).isEqualTo(2)
+        assertThat(result?.experiences?.first()).isEqualTo(mappedExperience)
         coVerify { appcuesLocalSource.removeActivity(any()) }
     }
 

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -22,7 +22,7 @@ internal fun mockPresentingTrait(onPresent: (() -> Unit)? = null): PresentingTra
 }
 
 // an experience with a group having 3 steps, then a single step group
-internal fun mockExperience(trigger: ExperienceTrigger = ShowCall, onPresent: (() -> Unit)? = null) =
+internal fun mockExperience(onPresent: (() -> Unit)? = null) =
     Experience(
         id = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
         name = "Mock Experience",
@@ -57,7 +57,7 @@ internal fun mockExperience(trigger: ExperienceTrigger = ShowCall, onPresent: ((
         publishedAt = 1652895835000,
         experiment = null,
         completionActions = arrayListOf(TrackEventAction(hashMapOf(), appcues = mockk(relaxed = true))),
-        trigger = trigger,
+        trigger = ShowCall,
     )
 
 internal fun mockStep(id: UUID) =

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -6,13 +6,9 @@ import com.appcues.analytics.AnalyticsTracker
 import com.appcues.analytics.ExperienceLifecycleTracker
 import com.appcues.analytics.track
 import com.appcues.data.model.Experience
-import com.appcues.data.model.ExperienceTrigger.DeepLink
-import com.appcues.data.model.ExperienceTrigger.ExperienceCompletionAction
-import com.appcues.data.model.ExperienceTrigger.LaunchExperienceAction
-import com.appcues.data.model.ExperienceTrigger.Preview
 import com.appcues.data.model.ExperienceTrigger.Qualification
-import com.appcues.data.model.ExperienceTrigger.ShowCall
 import com.appcues.data.model.Experiment
+import com.appcues.data.model.QualificationResult
 import com.appcues.data.model.RenderContext
 import com.appcues.mocks.mockEmbedExperience
 import com.appcues.mocks.mockExperience
@@ -215,7 +211,7 @@ internal class ExperienceRendererTest {
         experienceRenderer.start(owner, context)
 
         // WHEN
-        experienceRenderer.show(listOf(experience))
+        experienceRenderer.show(QualificationResult(Qualification("screen_view"), listOf(experience)))
 
         // THEN
         coVerify { stateMachine.handleAction(StartExperience(experience)) }
@@ -234,7 +230,7 @@ internal class ExperienceRendererTest {
         val experienceRenderer = ExperienceRenderer(scope)
         val owner = AppcuesFrameStateMachineOwner(mockk(relaxed = true))
         val context = RenderContext.Embed("frame1")
-        experienceRenderer.show(listOf(experience))
+        experienceRenderer.show(QualificationResult(Qualification("screen_view"), listOf(experience)))
 
         // WHEN
         experienceRenderer.start(owner, context)
@@ -273,16 +269,12 @@ internal class ExperienceRendererTest {
         val experienceRenderer = ExperienceRenderer(scope)
         val owner = AppcuesFrameStateMachineOwner(mockk(relaxed = true))
         val context = RenderContext.Embed("frame1")
-        experienceRenderer.show(listOf(experience))
+        experienceRenderer.show(QualificationResult(Qualification("screen_view"), listOf(experience)))
 
         // WHEN
         // all of these will process through but the embed will remain in cache and still start after this
-        experienceRenderer.show(listOf(mockExperience(trigger = Qualification("event_trigger"))))
-        experienceRenderer.show(listOf(mockExperience(trigger = ShowCall)))
-        experienceRenderer.show(listOf(mockExperience(trigger = Preview)))
-        experienceRenderer.show(listOf(mockExperience(trigger = DeepLink)))
-        experienceRenderer.show(listOf(mockExperience(trigger = LaunchExperienceAction(UUID.randomUUID()))))
-        experienceRenderer.show(listOf(mockExperience(trigger = ExperienceCompletionAction(UUID.randomUUID()))))
+        experienceRenderer.show(QualificationResult(Qualification("event_trigger"), listOf()))
+        experienceRenderer.show(QualificationResult(Qualification("unknown_value"), listOf()))
 
         experienceRenderer.start(owner, context)
 
@@ -302,10 +294,10 @@ internal class ExperienceRendererTest {
         val experienceRenderer = ExperienceRenderer(scope)
         val owner = AppcuesFrameStateMachineOwner(mockk(relaxed = true))
         val context = RenderContext.Embed("frame1")
-        experienceRenderer.show(listOf(experience))
+        experienceRenderer.show(QualificationResult(Qualification("screen_view"), listOf(experience)))
 
         // WHEN
-        experienceRenderer.show(listOf(mockExperience(trigger = Qualification("screen_view"))))
+        experienceRenderer.show(QualificationResult(Qualification("screen_view"), listOf()))
         experienceRenderer.start(owner, context)
 
         // THEN
@@ -327,7 +319,7 @@ internal class ExperienceRendererTest {
             every { this@mockk.stateMachine } answers { stateMachine }
         }
         val context = RenderContext.Embed("frame1")
-        experienceRenderer.show(listOf(experience))
+        experienceRenderer.show(QualificationResult(Qualification("screen_view"), listOf(experience)))
 
         // WHEN
         experienceRenderer.start(owner, context)


### PR DESCRIPTION
...not just those with qualified experiences

The lower level code now returns a `QualificationResult`, instead of just `List<Experiences>`. This result can have an empty list of experiences, but will always communicate the qualification reason from the most recent response - so that the `ExperienceRenderer` can use that to determine cache behavior. This reason is passed in on all responses now, not just those with non-zero qualified experiences. The passed in value is used rather than relying on the value from the first qualified experience (which may not always exist).

This is adding the same handling as noted in the iOS [todo](https://github.com/appcues/appcues-ios-sdk/pull/416#discussion_r1232330446) here, and then in the update [here](https://github.com/appcues/appcues-ios-sdk/pull/419).

