### PR TITLE
🐛 guarding onSizeChange to only apply when size is not the same as old size

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipPathExt.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.appcues.trait.appcues.TooltipPointerPosition.Bottom
 import com.appcues.trait.appcues.TooltipPointerPosition.Left
@@ -180,6 +181,12 @@ internal data class TooltipContainerDimens(
 
     val availableHorizontalSpace = (widthDp - (cornerRadius * 2)).coerceAtLeast(0.dp)
     val availableVerticalSpace = (heightDp - (cornerRadius * 2)).coerceAtLeast(0.dp)
+}
+
+internal fun TooltipContainerDimens?.equals(size: IntSize): Boolean {
+    if (this == null) return false
+
+    return (widthPx.toInt() == size.width && heightPx.toInt() == size.height)
 }
 
 internal fun calculatePointerXOffset(

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -218,6 +218,8 @@ internal class TooltipTrait(
         then(
             Modifier.onSizeChanged {
                 with(density) {
+                    if (containerDimens.value.equals(it)) return@onSizeChanged
+
                     containerDimens.value = TooltipContainerDimens(
                         widthDp = it.width.toDp(),
                         heightDp = it.height.toDp(),


### PR DESCRIPTION
comparing width and height (as Int) to make sure we are not updating size on every decimal size update.


unsure the root cause of the issue, its probably because we may have an unintentional loop in this composition, where we need the containerSize and contentSize to build the tooltipSettings, and tooltipSettings needs to know the content size too.

maybe worth revisiting this later to see if we can simplify how we build tooltips, but for now I think we can limit the update on containerSize to only update when its a relevant value