### PR TITLE
Dependency updates

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -14,7 +14,7 @@ apply from: 'dokka.gradle'
 ext.room_version = '2.5.2'
 ext.compose_version = '1.5.1'
 ext.compose_compiler_version = '1.5.3'
-ext.koin_version = '3.4.3'
+ext.koin_version = '3.5.0'
 ext.coil_version = '2.4.0'
 ext.moshi_version = '1.15.0'
 

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -14,7 +14,6 @@ apply from: 'dokka.gradle'
 ext.room_version = '2.5.2'
 ext.compose_version = '1.5.0'
 ext.compose_compiler_version = '1.5.3'
-ext.accompanist_version = '0.32.0'
 ext.koin_version = '3.4.3'
 ext.coil_version = '2.4.0'
 ext.moshi_version = '1.15.0'
@@ -113,8 +112,6 @@ dependencies {
     // Dependency Injection
     implementation "io.insert-koin:koin-core:$koin_version"
     implementation "io.insert-koin:koin-android:$koin_version"
-    // Webview
-    implementation "com.google.accompanist:accompanist-webview:$accompanist_version"
     // Play In-App Review
     implementation 'com.google.android.play:review:2.0.1'
     implementation 'com.google.android.play:review-ktx:2.0.1'

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -20,13 +20,13 @@ ext.coil_version = '2.2.2'
 ext.moshi_version = '1.14.0'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     namespace "com.appcues"
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testApplicationId = "com.appcues.test"
@@ -76,11 +76,11 @@ android {
 
 dependencies {
     // Androidx
-    implementation "androidx.core:core-ktx:1.9.0"
-    implementation 'androidx.activity:activity-compose:1.6.1'
-    implementation "androidx.browser:browser:1.4.0"
+    implementation "androidx.core:core-ktx:1.10.1"
+    implementation 'androidx.activity:activity-compose:1.7.2'
+    implementation "androidx.browser:browser:1.6.0"
     implementation "androidx.startup:startup-runtime:1.1.1"
-    implementation "androidx.navigation:navigation-compose:2.5.3"
+    implementation "androidx.navigation:navigation-compose:2.7.1"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
@@ -91,12 +91,12 @@ dependencies {
     debugImplementation "androidx.customview:customview:1.2.0-alpha02"
     debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0"
     // ----
-    implementation "com.google.android.material:material:1.7.0"
+    implementation "com.google.android.material:material:1.9.0"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     ksp "androidx.room:room-compiler:$room_version"
-    implementation "androidx.savedstate:savedstate:1.2.0"
+    implementation "androidx.savedstate:savedstate:1.2.1"
     // Image Loader
     implementation "io.coil-kt:coil-compose:$coil_version"
     implementation "io.coil-kt:coil-gif:$coil_version"
@@ -105,7 +105,7 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.okhttp3:okhttp:4.11.0"
     implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.9.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.11.0"
     implementation "com.squareup.moshi:moshi:$moshi_version"
     implementation "com.squareup.moshi:moshi-adapters:$moshi_version"
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -12,7 +12,7 @@ apply from: 'codecov.gradle'
 apply from: 'dokka.gradle'
 
 ext.room_version = '2.5.2'
-ext.compose_version = '1.5.0'
+ext.compose_version = '1.5.1'
 ext.compose_compiler_version = '1.5.3'
 ext.koin_version = '3.4.3'
 ext.coil_version = '2.4.0'
@@ -75,21 +75,16 @@ android {
 
 dependencies {
     // Androidx
-    implementation "androidx.core:core-ktx:1.10.1"
+    implementation "androidx.core:core-ktx:1.12.0"
     implementation 'androidx.activity:activity-compose:1.7.2'
     implementation "androidx.browser:browser:1.6.0"
     implementation "androidx.startup:startup-runtime:1.1.1"
-    implementation "androidx.navigation:navigation-compose:2.7.1"
+    implementation "androidx.navigation:navigation-compose:2.7.3"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
-    // Workaround for an issue that will be fixed by google some day.
-    // https://issuetracker.google.com/issues/227767363
-    debugImplementation "androidx.customview:customview:1.2.0-alpha02"
-    debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0"
-    // ----
     implementation "com.google.android.material:material:1.9.0"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.room:room-runtime:$room_version"

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -15,9 +15,9 @@ ext.room_version = '2.5.2'
 ext.compose_version = '1.5.0'
 ext.compose_compiler_version = '1.5.3'
 ext.accompanist_version = '0.32.0'
-ext.koin_version = '3.4.2'
-ext.coil_version = '2.2.2'
-ext.moshi_version = '1.14.0'
+ext.koin_version = '3.4.3'
+ext.coil_version = '2.4.0'
+ext.moshi_version = '1.15.0'
 
 android {
     compileSdk 34

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-kapt'
     id 'org.jetbrains.dokka'
+    id "com.google.devtools.ksp"
 }
 
 apply from: 'artifacts-android.gradle'
@@ -11,10 +11,10 @@ apply from: 'copy-dependencies.gradle'
 apply from: 'codecov.gradle'
 apply from: 'dokka.gradle'
 
-ext.room_version = '2.4.3'
-ext.compose_version = '1.4.3'
-ext.compose_compiler_version = '1.4.7'
-ext.accompanist_version = '0.30.1'
+ext.room_version = '2.5.2'
+ext.compose_version = '1.5.0'
+ext.compose_compiler_version = '1.5.3'
+ext.accompanist_version = '0.32.0'
 ext.koin_version = '3.4.2'
 ext.coil_version = '2.2.2'
 ext.moshi_version = '1.14.0'
@@ -33,10 +33,8 @@ android {
 
         consumerProguardFiles "consumer-rules.pro"
 
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
-            }
+        ksp {
+            arg("room.schemaLocation", "$projectDir/schemas".toString())
         }
     }
 
@@ -97,7 +95,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
     implementation "androidx.savedstate:savedstate:1.2.0"
     // Image Loader
     implementation "io.coil-kt:coil-compose:$coil_version"
@@ -111,14 +109,12 @@ dependencies {
     implementation "com.squareup.moshi:moshi:$moshi_version"
     implementation "com.squareup.moshi:moshi-adapters:$moshi_version"
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
+    ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
     // Dependency Injection
     implementation "io.insert-koin:koin-core:$koin_version"
     implementation "io.insert-koin:koin-android:$koin_version"
     // Webview
     implementation "com.google.accompanist:accompanist-webview:$accompanist_version"
-    // Navigation Animated
-    implementation "com.google.accompanist:accompanist-navigation-animation:$accompanist_version"
     // Play In-App Review
     implementation 'com.google.android.play:review:2.0.1'
     implementation 'com.google.android.play:review-ktx:2.0.1'

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerPanel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerPanel.kt
@@ -1,9 +1,9 @@
 package com.appcues.debugger.ui
 
 import android.widget.Toast
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
@@ -149,7 +149,7 @@ private fun exitTransition(): ExitTransition {
 private fun NavGraphBuilder.mainComposable(
     pageName: String,
     eventDetailsPage: String,
-    content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
+    content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit
 ) {
     composable(
         route = pageName,
@@ -174,7 +174,7 @@ private fun NavGraphBuilder.mainComposable(
 private fun NavGraphBuilder.detailPageComposable(
     pageName: String,
     mainPage: String,
-    content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
+    content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit
 ) {
     composable(
         route = pageName,

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerPanel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerPanel.kt
@@ -1,12 +1,11 @@
 package com.appcues.debugger.ui
 
 import android.widget.Toast
-import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -37,6 +36,9 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.appcues.R
 import com.appcues.debugger.DebugMode.Debugger
 import com.appcues.debugger.DebuggerViewModel
@@ -46,16 +48,12 @@ import com.appcues.debugger.ui.details.DebuggerEventDetails
 import com.appcues.debugger.ui.fonts.DebuggerFontDetails
 import com.appcues.debugger.ui.main.DebuggerMain
 import com.appcues.ui.theme.AppcuesColors
-import com.google.accompanist.navigation.animation.AnimatedNavHost
-import com.google.accompanist.navigation.animation.composable
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 
 private const val SLIDE_TRANSITION_MILLIS = 250
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 internal fun BoxScope.DebuggerPanel(debuggerState: MutableDebuggerState, debuggerViewModel: DebuggerViewModel) {
-    val navController = rememberAnimatedNavController()
+    val navController = rememberNavController()
     val selectedEvent = remember { mutableStateOf<DebuggerEventItem?>(null) }
 
     // don't show if current debugger is paused
@@ -97,9 +95,8 @@ internal fun BoxScope.DebuggerPanel(debuggerState: MutableDebuggerState, debugge
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
-private fun BoxScope.DebuggerPanelPages(
+private fun DebuggerPanelPages(
     navController: NavHostController,
     selectedEvent: MutableState<DebuggerEventItem?>,
     debuggerViewModel: DebuggerViewModel,
@@ -110,7 +107,7 @@ private fun BoxScope.DebuggerPanelPages(
     val fontDetailsPage = "font_details"
     val deepLinkPath = debuggerState.deepLinkPath.value
 
-    AnimatedNavHost(navController = navController, startDestination = mainPage) {
+    NavHost(navController = navController, startDestination = mainPage) {
         mainComposable(
             pageName = mainPage,
             eventDetailsPage = eventDetailsPage
@@ -149,7 +146,6 @@ private fun exitTransition(): ExitTransition {
         fadeOut(tween(durationMillis = 150))
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 private fun NavGraphBuilder.mainComposable(
     pageName: String,
     eventDetailsPage: String,
@@ -160,14 +156,14 @@ private fun NavGraphBuilder.mainComposable(
         enterTransition = {
             when (initialState.destination.route) {
                 eventDetailsPage ->
-                    slideIntoContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(SLIDE_TRANSITION_MILLIS))
+                    slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.End, animationSpec = tween(SLIDE_TRANSITION_MILLIS))
                 else -> null
             }
         },
         exitTransition = {
             when (targetState.destination.route) {
                 eventDetailsPage ->
-                    slideOutOfContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(SLIDE_TRANSITION_MILLIS))
+                    slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Start, animationSpec = tween(SLIDE_TRANSITION_MILLIS))
                 else -> null
             }
         },
@@ -175,7 +171,6 @@ private fun NavGraphBuilder.mainComposable(
     )
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 private fun NavGraphBuilder.detailPageComposable(
     pageName: String,
     mainPage: String,
@@ -186,14 +181,14 @@ private fun NavGraphBuilder.detailPageComposable(
         enterTransition = {
             when (initialState.destination.route) {
                 mainPage ->
-                    slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(SLIDE_TRANSITION_MILLIS))
+                    slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Start, animationSpec = tween(SLIDE_TRANSITION_MILLIS))
                 else -> null
             }
         },
         exitTransition = {
             when (targetState.destination.route) {
                 mainPage ->
-                    slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(SLIDE_TRANSITION_MILLIS))
+                    slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.End, animationSpec = tween(SLIDE_TRANSITION_MILLIS))
                 else -> null
             }
         },

--- a/appcues/src/main/java/com/appcues/trait/appcues/CarouselTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/CarouselTrait.kt
@@ -34,7 +34,10 @@ internal class CarouselTrait(
     @OptIn(ExperimentalFoundationApi::class)
     @Composable
     override fun BoxScope.CreateContentHolder(containerPages: ContainerPages) {
-        val pagerState = rememberPagerState(initialPage = containerPages.currentPage).also {
+        val pagerState = rememberPagerState(
+            initialPage = containerPages.currentPage,
+            pageCount = { containerPages.pageCount }
+        ).also {
             containerPages.UpdatePaginationData(
                 AppcuesPaginationData(
                     pageCount = containerPages.pageCount,
@@ -102,7 +105,6 @@ internal class CarouselTrait(
 
                     layout(constraints.maxWidth, calculatedHeight) { placeable.place(0, 0) }
                 },
-            pageCount = containerPages.pageCount,
             state = pagerState,
             verticalAlignment = Alignment.Top
         ) { index ->

--- a/appcues/src/main/java/com/appcues/trait/appcues/EmbedTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/EmbedTrait.kt
@@ -86,9 +86,9 @@ internal class EmbedTrait(
                         .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) },
                     content = {
                         content(
-                            modifier = if (constraints.hasBoundedHeight) Modifier.verticalScroll(rememberScrollState()) else Modifier,
-                            containerPadding = style.getPaddings(),
-                            safeAreaInsets = PaddingValues()
+                            if (constraints.hasBoundedHeight) Modifier.verticalScroll(rememberScrollState()) else Modifier,
+                            style.getPaddings(),
+                            PaddingValues()
                         )
                     },
                 )

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -194,9 +194,9 @@ internal class TooltipTrait(
                             .styleBorderPath(style, tooltipPath, isSystemInDarkTheme())
                     ) {
                         content(
-                            modifier = Modifier.verticalScroll(rememberScrollState()),
-                            containerPadding = style.getPaddings(),
-                            safeAreaInsets = tooltipSettings.getContentPaddingValues()
+                            Modifier.verticalScroll(rememberScrollState()),
+                            style.getPaddings(),
+                            tooltipSettings.getContentPaddingValues()
                         )
                     }
                 }

--- a/appcues/src/main/java/com/appcues/ui/InAppReviewActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/InAppReviewActivity.kt
@@ -2,6 +2,8 @@ package com.appcues.ui
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
@@ -40,7 +42,12 @@ internal class InAppReviewActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // remove enter animation from this activity
-        overridePendingTransition(0, 0)
+        if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
+        } else {
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+        }
         super.onCreate(savedInstanceState)
 
         val requestCompletion = CompletableDeferred<Boolean>()
@@ -92,7 +99,12 @@ internal class InAppReviewActivity : AppCompatActivity() {
     override fun finish() {
         super.finish()
         // remove exit animation from this activity
-        overridePendingTransition(0, 0)
+        if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
+        } else {
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+        }
 
         completion?.complete(true)
     }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -1,5 +1,6 @@
 package com.appcues.ui.composables
 
+import android.webkit.WebChromeClient
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -25,14 +26,13 @@ import com.appcues.ui.presentation.AppcuesViewModel
 import com.appcues.ui.presentation.AppcuesViewModel.UIState.Dismissing
 import com.appcues.ui.presentation.AppcuesViewModel.UIState.Rendering
 import com.appcues.ui.theme.AppcuesTheme
-import com.google.accompanist.web.AccompanistWebChromeClient
 
 @Composable
 internal fun AppcuesComposition(
     viewModel: AppcuesViewModel,
     imageLoader: ImageLoader,
     logcues: Logcues,
-    chromeClient: AccompanistWebChromeClient,
+    chromeClient: WebChromeClient,
 ) {
     // ensure to change some colors to match appropriate design for custom primitive blocks
     AppcuesTheme {

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -1,5 +1,6 @@
 package com.appcues.ui.composables
 
+import android.webkit.WebChromeClient
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -10,7 +11,6 @@ import com.appcues.data.model.Action
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.logging.Logcues
 import com.appcues.ui.presentation.AppcuesViewModel
-import com.google.accompanist.web.AccompanistWebChromeClient
 import java.util.UUID
 
 // used to register callback for all Actions triggered from primitives
@@ -58,7 +58,7 @@ internal val LocalExperienceStepFormStateDelegate = compositionLocalOf { Experie
 
 internal val LocalStackScope = compositionLocalOf { StackScope.COLUMN }
 
-internal val LocalChromeClient = compositionLocalOf { AccompanistWebChromeClient() }
+internal val LocalChromeClient = compositionLocalOf { WebChromeClient() }
 
 internal enum class StackScope {
     ROW, COLUMN

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -74,11 +74,11 @@ internal fun BottomSheetModal(
                         .modalStyle(style, isDark) { Modifier.sheetModifier(appcuesWindowInfo, isDark, it) },
                     content = {
                         content(
-                            modifier = Modifier
+                            Modifier
                                 .fillMaxSize()
                                 .verticalScroll(rememberScrollState()),
-                            containerPadding = style.getPaddings(),
-                            safeAreaInsets = PaddingValues()
+                            style.getPaddings(),
+                            PaddingValues()
                         )
                     },
                 )

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -110,9 +110,9 @@ internal fun DialogModal(
                     .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) }
             ) {
                 content(
-                    modifier = Modifier.verticalScroll(rememberScrollState()),
-                    containerPadding = style.getPaddings(),
-                    safeAreaInsets = PaddingValues()
+                    Modifier.verticalScroll(rememberScrollState()),
+                    style.getPaddings(),
+                    PaddingValues()
                 )
             }
         }

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -70,11 +70,11 @@ internal fun ExpandedBottomSheetModal(
                         .modalStyle(style, isDark) { Modifier.sheetModifier(windowInfo, isDark, it) },
                     content = {
                         content(
-                            modifier = Modifier
+                            Modifier
                                 .fillMaxSize()
                                 .verticalScroll(rememberScrollState()),
-                            containerPadding = style.getPaddings(),
-                            safeAreaInsets = PaddingValues()
+                            style.getPaddings(),
+                            PaddingValues()
                         )
                     },
                 )

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -73,11 +73,11 @@ internal fun FullScreenModal(
                         .modalStyle(style, isDark) { Modifier.fullModifier(windowInfo, isDark, it) },
                     content = {
                         content(
-                            modifier = Modifier
+                            Modifier
                                 .fillMaxSize()
                                 .verticalScroll(rememberScrollState()),
-                            containerPadding = style.getPaddings(),
-                            safeAreaInsets = PaddingValues()
+                            style.getPaddings(),
+                            PaddingValues()
                         )
                     },
                 )

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21"
+        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10"
         classpath "org.jacoco:org.jacoco.core:0.8.9"
         classpath "org.jetbrains.dokka:kotlin-as-java-plugin:1.8.20"
     }
@@ -14,6 +14,7 @@ buildscript {
 plugins {
     id "io.gitlab.arturbosch.detekt" version "1.21.0"
     id "org.jetbrains.dokka" version "1.8.20"
+    id "com.google.devtools.ksp" version "1.9.10-1.0.13" apply false
 }
 
 allprojects {

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     namespace "com.appcues.samples.kotlin"
 
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         applicationId "com.appcues.samples.kotlin"
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode Integer.valueOf(System.getenv("CIRCLE_BUILD_NUM") ?: 1)
         versionName "1.0"
 

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -39,12 +39,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     buildFeatures {
@@ -56,14 +56,14 @@ android {
 dependencies {
     implementation project(":appcues")
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.1'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.5.1'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.7.3'
 }
 
-task versionTxt() {
+tasks.register('versionTxt') {
     doLast {
         new File(projectDir.parentFile.parentFile, "sample_version.txt").text = "$android.defaultConfig.versionCode ($android.defaultConfig.versionName)"
     }


### PR DESCRIPTION
Taking a pass through, post 3.0 release, to update various dependencies and settings. Will need to consider the best time to push these updates out, and test with cross platform toolkits still.

* AGP 8.0.2 -> 8.1.1
* Kotlin 1.8.21 -> 1.9.10
* compileSdk and targetSdk 33 -> 34
* migrate [from kapt to ksp](https://developer.android.com/build/migrate-to-ksp)
* Room 2.4.3 -> 2.5.2 (required for Kotlin 1.9)
* Compose 1.4.3 -> 1.5.0 (compiler 1.4.7 -> 1.5.3)
* Koin 3.4.2 -> 3.5.0
* Coil 2.2.2 -> 2.4.0
* Moshi 1.14.0 -> 1.15.0
* few other misc androidx lib patch updates

removed usage of Accompanist entirely
* the Navigation lib is now rolled into compose navigation in the core
* the WebView lib is [deprecated](https://google.github.io/accompanist/web/), and replaced with a simple port into our code using an AndroidView containing a WebView, [matching what we were using before](https://github.com/google/accompanist/blob/main/web/src/main/java/com/google/accompanist/web/WebView.kt#L234)

Code changes are to fix any API changes or deprecations related to the above - with exception of one bug fix on the web view, will note inline.