### PR TITLE
✨ Sending new property session_id on every ActivityRequest

### DIFF
--- a/appcues/src/main/java/com/appcues/SessionMonitor.kt
+++ b/appcues/src/main/java/com/appcues/SessionMonitor.kt
@@ -41,11 +41,13 @@ internal class SessionMonitor(
         }
     }
 
-    fun startNewSession(): Boolean {
-        if (storage.userId.isEmpty()) return false
-        _sessionId = UUID.randomUUID()
-        updateLastActivity()
-        return true
+    fun startNewSession(): UUID? {
+        if (storage.userId.isEmpty()) return null
+
+        return UUID.randomUUID().also {
+            _sessionId = it
+            updateLastActivity()
+        }
     }
 
     fun updateLastActivity() {

--- a/appcues/src/main/java/com/appcues/analytics/ActivityRequestBuilder.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ActivityRequestBuilder.kt
@@ -5,6 +5,7 @@ import com.appcues.Storage
 import com.appcues.analytics.AnalyticsEvent.ScreenView
 import com.appcues.data.remote.appcues.request.ActivityRequest
 import com.appcues.data.remote.appcues.request.EventRequest
+import java.util.UUID
 
 internal class ActivityRequestBuilder(
     private val config: AppcuesConfig,
@@ -18,25 +19,27 @@ internal class ActivityRequestBuilder(
         const val SCREEN_TITLE_CONTEXT = "screen_title"
     }
 
-    fun identify(properties: Map<String, Any>? = null) = decorator.decorateIdentify(
+    fun identify(sessionId: UUID, properties: Map<String, Any>? = null) = decorator.decorateIdentify(
         ActivityRequest(
             userId = storage.userId,
             accountId = config.accountId,
             groupId = storage.groupId,
+            sessionId = sessionId,
             profileUpdate = properties?.toMutableMap(),
-            userSignature = storage.userSignature,
+            userSignature = storage.userSignature
         )
     )
 
-    fun group(properties: Map<String, Any>? = null) = ActivityRequest(
+    fun group(sessionId: UUID, properties: Map<String, Any>? = null) = ActivityRequest(
         userId = storage.userId,
         accountId = config.accountId,
         groupId = storage.groupId,
+        sessionId = sessionId,
         groupUpdate = properties, // no auto-properties on group calls
         userSignature = storage.userSignature,
     )
 
-    fun track(name: String, properties: Map<String, Any>? = null): ActivityRequest {
+    fun track(sessionId: UUID, name: String, properties: Map<String, Any>? = null): ActivityRequest {
         // must do this decoration first, so that any auto-prop updates resulting from it get applied before
         // using in the profileUpdate below
         val trackEvent = decorator.decorateTrack(
@@ -48,12 +51,13 @@ internal class ActivityRequestBuilder(
             profileUpdate = decorator.autoProperties.toMutableMap(),
             accountId = config.accountId,
             groupId = storage.groupId,
+            sessionId = sessionId,
             events = listOf(trackEvent),
             userSignature = storage.userSignature,
         )
     }
 
-    fun screen(title: String, properties: MutableMap<String, Any>? = null): ActivityRequest {
+    fun screen(sessionId: UUID, title: String, properties: MutableMap<String, Any>? = null): ActivityRequest {
         // must do this decoration first, so that any auto-prop updates resulting from it get applied before
         // using in the profileUpdate below
         val screenEvent = decorator.decorateTrack(
@@ -70,6 +74,7 @@ internal class ActivityRequestBuilder(
             profileUpdate = decorator.autoProperties.toMutableMap(),
             accountId = config.accountId,
             groupId = storage.groupId,
+            sessionId = sessionId,
             events = listOf(screenEvent),
             userSignature = storage.userSignature,
         )

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/request/ActivityRequest.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/request/ActivityRequest.kt
@@ -17,6 +17,8 @@ internal data class ActivityRequest(
     val userId: String,
     @Json(name = "account_id")
     val accountId: String,
+    @Json(name = "session_id")
+    val sessionId: UUID,
     @Json(name = "group_id")
     @SerializeNull
     val groupId: String? = null,

--- a/appcues/src/test/java/com/appcues/AnalyticsPublisherTest.kt
+++ b/appcues/src/test/java/com/appcues/AnalyticsPublisherTest.kt
@@ -20,6 +20,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.koin.core.component.get
 import java.util.Date
+import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class AnalyticsPublisherTest : AppcuesScopeTest {
@@ -66,6 +67,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val activity = ActivityRequest(
             accountId = "123",
             userId = "userId",
+            sessionId = UUID.randomUUID(),
             events = listOf(EventRequest("event1", attributes = attributes))
         )
         val data = TrackingData(EVENT, false, activity)
@@ -91,6 +93,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val activity = ActivityRequest(
             accountId = "123",
             userId = "userId",
+            sessionId = UUID.randomUUID(),
             events = listOf(EventRequest("event1", attributes = attributes))
         )
         val data = TrackingData(EVENT, false, activity)
@@ -110,6 +113,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val activity = ActivityRequest(
             accountId = "123",
             userId = "userId",
+            sessionId = UUID.randomUUID(),
             events = listOf(EventRequest(ScreenView.eventName, attributes = attributes))
         )
         val data = TrackingData(SCREEN, false, activity)
@@ -130,6 +134,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val attributes = hashMapOf<String, Any>("prop" to 42)
         val activity = ActivityRequest(
             accountId = "123",
+            sessionId = UUID.randomUUID(),
             userId = storage.userId,
             profileUpdate = attributes
         )
@@ -152,6 +157,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val activity = ActivityRequest(
             accountId = "123",
             userId = "userId",
+            sessionId = UUID.randomUUID(),
             groupId = storage.groupId,
             groupUpdate = attributes
         )
@@ -172,6 +178,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val activity = ActivityRequest(
             accountId = "123",
             userId = "userId",
+            sessionId = UUID.randomUUID(),
             events = listOf(EventRequest("event1", attributes = attributes))
         )
         val data = TrackingData(EVENT, true, activity)

--- a/appcues/src/test/java/com/appcues/analytics/ActivityRequestBuilderTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ActivityRequestBuilderTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verifySequence
 import org.junit.Test
+import java.util.UUID
 
 internal class ActivityRequestBuilderTest {
 
@@ -42,13 +43,15 @@ internal class ActivityRequestBuilderTest {
     fun `identify SHOULD call decorator WITH proper ActivityRequest`() {
         // given
         val properties = hashMapOf("_test" to "test")
+        val sessionId = UUID.randomUUID()
         // when
-        activityRequestBuilder.identify(properties)
+        activityRequestBuilder.identify(sessionId, properties)
         // then
         with(activityRequestSlot.captured) {
             assertThat(userId).isEqualTo("userId")
             assertThat(groupId).isEqualTo("groupId")
             assertThat(accountId).isEqualTo("accountId")
+            assertThat(this.sessionId).isEqualTo(sessionId)
             assertThat(profileUpdate).hasSize(1)
             assertThat(profileUpdate).containsEntry("_test", "test")
             assertThat(userSignature).isEqualTo("user-signature")
@@ -59,12 +62,14 @@ internal class ActivityRequestBuilderTest {
     fun `group SHOULD return ActivityRequest WITH proper properties`() {
         // given
         val properties = hashMapOf("_test" to "test")
+        val sessionId = UUID.randomUUID()
         // when
-        with(activityRequestBuilder.group(properties)) {
+        with(activityRequestBuilder.group(sessionId, properties)) {
             // then
             assertThat(userId).isEqualTo("userId")
             assertThat(groupId).isEqualTo("groupId")
             assertThat(accountId).isEqualTo("accountId")
+            assertThat(this.sessionId).isEqualTo(sessionId)
             assertThat(groupUpdate).hasSize(1)
             assertThat(groupUpdate).containsEntry("_test", "test")
             assertThat(userSignature).isEqualTo("user-signature")
@@ -76,7 +81,7 @@ internal class ActivityRequestBuilderTest {
         // given
         val properties = hashMapOf("_test" to "test")
         // when
-        activityRequestBuilder.track("event1", properties)
+        activityRequestBuilder.track(UUID.randomUUID(), "event1", properties)
         // then
         verifySequence {
             autoPropertyDecorator.decorateTrack(eventRequestSlot.captured)
@@ -92,12 +97,14 @@ internal class ActivityRequestBuilderTest {
     fun `track SHOULD return ActivityRequest`() {
         // given
         val properties = hashMapOf("_test" to "test")
+        val sessionId = UUID.randomUUID()
         // when
-        with(activityRequestBuilder.track("event1", properties)) {
+        with(activityRequestBuilder.track(sessionId, "event1", properties)) {
             // then
             assertThat(userId).isEqualTo("userId")
             assertThat(accountId).isEqualTo("accountId")
             assertThat(groupId).isEqualTo("groupId")
+            assertThat(this.sessionId).isEqualTo(sessionId)
             assertThat(profileUpdate).hasSize(1)
             assertThat(profileUpdate).containsEntry("auto", "properties")
             assertThat(events).hasSize(1)
@@ -110,7 +117,7 @@ internal class ActivityRequestBuilderTest {
         // given
         val properties = mutableMapOf<String, Any>("_test" to "test")
         // when
-        activityRequestBuilder.screen("screen2", properties)
+        activityRequestBuilder.screen(UUID.randomUUID(), "screen2", properties)
         // then
         verifySequence {
             autoPropertyDecorator.decorateTrack(eventRequestSlot.captured)
@@ -128,12 +135,14 @@ internal class ActivityRequestBuilderTest {
     fun `screen SHOULD return ActivityRequest`() {
         // given
         val properties = mutableMapOf<String, Any>("_test" to "test")
+        val sessionId = UUID.randomUUID()
         // when
-        with(activityRequestBuilder.screen("screen2", properties)) {
+        with(activityRequestBuilder.screen(sessionId, "screen2", properties)) {
             // then
             assertThat(userId).isEqualTo("userId")
             assertThat(accountId).isEqualTo("accountId")
             assertThat(groupId).isEqualTo("groupId")
+            assertThat(this.sessionId).isEqualTo(sessionId)
             assertThat(profileUpdate).hasSize(1)
             assertThat(profileUpdate).containsEntry("auto", "properties")
             assertThat(events).hasSize(1)

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
@@ -20,6 +20,7 @@ import io.mockk.verify
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.util.UUID
 
 internal class AnalyticsQueueProcessorTest {
 
@@ -27,7 +28,8 @@ internal class AnalyticsQueueProcessorTest {
     val dispatcherRule = MainDispatcherRule()
 
     private val mockkEvent: EventRequest = mockk()
-    private val mockkActivity: ActivityRequest = ActivityRequest(userId = "222", accountId = "111", events = listOf(mockkEvent))
+    private val mockkActivity: ActivityRequest =
+        ActivityRequest(userId = "222", accountId = "111", sessionId = UUID.randomUUID(), events = listOf(mockkEvent))
     private val mockkQualificationResult: QualificationResult =
         QualificationResult(Qualification("screen_view"), arrayListOf(mockk()))
 
@@ -82,7 +84,7 @@ internal class AnalyticsQueueProcessorTest {
         // given
         val queuedActivitySlot = slot<ActivityRequest>()
         val queuedEvent: EventRequest = mockk()
-        val queuedActivity = ActivityRequest(userId = "222", accountId = "111", events = listOf(queuedEvent))
+        val queuedActivity = ActivityRequest(userId = "222", accountId = "111", sessionId = UUID.randomUUID(), events = listOf(queuedEvent))
         val activitySlot = slot<ActivityRequest>()
         analyticsQueueProcessor.queueForTesting(queuedActivity)
         // when
@@ -108,7 +110,7 @@ internal class AnalyticsQueueProcessorTest {
         // given
         val queuedActivitySlot = slot<ActivityRequest>()
         val queuedEvent: EventRequest = mockk()
-        val queuedActivity = ActivityRequest(userId = "222", accountId = "111", events = listOf(queuedEvent))
+        val queuedActivity = ActivityRequest(userId = "222", accountId = "111", sessionId = UUID.randomUUID(), events = listOf(queuedEvent))
         analyticsQueueProcessor.queueForTesting(queuedActivity)
         // when
         analyticsQueueProcessor.flushAsync()

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
@@ -68,8 +68,9 @@ internal class AnalyticsTrackerExtTest {
     fun `track experiment SHOULD call track with correct properties set in the map`() {
         // GIVEN
         val activity: ActivityRequest = mockk(relaxed = true)
-        every { activityBuilder.track(any(), any()) } returns activity
-        every { sessionMonitor.sessionId } returns UUID.randomUUID()
+        val sessionId = UUID.randomUUID()
+        every { activityBuilder.track(sessionId, any(), any()) } returns activity
+        every { sessionMonitor.sessionId } returns sessionId
         every { sessionMonitor.isExpired } returns false
         val experiment = Experiment(
             id = UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"),
@@ -83,6 +84,7 @@ internal class AnalyticsTrackerExtTest {
         // THEN
         verify {
             activityBuilder.track(
+                sessionId = sessionId,
                 name = "appcues:experiment_entered",
                 properties = mapOf(
                     "experimentId" to "06f9bf87-1921-4919-be55-429b278bf578",

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
@@ -52,7 +52,7 @@ internal class AnalyticsTrackerTest {
     fun `identify SHOULD do nothing WHEN no active session available`() {
         // given
         every { sessionMonitor.sessionId } returns null
-        every { sessionMonitor.startNewSession() } returns false
+        every { sessionMonitor.startNewSession() } returns null
         // when
         analyticsTracker.identify()
         // then
@@ -62,8 +62,9 @@ internal class AnalyticsTrackerTest {
     @Test
     fun `identify SHOULD update analyticsFlow AND flushThenSend`() {
         // given
-        every { sessionMonitor.sessionId } returns UUID.randomUUID()
-        every { sessionMonitor.startNewSession() } returns true
+        val sessionId = UUID.randomUUID()
+        every { sessionMonitor.sessionId } returns sessionId
+        every { sessionMonitor.startNewSession() } returns sessionId
         val activity: ActivityRequest = mockk(relaxed = true)
         every { activityBuilder.identify(any()) } returns activity
         // when
@@ -81,7 +82,7 @@ internal class AnalyticsTrackerTest {
     fun `track SHOULD do nothing WHEN no active session available`() {
         // given
         every { sessionMonitor.sessionId } returns null
-        every { sessionMonitor.startNewSession() } returns false
+        every { sessionMonitor.startNewSession() } returns null
         // when
         analyticsTracker.track("event1")
         // then
@@ -91,10 +92,11 @@ internal class AnalyticsTrackerTest {
     @Test
     fun `track SHOULD update analyticsFlow AND queueThenFlush WHEN interactive is true`() {
         // given
-        every { sessionMonitor.sessionId } returns UUID.randomUUID()
+        val sessionId = UUID.randomUUID()
+        every { sessionMonitor.sessionId } returns sessionId
         every { sessionMonitor.isExpired } returns false
         val activity: ActivityRequest = mockk(relaxed = true)
-        every { activityBuilder.track(any()) } returns activity
+        every { activityBuilder.track(sessionId, any()) } returns activity
         // when
         analyticsTracker.track("event1", interactive = true)
         // then
@@ -109,10 +111,11 @@ internal class AnalyticsTrackerTest {
     @Test
     fun `track SHOULD update analyticsFlow AND queue WHEN interactive is false`() {
         // given
-        every { sessionMonitor.sessionId } returns UUID.randomUUID()
+        val sessionId = UUID.randomUUID()
+        every { sessionMonitor.sessionId } returns sessionId
         every { sessionMonitor.isExpired } returns false
         val activity: ActivityRequest = mockk(relaxed = true)
-        every { activityBuilder.track(any()) } returns activity
+        every { activityBuilder.track(sessionId, any()) } returns activity
         // when
         analyticsTracker.track("event1", interactive = false)
         // then
@@ -128,7 +131,7 @@ internal class AnalyticsTrackerTest {
     fun `screen SHOULD do nothing WHEN no active session available`() {
         // given
         every { sessionMonitor.sessionId } returns null
-        every { sessionMonitor.startNewSession() } returns false
+        every { sessionMonitor.startNewSession() } returns null
         // when
         analyticsTracker.screen("title")
         // then
@@ -138,10 +141,11 @@ internal class AnalyticsTrackerTest {
     @Test
     fun `screen SHOULD update analyticsFlow AND queueThenFlush`() {
         // given
-        every { sessionMonitor.sessionId } returns UUID.randomUUID()
+        val sessionId = UUID.randomUUID()
+        every { sessionMonitor.sessionId } returns sessionId
         every { sessionMonitor.isExpired } returns false
         val activity: ActivityRequest = mockk(relaxed = true)
-        every { activityBuilder.screen(any()) } returns activity
+        every { activityBuilder.screen(sessionId, any()) } returns activity
         // when
         analyticsTracker.screen("title")
         // then
@@ -157,7 +161,7 @@ internal class AnalyticsTrackerTest {
     fun `group SHOULD do nothing WHEN no active session available`() {
         // given
         every { sessionMonitor.sessionId } returns null
-        every { sessionMonitor.startNewSession() } returns false
+        every { sessionMonitor.startNewSession() } returns null
         // when
         analyticsTracker.group()
         // then
@@ -167,10 +171,11 @@ internal class AnalyticsTrackerTest {
     @Test
     fun `group SHOULD update analyticsFlow AND flushThenSend`() {
         // given
-        every { sessionMonitor.sessionId } returns UUID.randomUUID()
+        val sessionId = UUID.randomUUID()
+        every { sessionMonitor.sessionId } returns sessionId
         every { sessionMonitor.isExpired } returns false
         val activity: ActivityRequest = mockk(relaxed = true)
-        every { activityBuilder.group() } returns activity
+        every { activityBuilder.group(sessionId) } returns activity
         // when
         analyticsTracker.group()
         // then

--- a/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
@@ -15,6 +15,7 @@ import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.util.UUID
 
 internal class AutoPropertyDecoratorTest {
 
@@ -187,7 +188,7 @@ internal class AutoPropertyDecoratorTest {
     @Test
     fun `decorateIdentity SHOULD add autoProperties to profileUpdate map`() {
         // given
-        val activityRequest = ActivityRequest(userId = "test userId", accountId = "test accountId")
+        val activityRequest = ActivityRequest(userId = "test userId", sessionId = UUID.randomUUID(), accountId = "test accountId")
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
@@ -201,6 +202,7 @@ internal class AutoPropertyDecoratorTest {
         val activityRequest = ActivityRequest(
             userId = "test userId",
             accountId = "test accountId",
+            sessionId = UUID.randomUUID(),
             profileUpdate = hashMapOf("test_property" to "test_value")
         )
         // when
@@ -220,6 +222,7 @@ internal class AutoPropertyDecoratorTest {
         val activityRequest = ActivityRequest(
             userId = "test userId",
             accountId = "test accountId",
+            sessionId = UUID.randomUUID(),
             profileUpdate = hashMapOf("_test" to "Test")
         )
         // when

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -109,7 +109,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD save to local storage AND send qualify request`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId")
+        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk<ExperienceResponse>(), mockk<ExperienceResponse>()),
             performedQualification = true,
@@ -136,7 +136,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD call postActivity on cache item WHEN the next request is sent`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId")
+        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
         val activityStorage = ActivityStorage(UUID.randomUUID(), "123", "userId", "data", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
 
@@ -154,7 +154,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD retain cache item WHEN the qualify request fails with a NetworkError`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId")
+        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
         coEvery { appcuesRemoteSource.qualify(any(), any(), request.requestId, any()) } returns Failure(NetworkError())
 
         // WHEN
@@ -168,7 +168,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD NOT retain cache item WHEN the qualify request fails with an HTTPError`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId")
+        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
         coEvery { appcuesRemoteSource.qualify(any(), any(), request.requestId, any()) } returns Failure(HttpError())
 
         // WHEN
@@ -182,7 +182,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD retain a cache item WHEN the retry fails with a NetworkError`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId")
+        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
         val activityStorage = ActivityStorage(UUID.randomUUID(), "123", "userId", "data", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
         coEvery { appcuesRemoteSource.postActivity("userId", null, "data") } returns Failure(NetworkError())
@@ -200,7 +200,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD NOT retain a cache item WHEN the retry fails with an HTTPError`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId")
+        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
         val activityStorage = ActivityStorage(UUID.randomUUID(), "123", "userId", "data", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
         coEvery { appcuesRemoteSource.postActivity("userId", null, "data") } returns Failure(HttpError())
@@ -267,7 +267,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD mark the experience LOW priority WHEN the qualification reason is screen_view`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId")
+        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk<ExperienceResponse>(), mockk<ExperienceResponse>()),
             performedQualification = true,
@@ -290,7 +290,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD mark the experience NORMAL priority WHEN the qualification reason is not screen_view`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId")
+        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk<ExperienceResponse>(), mockk<ExperienceResponse>()),
             performedQualification = true,
@@ -313,7 +313,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD include user signature in ActivityStorage WHEN the ActivityRequest has a user signature`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId", userSignature = "user-signature")
+        val request = ActivityRequest(accountId = "123", userId = "userId", sessionId = UUID.randomUUID(), userSignature = "user-signature")
         val cacheItem = ActivityStorage(UUID.randomUUID(), "123", "userId", "data1", "user-signature-cache")
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(cacheItem)
 


### PR DESCRIPTION
As requested [here](https://appcues.slack.com/archives/C04MYUL758B/p1694113053183879). adding new property session_id to every ActivityRequest.

most of the changes impacted unit test since ActivityRequest is an object used in many places, the core change is on AnalyticsTracker and SessionMonitor, where we changed `checkSession: Boolean` to `getSession(): UUID? `
and `startSession(): Boolean` to `startSession(): UUID?`



updated example of response including new session_id:

```json

{
	"request_id": "c592f943-8b38-42b0-a3b5-cdfaa060c56d",
	"profile_update": {
		"_deviceType": "phone",
		"_deviceModel": "Google sdk_gphone64_arm64",
		"_sessionRandomizer": 19,
		"_appVersion": "1.0",
		"_lastContentShownAt": 1694446894789,
		"_appBuild": "1",
		"_sessionId": "d473c99e-e810-4308-98dd-9e7ec2b30f4a",
		"_userAgent": "Dalvik/2.1.0 (Linux; U; Android 13; sdk_gphone64_arm64 Build/TE1A.220922.031)",
		"userId": "default-5555",
		"_operatingSystem": "android",
		"_sdkName": "appcues-android",
		"_osVersion": "33",
		"_appName": "Appcues Example",
		"_lastBrowserLanguage": "en",
		"_appId": "4b6b796f-1313-440a-b356-ee4b7abe931c",
		"_isAnonymous": false,
		"_sessionPageviews": 0,
		"_localId": "6231d407-fb8f-43e2-a177-75e2e4fa28b4",
		"_updatedAt": 1694447738282,
		"_bundlePackageId": "com.appcues.samples.kotlin",
		"_sdkVersion": "3.0.2"
	},
	"user_id": "default-5555",
	"account_id": "103523",
	"session_id": "d473c99e-e810-4308-98dd-9e7ec2b30f4a",
	"group_id": null
}
```