### PR TITLE
State machine updates/simplifications to handle rendering issues

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -98,6 +98,8 @@ public fun ComposeContainer(context: Context, stepContentJson: List<String>?, tr
     val experienceMapper: ExperienceMapper = scope.get()
     val experience = experienceMapper.map(updatedExperienceResponse, ExperienceTrigger.Preview)
     val container = experience.stepContainers[0]
+    val metadataSettingTraits = container.steps[0].metadataSettingTraits
+    val metadata = hashMapOf<String, Any?>().apply { metadataSettingTraits.forEach { putAll(it.produceMetadata()) } }
 
     AppcuesTheme {
         CompositionLocalProvider(
@@ -117,7 +119,7 @@ public fun ComposeContainer(context: Context, stepContentJson: List<String>?, tr
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
-                ComposeContainer(container, 0)
+                ComposeContainer(container, 0, metadata)
             }
         }
     }

--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -17,7 +17,6 @@ import com.appcues.logging.Logcues
 import com.appcues.trait.ExperienceTrait
 import com.appcues.trait.ExperienceTraitLevel
 import com.appcues.trait.TraitRegistry
-import com.appcues.ui.AppcuesFrameStateMachineOwner
 import com.appcues.ui.ExperienceRenderer
 import kotlinx.coroutines.launch
 import org.koin.core.scope.Scope
@@ -252,7 +251,7 @@ public class Appcues internal constructor(koinScope: Scope) {
      */
     public fun registerEmbed(frameId: String, frame: AppcuesFrameView) {
         appcuesCoroutineScope.launch {
-            experienceRenderer.start(AppcuesFrameStateMachineOwner(frame), RenderContext.Embed(frameId))
+            experienceRenderer.start(frame, RenderContext.Embed(frameId))
         }
     }
 

--- a/appcues/src/main/java/com/appcues/statemachine/BeginningStepExt.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/BeginningStepExt.kt
@@ -24,9 +24,12 @@ internal suspend fun BeginningStep.presentContainer(
         produceMetadataWithRetry()
 
         // kick off UI
-        presentingTrait()?.present()
-
-        RenderStep
+        presentingTrait()?.run {
+            present()
+            RenderStep
+        } ?: ReportError(toStepError(AppcuesTraitException("Unable to present step $flatStepIndex")), true)
+        // the exception above would only happen if the step index was not a valid step in the experience and
+        // we could not find the group for that step - should never really happen
     } catch (exception: AppcuesTraitException) {
         ReportError(toStepError(exception), true)
     }

--- a/appcues/src/main/java/com/appcues/statemachine/BeginningStepExt.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/BeginningStepExt.kt
@@ -1,0 +1,81 @@
+package com.appcues.statemachine
+
+import com.appcues.action.ActionProcessor
+import com.appcues.action.ExperienceAction
+import com.appcues.statemachine.Action.RenderStep
+import com.appcues.statemachine.Action.ReportError
+import com.appcues.statemachine.Error.StepError
+import com.appcues.statemachine.State.BeginningStep
+import com.appcues.trait.AppcuesTraitException
+import com.appcues.trait.MetadataSettingTrait
+import com.appcues.trait.PresentingTrait
+import kotlinx.coroutines.delay
+
+internal suspend fun BeginningStep.presentContainer(
+    actionProcessor: ActionProcessor,
+    actions: List<ExperienceAction>,
+): Action {
+    // first, process any pre-step actions that need to be handled before the container is presented.
+    // for example - navigating to another screen in the app
+    actionProcessor.process(actions)
+
+    return try {
+        // this could throw an exception on trait failure, handled below
+        produceMetadataWithRetry()
+
+        // kick off UI
+        presentingTrait()?.present()
+
+        RenderStep
+    } catch (exception: AppcuesTraitException) {
+        ReportError(toStepError(exception), true)
+    }
+}
+
+internal fun BeginningStep.presentingTrait(): PresentingTrait? {
+    return experience.groupLookup[flatStepIndex]?.let { experience.stepContainers[it].presentingTrait }
+}
+
+internal fun BeginningStep.toStepError(exception: AppcuesTraitException): StepError {
+    return StepError(
+        experience = experience,
+        stepIndex = flatStepIndex,
+        message = exception.message ?: "Unable to render step $flatStepIndex"
+    )
+}
+
+internal fun BeginningStep.produceMetadata() {
+    metadata = hashMapOf<String, Any?>().apply { metadataSettingsTraits().forEach { putAll(it.produceMetadata()) } }
+}
+
+private suspend fun BeginningStep.produceMetadataWithRetry() {
+    return try {
+        metadata = hashMapOf<String, Any?>().apply { metadataSettingsTraits().forEach { putAll(it.produceMetadata()) } }
+    } catch (ex: AppcuesTraitException) {
+        if (ex.retryMilliseconds != null) {
+            delay(ex.retryMilliseconds.toLong())
+            produceMetadataWithRetry()
+        } else {
+            throw ex
+        }
+    }
+}
+
+private fun BeginningStep.metadataSettingsTraits(): List<MetadataSettingTrait> {
+    return with(experience) {
+        // find the container index
+        val containerId = groupLookup[flatStepIndex]
+        // find the step index in relation to the container
+        val stepIndexInContainer = stepIndexLookup[flatStepIndex]
+        // if both are valid ids we return Rendering else null
+        if (containerId != null && stepIndexInContainer != null) {
+            val container = stepContainers[containerId]
+            val step = container.steps[stepIndexInContainer]
+            // this will throw if metadata fails
+            step.metadataSettingTraits
+        } else {
+            // should be impossible at this point, but will cover with an exception as well
+            throw AppcuesTraitException("Invalid step index $flatStepIndex")
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
@@ -9,8 +9,10 @@ internal sealed class SideEffect {
     data class ContinuationEffect(val action: Action) : SideEffect()
     data class PresentContainerEffect(
         val experience: Experience,
+        val flatStepIndex: Int,
         val containerIndex: Int,
         val actions: List<ExperienceAction>,
+        val produceMetadata: suspend () -> Unit,
     ) : SideEffect()
 
     data class ReportErrorEffect(val error: Error) : SideEffect()

--- a/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
@@ -1,18 +1,19 @@
 package com.appcues.statemachine
 
+import com.appcues.action.ActionProcessor
 import com.appcues.action.ExperienceAction
-import com.appcues.data.model.Experience
 import com.appcues.util.ResultOf
 import kotlinx.coroutines.CompletableDeferred
 
 internal sealed class SideEffect {
     data class ContinuationEffect(val action: Action) : SideEffect()
     data class PresentContainerEffect(
-        val experience: Experience,
-        val flatStepIndex: Int,
-        val containerIndex: Int,
-        val actions: List<ExperienceAction>,
-        val produceMetadata: suspend () -> Unit,
+        val presentContainer: suspend (ActionProcessor) -> Action
+//        val experience: Experience,
+//        val flatStepIndex: Int,
+//        val containerIndex: Int,
+//        val actions: List<ExperienceAction>,
+//        val produceMetadata: suspend () -> Unit,
     ) : SideEffect()
 
     data class ReportErrorEffect(val error: Error) : SideEffect()

--- a/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
@@ -7,15 +7,7 @@ import kotlinx.coroutines.CompletableDeferred
 
 internal sealed class SideEffect {
     data class ContinuationEffect(val action: Action) : SideEffect()
-    data class PresentContainerEffect(
-        val presentContainer: suspend (ActionProcessor) -> Action
-//        val experience: Experience,
-//        val flatStepIndex: Int,
-//        val containerIndex: Int,
-//        val actions: List<ExperienceAction>,
-//        val produceMetadata: suspend () -> Unit,
-    ) : SideEffect()
-
+    data class PresentContainerEffect(val presentContainer: suspend (ActionProcessor) -> Action) : SideEffect()
     data class ReportErrorEffect(val error: Error) : SideEffect()
     data class AwaitEffect(val completion: CompletableDeferred<ResultOf<State, Error>>) : SideEffect()
     data class ProcessActions(val actions: List<ExperienceAction>) : SideEffect()

--- a/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
@@ -10,7 +10,6 @@ internal sealed class SideEffect {
     data class PresentContainerEffect(
         val experience: Experience,
         val containerIndex: Int,
-        val completion: CompletableDeferred<ResultOf<State, Error>>,
         val actions: List<ExperienceAction>,
     ) : SideEffect()
 

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -1,7 +1,6 @@
 package com.appcues.statemachine
 
 import com.appcues.data.model.Experience
-import com.appcues.util.ResultOf
 
 internal sealed class State {
 
@@ -11,6 +10,7 @@ internal sealed class State {
         val experience: Experience,
         val flatStepIndex: Int,
         val isFirst: Boolean,
+        var metadata: Map<String, Any?> = hashMapOf(),
     ) : State()
 
     data class RenderingStep(val experience: Experience, val flatStepIndex: Int, val isFirst: Boolean) : State()

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -11,9 +11,6 @@ internal sealed class State {
         val experience: Experience,
         val flatStepIndex: Int,
         val isFirst: Boolean,
-        // this is how the UI communicates success/failure in presentation
-        // back to the state machine
-        val presentationComplete: ((ResultOf<Unit, Error>) -> Unit),
     ) : State()
 
     data class RenderingStep(val experience: Experience, val flatStepIndex: Int, val isFirst: Boolean) : State()

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -115,32 +115,6 @@ internal class StateMachine(
                     // this will execute the presentation, asynchronously, and return
                     // the subsequent action to take - either continue to Rendering, or report Error
                     handleActionInternal(sideEffect.presentContainer(actionProcessor))
-
-//                    // first, process any pre-step actions that need to be handled before the container is presented.
-//                    // for example - navigating to another screen in the app
-//                    actionProcessor.process(sideEffect.actions)
-//
-//                    try {
-//                        // this could throw an exception on trait failure, handled below
-//                        sideEffect.produceMetadata()
-//
-//                        // kick off UI
-//                        sideEffect.experience.stepContainers[sideEffect.containerIndex].presentingTrait.present()
-//
-//                        handleActionInternal(RenderStep)
-//                    } catch (exception: AppcuesTraitException) {
-//                        val message = exception.message ?: "Presenting trait failed to present for index ${sideEffect.containerIndex}"
-//                        handleActionInternal(
-//                            ReportError(
-//                                error = StepError(
-//                                    experience = sideEffect.experience,
-//                                    stepIndex = sideEffect.flatStepIndex,
-//                                    message = message
-//                                ),
-//                                fatal = true
-//                            )
-//                        )
-//                    }
                 }
 
                 is AwaitEffect -> {

--- a/appcues/src/main/java/com/appcues/trait/PresentingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/PresentingTrait.kt
@@ -16,4 +16,9 @@ internal interface PresentingTrait : ExperienceTrait {
      */
     @Throws(AppcuesTraitException::class)
     fun present()
+
+    /**
+     * Remove the container for the applicable group of steps in the Experience.
+     */
+    fun remove()
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/EmbedTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/EmbedTrait.kt
@@ -62,6 +62,8 @@ internal class EmbedTrait(
         }
     }
 
+    private val presenter = EmbedViewPresenter(scope, renderContext, scope.get())
+
     @Composable
     override fun WrapContent(
         content: @Composable (
@@ -117,10 +119,14 @@ internal class EmbedTrait(
     }
 
     override fun present() {
-        val success = EmbedViewPresenter(scope, renderContext, scope.get()).present()
+        val success = presenter.present()
 
         if (!success) {
             throw AppcuesTraitException("unable to create embed view for $renderContext")
         }
+    }
+
+    override fun remove() {
+        presenter.remove()
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -34,6 +34,8 @@ internal class ModalTrait(
 
     private val style = config.getConfigStyle("style")
 
+    private val presenter = OverlayViewPresenter(scope, renderContext)
+
     @Composable
     override fun WrapContent(
         content: @Composable (
@@ -55,10 +57,14 @@ internal class ModalTrait(
     }
 
     override fun present() {
-        val success = OverlayViewPresenter(scope, renderContext).present()
+        val success = presenter.present()
 
         if (!success) {
             throw AppcuesTraitException("unable to create modal overlay view")
         }
+    }
+
+    override fun remove() {
+        presenter.remove()
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -85,6 +85,8 @@ internal class TooltipTrait(
         private val MAX_TOOLTIP_WIDTH = 400.0.dp
     }
 
+    private val presenter = OverlayViewPresenter(scope, renderContext)
+
     private val style = config.getConfigStyle("style")
 
     // if hidePointer is present, set base and length to 0 Dp
@@ -101,11 +103,15 @@ internal class TooltipTrait(
     }
 
     override fun present() {
-        val success = OverlayViewPresenter(scope, renderContext).present()
+        val success = presenter.present()
 
         if (!success) {
             throw AppcuesTraitException("unable to create tooltip overlay view")
         }
+    }
+
+    override fun remove() {
+        presenter.remove()
     }
 
     @Composable
@@ -185,7 +191,7 @@ internal class TooltipTrait(
                                 contentSized.value = true
                             }
                             .styleShadowPath(style, tooltipPath, isSystemInDarkTheme())
-                            .clipToPath(tooltipPath)
+                            .clip(GenericShape { _, _ -> addPath(tooltipPath) })
                             .styleBackground(style, isSystemInDarkTheme())
                             .styleBorderPath(style, tooltipPath, isSystemInDarkTheme())
                     ) {
@@ -234,10 +240,6 @@ internal class TooltipTrait(
             }
         )
     }
-
-    private fun Modifier.clipToPath(path: Path) = then(
-        Modifier.clip(GenericShape { _, _ -> addPath(path) })
-    )
 
     private fun Modifier.styleBorderPath(
         style: ComponentStyle?,

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -16,7 +16,6 @@ import com.appcues.data.model.RenderContext.Modal
 import com.appcues.data.model.getFrameId
 import com.appcues.data.remote.RemoteError.HttpError
 import com.appcues.statemachine.Action.EndExperience
-import com.appcues.statemachine.Action.ReportError
 import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.Action.StartStep
 import com.appcues.statemachine.Error
@@ -239,10 +238,6 @@ internal class ExperienceRenderer(
     suspend fun dismiss(renderContext: RenderContext, markComplete: Boolean, destroyed: Boolean): ResultOf<State, Error> {
         return stateMachines.getOwner(renderContext)?.stateMachine?.handleAction(EndExperience(markComplete, destroyed))
             ?: Failure(RenderContextNotActive(renderContext))
-    }
-
-    suspend fun reportError(renderContext: RenderContext, error: Error) {
-        stateMachines.getOwner(renderContext)?.stateMachine?.handleAction(ReportError(error, true))
     }
 
     suspend fun resetAll() {

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -16,6 +16,7 @@ import com.appcues.data.model.RenderContext.Modal
 import com.appcues.data.model.getFrameId
 import com.appcues.data.remote.RemoteError.HttpError
 import com.appcues.statemachine.Action.EndExperience
+import com.appcues.statemachine.Action.ReportError
 import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.Action.StartStep
 import com.appcues.statemachine.Error
@@ -238,6 +239,10 @@ internal class ExperienceRenderer(
     suspend fun dismiss(renderContext: RenderContext, markComplete: Boolean, destroyed: Boolean): ResultOf<State, Error> {
         return stateMachines.getOwner(renderContext)?.stateMachine?.handleAction(EndExperience(markComplete, destroyed))
             ?: Failure(RenderContextNotActive(renderContext))
+    }
+
+    suspend fun reportError(renderContext: RenderContext, error: Error) {
+        stateMachines.getOwner(renderContext)?.stateMachine?.handleAction(ReportError(error, true))
     }
 
     suspend fun resetAll() {

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -68,10 +68,6 @@ private fun MainSurface() {
                 value?.let { ComposeContainer(it.stepContainer, it.position) }
             }
 
-            LaunchOnShowAnimationCompleted {
-                viewModel.onPresentationComplete()
-            }
-
             // will run when transition from visible to gone is completed
             LaunchOnHideAnimationCompleted {
                 // if state is dismissing then finish activity

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -16,17 +15,14 @@ import androidx.compose.ui.input.pointer.pointerInteropFilter
 import androidx.compose.ui.platform.testTag
 import com.appcues.data.model.StepContainer
 import com.appcues.logging.Logcues
-import com.appcues.trait.AppcuesTraitException
 import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.ContainerDecoratingTrait
 import com.appcues.trait.ContainerDecoratingTrait.ContainerDecoratingType
 import com.appcues.trait.ContentHolderTrait.ContainerPages
-import com.appcues.trait.MetadataSettingTrait
 import com.appcues.ui.presentation.AppcuesViewModel
 import com.appcues.ui.presentation.AppcuesViewModel.UIState.Dismissing
 import com.appcues.ui.theme.AppcuesTheme
 import com.google.accompanist.web.AccompanistWebChromeClient
-import kotlinx.coroutines.delay
 
 @Composable
 internal fun AppcuesComposition(
@@ -43,8 +39,6 @@ internal fun AppcuesComposition(
             LocalChromeClient provides chromeClient,
             LocalAppcuesActionDelegate provides DefaultAppcuesActionsDelegate(viewModel),
             LocalAppcuesPaginationDelegate provides AppcuesPagination { viewModel.onPageChanged(it) },
-            LocalAppcuesExperienceVisibility provides AppcuesExperienceVisibility { viewModel.updateViewVisibility(it) },
-            LocalTraitExceptionHandler provides AppcuesTraitExceptionHandler { viewModel.onTraitException(it) },
             LocalExperienceCompositionState provides ExperienceCompositionState()
         ) {
             MainSurface()
@@ -65,7 +59,7 @@ private fun MainSurface() {
             // update last rendering state based on new state
             rememberLastRenderingState(state).run {
                 // render last known rendering state
-                value?.let { ComposeContainer(it.stepContainer, it.position) }
+                value?.let { ComposeContainer(it.stepContainer, it.position, it.metadata) }
             }
 
             // will run when transition from visible to gone is completed
@@ -79,46 +73,17 @@ private fun MainSurface() {
     }
 }
 
-private suspend fun produceMetadata(
-    metadataSettingTraits: List<MetadataSettingTrait>,
-    traitExceptionHandler: AppcuesTraitExceptionHandler,
-    experienceVisibility: AppcuesExperienceVisibility,
-): HashMap<String, Any?>? {
-    return try {
-        hashMapOf<String, Any?>().apply { metadataSettingTraits.forEach { putAll(it.produceMetadata()) } }.also {
-            experienceVisibility.setVisible(true)
-        }
-    } catch (ex: AppcuesTraitException) {
-        if (ex.retryMilliseconds != null) {
-            experienceVisibility.setVisible(false)
-            delay(ex.retryMilliseconds.toLong())
-            produceMetadata(metadataSettingTraits, traitExceptionHandler, experienceVisibility)
-        } else {
-            traitExceptionHandler.onTraitException(ex)
-            null
-        }
-    }
-}
-
 @Composable
-internal fun BoxScope.ComposeContainer(stepContainer: StepContainer, stepIndex: Int) {
+internal fun BoxScope.ComposeContainer(stepContainer: StepContainer, stepIndex: Int, metadata: Map<String, Any?>) {
     with(stepContainer) {
         val backdropDecoratingTraits = remember(stepIndex) { mutableStateOf(steps[stepIndex].backdropDecoratingTraits) }
         val containerDecoratingTraits = remember(stepIndex) { mutableStateOf(steps[stepIndex].containerDecoratingTraits) }
-        val metadataSettingTraits = remember(stepIndex) { mutableStateOf(steps[stepIndex].metadataSettingTraits) }
 
-        val traitExceptionHandler = LocalTraitExceptionHandler.current
-        val experienceVisibility = LocalAppcuesExperienceVisibility.current
         val stepMetadata = remember { mutableStateOf<AppcuesStepMetadata?>(null) }
         val previousStepMetaData = remember { mutableStateOf(AppcuesStepMetadata()) }
 
-        LaunchedEffect(metadataSettingTraits) {
-            val actual = produceMetadata(metadataSettingTraits.value, traitExceptionHandler, experienceVisibility)
-            if (actual != null) {
-                stepMetadata.value = AppcuesStepMetadata(previous = previousStepMetaData.value.current, current = actual).also {
-                    previousStepMetaData.value = it
-                }
-            }
+        stepMetadata.value = AppcuesStepMetadata(previous = previousStepMetaData.value.current, current = metadata).also {
+            previousStepMetaData.value = it
         }
 
         stepMetadata.value?.let { metadata ->

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -9,7 +9,6 @@ import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.Interactio
 import com.appcues.data.model.Action
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.logging.Logcues
-import com.appcues.trait.AppcuesTraitException
 import com.appcues.ui.presentation.AppcuesViewModel
 import com.google.accompanist.web.AccompanistWebChromeClient
 import java.util.UUID
@@ -60,14 +59,6 @@ internal val LocalExperienceStepFormStateDelegate = compositionLocalOf { Experie
 internal val LocalStackScope = compositionLocalOf { StackScope.COLUMN }
 
 internal val LocalChromeClient = compositionLocalOf { AccompanistWebChromeClient() }
-
-internal val LocalTraitExceptionHandler = compositionLocalOf { AppcuesTraitExceptionHandler {} }
-
-internal val LocalAppcuesExperienceVisibility = compositionLocalOf { AppcuesExperienceVisibility {} }
-
-internal data class AppcuesTraitExceptionHandler(val onTraitException: (AppcuesTraitException) -> Unit)
-
-internal data class AppcuesExperienceVisibility(val setVisible: (Boolean) -> Unit)
 
 internal enum class StackScope {
     ROW, COLUMN

--- a/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
@@ -12,7 +12,6 @@ import com.appcues.data.model.RenderContext
 import com.appcues.data.model.StepContainer
 import com.appcues.statemachine.State.BeginningStep
 import com.appcues.statemachine.State.EndingStep
-import com.appcues.statemachine.State.Idling
 import com.appcues.statemachine.StepReference.StepGroupPageIndex
 import com.appcues.ui.ExperienceRenderer
 import com.appcues.ui.presentation.AppcuesViewModel.UIState.Dismissing
@@ -73,10 +72,6 @@ internal class AppcuesViewModel(
                         if (result.dismissAndContinue != null) {
                             _uiState.value = Dismissing(result.dismissAndContinue)
                         }
-                    }
-                    is Idling -> {
-                        // can occur in a trait processing error, where the state was reset and the UI should just dismiss
-                        _uiState.value = Dismissing { }
                     }
                     // ignore other state changes
                     else -> Unit

--- a/appcues/src/main/java/com/appcues/ui/presentation/EmbedViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/EmbedViewPresenter.kt
@@ -30,13 +30,6 @@ internal class EmbedViewPresenter(
         }
     }
 
-    override fun setViewVisible(isVisible: Boolean) {
-        // adhering to requirement for the AppcuesViewModel constructor on line 71 below
-        // would got called during any trait error/retry flow - which is not applicable here
-        // for embeds, as it is only used for tooltips in flows, currently.
-        stateMachines.getFrame(renderContext)?.isVisible = isVisible
-    }
-
     private fun StateMachineDirectory.getFrame(context: RenderContext): AppcuesFrameView? {
         return (getOwner(context) as? AppcuesFrameStateMachineOwner)?.frame?.get()
     }

--- a/appcues/src/main/java/com/appcues/ui/presentation/OverlayViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/OverlayViewPresenter.kt
@@ -8,12 +8,9 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
-import androidx.core.view.isVisible
 import com.appcues.AppcuesOverlayView
 import com.appcues.R
 import com.appcues.data.model.RenderContext
-import com.appcues.monitor.AppcuesActivityMonitor
-import com.appcues.ui.utils.getParentView
 import org.koin.core.scope.Scope
 
 internal class OverlayViewPresenter(scope: Scope, renderContext: RenderContext) : ViewPresenter(scope, renderContext) {
@@ -54,28 +51,6 @@ internal class OverlayViewPresenter(scope: Scope, renderContext: RenderContext) 
 
         // add customers view back to accessibility stack
         setAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES)
-    }
-
-    override fun setViewVisible(isVisible: Boolean) {
-        AppcuesActivityMonitor.activity?.updateOverlayVisibility(isVisible)
-    }
-
-    private fun Activity.updateOverlayVisibility(isVisible: Boolean) {
-        getParentView().let { parentView ->
-            parentView.post {
-                findViewById<AppcuesOverlayView>(R.id.appcues_overlay_view)?.let {
-                    it.isVisible = isVisible
-                }
-                parentView.setAccessibility(
-                    if (isVisible) {
-                        // when our view is visible, the parent view is removed from the accessibility stack
-                        View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
-                    } else {
-                        View.IMPORTANT_FOR_ACCESSIBILITY_YES
-                    }
-                )
-            }
-        }
     }
 
     private fun ViewGroup.setAccessibility(accessibilityFlag: Int) {

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -64,7 +64,7 @@ internal abstract class ViewPresenter(
             // grab composeView or exit with false
             val composeView = setupView(activity) ?: return false
 
-            viewModel = AppcuesViewModel(scope, renderContext, ::onCompositionDismiss, ::setViewVisible)
+            viewModel = AppcuesViewModel(scope, renderContext, ::onCompositionDismiss)
 
             if (currentExperience?.trigger == Preview) {
                 gestureListener = ShakeGestureListener(activity).also {
@@ -106,8 +106,6 @@ internal abstract class ViewPresenter(
     abstract fun ViewGroup.setupView(activity: Activity): ComposeView?
 
     abstract fun ViewGroup.removeView()
-
-    abstract fun setViewVisible(isVisible: Boolean)
 
     private fun refreshPreview() {
         currentExperience?.let {

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -86,6 +86,10 @@ internal abstract class ViewPresenter(
         }
     }
 
+    fun remove() {
+        onCompositionDismiss()
+    }
+
     private fun onCompositionDismiss() {
         AppcuesActivityMonitor.unsubscribe(activityMonitorListener)
 

--- a/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
@@ -15,7 +15,6 @@ import com.appcues.rules.MainDispatcherRule
 import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.Action.StartStep
 import com.appcues.statemachine.State
-import com.appcues.statemachine.State.BeginningStep
 import com.appcues.statemachine.State.EndingStep
 import com.appcues.statemachine.State.RenderingStep
 import com.appcues.statemachine.StateMachine
@@ -23,7 +22,6 @@ import com.appcues.statemachine.StepReference.StepOffset
 import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
 import com.appcues.util.LinkOpener
-import com.appcues.util.ResultOf.Success
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -135,9 +133,6 @@ internal class ExperienceLifecycleTrackerTest : KoinTest {
             // that is required to progress the state machine forward on UI present/dismiss
             machine.stateFlow.collect {
                 when (it) {
-                    is BeginningStep -> {
-                        it.presentationComplete.invoke(Success(Unit))
-                    }
                     is EndingStep -> {
                         it.dismissAndContinue?.invoke()
                     }

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -166,8 +166,8 @@ internal class StateMachineTest : AppcuesScopeTest {
 
         // THEN
         assertThat(stateMachine.state).isEqualTo(targetState)
-        assertThat(result.failureReason()).isInstanceOf(ExperienceError::class.java)
-        with(result.failureReason() as ExperienceError) {
+        assertThat(result.failureReason()).isInstanceOf(StepError::class.java)
+        with(result.failureReason() as StepError) {
             assertThat(message).isEqualTo("test trait exception")
         }
     }
@@ -624,7 +624,7 @@ internal class StateMachineTest : AppcuesScopeTest {
     fun `BeginningStep SHOULD NOT transition WHEN action is something other than RenderStep or Pause`() = runTest {
         // GIVEN
         val experience = mockExperience()
-        val initialState = BeginningStep(experience, 1, false) { }
+        val initialState = BeginningStep(experience, 1, false)
         val stateMachine = initMachine(initialState)
         val action = StartStep(StepOffset(1))
 
@@ -756,9 +756,6 @@ internal class StateMachineTest : AppcuesScopeTest {
             machine.stateFlow.collect {
                 onStateChange?.invoke(it)
                 when (it) {
-                    is BeginningStep -> {
-                        it.presentationComplete.invoke(Success(Unit))
-                    }
                     is EndingStep -> {
                         it.dismissAndContinue?.invoke()
                     }


### PR DESCRIPTION
These are the changes from a deeper review of state machine handling, in particular related to recent embeds work.

* Remove await on presentation callbacks to avoid issues with hung state machine, no longer needed
* Process trait metadata before presenting new container or moving to new steps in container, and handle errors prior to render
* Add remove() to PresentingTraits to ensure that UI can be dismissed in trait metadata error cases
* Simplify StateMachineOwning implementation (for embeds) to remove optionals and handle edge cases