### PR TITLE
🐛 Passing activity context instead of Generic context

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -23,6 +23,7 @@ import com.appcues.di.AppcuesKoinContext
 import com.appcues.logging.Logcues
 import com.appcues.ui.composables.AppcuesActionsDelegate
 import com.appcues.ui.composables.ComposeContainer
+import com.appcues.ui.composables.ExperienceCompositionState
 import com.appcues.ui.composables.LocalAppcuesActionDelegate
 import com.appcues.ui.composables.LocalExperienceCompositionState
 import com.appcues.ui.composables.LocalExperienceStepFormStateDelegate
@@ -44,7 +45,8 @@ public fun ComposeContent(json: String, imageLoader: ImageLoader) {
             LocalImageLoader provides imageLoader,
             LocalLogcues provides Logcues(LoggingLevel.DEBUG),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
-            LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate()
+            LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
+            LocalExperienceCompositionState provides ExperienceCompositionState(),
         ) {
             primitive.Compose()
         }
@@ -97,19 +99,20 @@ public fun ComposeContainer(context: Context, stepContentJson: List<String>?, tr
     val experience = experienceMapper.map(updatedExperienceResponse, ExperienceTrigger.Preview)
     val container = experience.stepContainers[0]
 
-    // render the step container on the desired step
-    LocalExperienceCompositionState.current.let {
-        it.isContentVisible.targetState = true // so animated visibility works
-        it.isBackdropVisible.targetState = true // so animated visibility works
-    }
-
     AppcuesTheme {
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
             LocalLogcues provides Logcues(LoggingLevel.DEBUG),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
-            LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate()
+            LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
+            LocalExperienceCompositionState provides ExperienceCompositionState()
         ) {
+            // render the step container on the desired step
+            LocalExperienceCompositionState.current.let {
+                it.isContentVisible.targetState = true // so animated visibility works
+                it.isBackdropVisible.targetState = true // so animated visibility works
+            }
+
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center

--- a/appcues/src/main/java/com/appcues/ui/presentation/EmbedViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/EmbedViewPresenter.kt
@@ -1,5 +1,6 @@
 package com.appcues.ui.presentation
 
+import android.app.Activity
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.isVisible
@@ -15,7 +16,7 @@ internal class EmbedViewPresenter(
     private val stateMachines: StateMachineDirectory,
 ) : ViewPresenter(scope, renderContext) {
 
-    override fun ViewGroup.setupView(): ComposeView? {
+    override fun ViewGroup.setupView(activity: Activity): ComposeView? {
         return stateMachines.getFrame(renderContext)?.setupComposeView()
     }
 

--- a/appcues/src/main/java/com/appcues/ui/presentation/OverlayViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/OverlayViewPresenter.kt
@@ -18,13 +18,13 @@ import org.koin.core.scope.Scope
 
 internal class OverlayViewPresenter(scope: Scope, renderContext: RenderContext) : ViewPresenter(scope, renderContext) {
 
-    override fun ViewGroup.setupView(): ComposeView {
+    override fun ViewGroup.setupView(activity: Activity): ComposeView {
         // remove customers view on accessibility stack
         setAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
 
         val overlayView = if (findViewById<View>(R.id.appcues_overlay_view) == null) {
             // create and add the view
-            AppcuesOverlayView(context).apply {
+            AppcuesOverlayView(activity).apply {
                 id = R.id.appcues_overlay_view
                 layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT).also {
                     // adds margin top and bottom according to visible status and navigation bar

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -50,7 +50,7 @@ internal abstract class ViewPresenter(
 
         activity.getParentView().run {
             // grab composeView or exit with false
-            val composeView = setupView() ?: return false
+            val composeView = setupView(activity) ?: return false
 
             viewModel = AppcuesViewModel(scope, renderContext, ::onCompositionDismiss, ::setViewVisible)
             gestureListener = ShakeGestureListener(activity)
@@ -84,7 +84,7 @@ internal abstract class ViewPresenter(
         }
     }
 
-    abstract fun ViewGroup.setupView(): ComposeView?
+    abstract fun ViewGroup.setupView(activity: Activity): ComposeView?
 
     abstract fun ViewGroup.removeView()
 


### PR DESCRIPTION
small change to pass in the correct Context so that Shot tests can capture screen properly