### PR TITLE
Handle preview refresh in the view presenter

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -24,8 +24,6 @@ import com.appcues.trait.ContentHolderTrait.ContainerPages
 import com.appcues.trait.MetadataSettingTrait
 import com.appcues.ui.presentation.AppcuesViewModel
 import com.appcues.ui.presentation.AppcuesViewModel.UIState.Dismissing
-import com.appcues.ui.presentation.AppcuesViewModel.UIState.Rendering
-import com.appcues.ui.presentation.ShakeGestureListener
 import com.appcues.ui.theme.AppcuesTheme
 import com.google.accompanist.web.AccompanistWebChromeClient
 import kotlinx.coroutines.delay
@@ -33,7 +31,6 @@ import kotlinx.coroutines.delay
 @Composable
 internal fun AppcuesComposition(
     viewModel: AppcuesViewModel,
-    shakeGestureListener: ShakeGestureListener,
     logcues: Logcues,
     chromeClient: AccompanistWebChromeClient,
 ) {
@@ -42,7 +39,6 @@ internal fun AppcuesComposition(
         // define composition local provided dependencies
         CompositionLocalProvider(
             LocalViewModel provides viewModel,
-            LocalShakeGestureListener provides shakeGestureListener,
             LocalLogcues provides logcues,
             LocalChromeClient provides chromeClient,
             LocalAppcuesActionDelegate provides DefaultAppcuesActionsDelegate(viewModel),
@@ -69,7 +65,7 @@ private fun MainSurface() {
             // update last rendering state based on new state
             rememberLastRenderingState(state).run {
                 // render last known rendering state
-                value?.let { ComposeLastRenderingState(it) }
+                value?.let { ComposeContainer(it.stepContainer, it.position) }
             }
 
             LaunchOnShowAnimationCompleted {
@@ -85,22 +81,6 @@ private fun MainSurface() {
             }
         }
     }
-}
-
-@Composable
-private fun BoxScope.ComposeLastRenderingState(state: Rendering) {
-    val shakeGestureListener = LocalShakeGestureListener.current
-    val viewModel = LocalViewModel.current
-
-    LaunchedEffect(state.isPreview) {
-        if (state.isPreview) {
-            shakeGestureListener.addListener(true) { viewModel.refreshPreview() }
-        } else {
-            shakeGestureListener.clearListener()
-        }
-    }
-
-    ComposeContainer(state.stepContainer, state.position)
 }
 
 private suspend fun produceMetadata(

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -11,7 +11,6 @@ import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.logging.Logcues
 import com.appcues.trait.AppcuesTraitException
 import com.appcues.ui.presentation.AppcuesViewModel
-import com.appcues.ui.presentation.ShakeGestureListener
 import com.google.accompanist.web.AccompanistWebChromeClient
 import java.util.UUID
 
@@ -49,10 +48,6 @@ internal val LocalAppcuesPaginationDelegate = compositionLocalOf { AppcuesPagina
 internal data class AppcuesPagination(val onPageChanged: (Int) -> Unit)
 
 internal val LocalViewModel = staticCompositionLocalOf<AppcuesViewModel> { noLocalProvidedFor("AppcuesViewModel") }
-
-internal val LocalShakeGestureListener = staticCompositionLocalOf<ShakeGestureListener> {
-    noLocalProvidedFor("ShakeGestureListener")
-}
 
 internal val LocalLogcues = staticCompositionLocalOf<Logcues> { noLocalProvidedFor("LocalLogcues") }
 

--- a/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
@@ -224,15 +224,4 @@ internal class AppcuesViewModel(
     fun dismiss() {
         onDismiss()
     }
-
-    fun refreshPreview() {
-        uiState.value.let { state ->
-            // if current state IS Rendering and we are Previewing then we refresh
-            if (state is Rendering && state.isPreview) {
-                appcuesCoroutineScope.launch {
-                    experienceRenderer.preview(state.experience.id.toString())
-                }
-            }
-        }
-    }
 }

--- a/appcues/src/main/java/com/appcues/ui/theme/AppcuesTheme.kt
+++ b/appcues/src/main/java/com/appcues/ui/theme/AppcuesTheme.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.appcues.LoggingLevel.NONE
 import com.appcues.action.ExperienceAction
@@ -24,8 +23,6 @@ import com.appcues.logging.Logcues
 import com.appcues.ui.composables.AppcuesActionsDelegate
 import com.appcues.ui.composables.LocalAppcuesActionDelegate
 import com.appcues.ui.composables.LocalLogcues
-import com.appcues.ui.composables.LocalShakeGestureListener
-import com.appcues.ui.presentation.ShakeGestureListener
 import com.appcues.ui.primitive.Compose
 
 /**
@@ -68,11 +65,9 @@ internal fun AppcuesPreviewPrimitive(
     primitiveBuilder: () -> ExperiencePrimitive
 ) {
     LocalConfiguration.current.uiMode = if (isDark) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
-    val context = LocalContext.current
 
     AppcuesTheme {
         CompositionLocalProvider(
-            LocalShakeGestureListener provides ShakeGestureListener(context),
             LocalLogcues provides Logcues(NONE),
             LocalAppcuesActionDelegate provides PreviewAppcuesActionDelegate(),
         ) {


### PR DESCRIPTION
This change moves the handling of shake/refresh to the `ViewPresenter` - removing/simplifying the previous usage in the `AppcuesViewModel` and `AppcuesComposition`. This also fixes the shake to refresh issue seen previously.