### PR TITLE
Add slideout transition handling to dialog modal

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/AppcuesContentAnimatedVisibility.kt
+++ b/appcues/src/main/java/com/appcues/trait/AppcuesContentAnimatedVisibility.kt
@@ -16,13 +16,14 @@ import com.appcues.ui.composables.LocalExperienceCompositionState
  */
 @Composable
 internal fun AppcuesContentAnimatedVisibility(
+    modifier: Modifier = Modifier,
     enter: EnterTransition,
     exit: ExitTransition,
     content: @Composable() AnimatedVisibilityScope.() -> Unit
 ) {
     val compositionState = LocalExperienceCompositionState.current
     AnimatedVisibility(
-        modifier = Modifier,
+        modifier = modifier,
         visibleState = compositionState.isContentVisible,
         enter = enter,
         exit = exit,

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.RenderContext
+import com.appcues.data.model.getConfig
 import com.appcues.data.model.getConfigOrDefault
 import com.appcues.data.model.getConfigStyle
 import com.appcues.trait.AppcuesTraitException
@@ -12,6 +13,7 @@ import com.appcues.trait.ContentWrappingTrait
 import com.appcues.trait.PresentingTrait
 import com.appcues.ui.modal.BottomSheetModal
 import com.appcues.ui.modal.DialogModal
+import com.appcues.ui.modal.DialogTransition
 import com.appcues.ui.modal.ExpandedBottomSheetModal
 import com.appcues.ui.modal.FullScreenModal
 import com.appcues.ui.presentation.OverlayViewPresenter
@@ -47,7 +49,7 @@ internal class ModalTrait(
         val windowInfo = rememberAppcuesWindowInfo()
 
         when (presentationStyle) {
-            "dialog" -> DialogModal(style, content, windowInfo)
+            "dialog" -> DialogModal(style, content, windowInfo, getDialogTransition())
             "full" -> FullScreenModal(style, content, windowInfo)
             "sheet" -> ExpandedBottomSheetModal(style, content, windowInfo)
             "halfSheet" -> BottomSheetModal(style, content, windowInfo)
@@ -66,5 +68,13 @@ internal class ModalTrait(
 
     override fun remove() {
         presenter.remove()
+    }
+
+    private fun getDialogTransition(): DialogTransition {
+        return DialogTransition(
+            type = config.getConfigOrDefault("transition", "fade"),
+            slideInEdge = config.getConfig("slideInEdge"),
+            slideOutEdge = config.getConfig("slideOutEdge")
+        )
     }
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.RenderContext
-import com.appcues.data.model.getConfig
 import com.appcues.data.model.getConfigOrDefault
 import com.appcues.data.model.getConfigStyle
 import com.appcues.trait.AppcuesTraitException
@@ -14,6 +13,8 @@ import com.appcues.trait.PresentingTrait
 import com.appcues.ui.modal.BottomSheetModal
 import com.appcues.ui.modal.DialogModal
 import com.appcues.ui.modal.DialogTransition
+import com.appcues.ui.modal.DialogTransition.FADE
+import com.appcues.ui.modal.DialogTransition.SLIDE
 import com.appcues.ui.modal.ExpandedBottomSheetModal
 import com.appcues.ui.modal.FullScreenModal
 import com.appcues.ui.presentation.OverlayViewPresenter
@@ -71,10 +72,9 @@ internal class ModalTrait(
     }
 
     private fun getDialogTransition(): DialogTransition {
-        return DialogTransition(
-            type = config.getConfigOrDefault("transition", "fade"),
-            slideInEdge = config.getConfig("slideInEdge"),
-            slideOutEdge = config.getConfig("slideOutEdge")
-        )
+        return when (config.getConfigOrDefault("transition", "fade")) {
+            "slide" -> SLIDE
+            else -> FADE
+        }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -43,8 +44,8 @@ private val MAX_WIDTH_EXPANDED_DP = 560.dp
 private val MAX_HEIGHT_COMPACT_DP = Dp.Unspecified
 private val MAX_HEIGHT_MEDIUM_DP = 800.dp
 private val MAX_HEIGHT_EXPANDED_DP = 900.dp
+private const val SCREEN_PADDING = 0.05
 
-private val SCREEN_HORIZONTAL_PADDING = 12.dp
 private val SCREEN_VERTICAL_PADDING = 24.dp
 
 internal data class DialogTransition(
@@ -70,13 +71,18 @@ internal fun DialogModal(
     val maxWidth = maxWidthDerivedOf(windowInfo)
     val maxHeight = maxHeightDerivedOf(windowInfo)
 
-    val horizontalPaddingPx = with(density) { SCREEN_HORIZONTAL_PADDING.roundToPx() }
+    // horizontal padding is a scale factor based on device width
+    // vertical padding is a fixed constant
+    val configuration = LocalConfiguration.current
+    val dialogHorizontalPadding = (configuration.screenWidthDp * SCREEN_PADDING).dp
+
+    val horizontalPaddingPx = with(density) { dialogHorizontalPadding.roundToPx() }
     val verticalPaddingPx = with(density) { SCREEN_VERTICAL_PADDING.roundToPx() }
 
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = SCREEN_HORIZONTAL_PADDING, vertical = SCREEN_VERTICAL_PADDING)
+            .padding(horizontal = dialogHorizontalPadding, vertical = SCREEN_VERTICAL_PADDING)
     ) {
         AppcuesContentAnimatedVisibility(
             modifier = Modifier.align(style.getBoxAlignment()),

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -1,5 +1,7 @@
 package com.appcues.ui.modal
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -7,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
@@ -14,14 +17,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
+import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment
+import com.appcues.data.model.styling.ComponentStyle.ComponentVerticalAlignment
 import com.appcues.trait.AppcuesContentAnimatedVisibility
 import com.appcues.ui.extensions.getBoxAlignment
 import com.appcues.ui.extensions.getPaddings
 import com.appcues.ui.extensions.modalStyle
+import com.appcues.ui.modal.TransitionEdge.BOTTOM
+import com.appcues.ui.modal.TransitionEdge.CENTER
+import com.appcues.ui.modal.TransitionEdge.LEADING
+import com.appcues.ui.modal.TransitionEdge.TOP
+import com.appcues.ui.modal.TransitionEdge.TRAILING
 import com.appcues.ui.utils.AppcuesWindowInfo
 import com.appcues.ui.utils.AppcuesWindowInfo.ScreenType.COMPACT
 import com.appcues.ui.utils.AppcuesWindowInfo.ScreenType.EXPANDED
@@ -33,47 +43,118 @@ private val MAX_WIDTH_EXPANDED_DP = 560.dp
 private val MAX_HEIGHT_COMPACT_DP = Dp.Unspecified
 private val MAX_HEIGHT_MEDIUM_DP = 800.dp
 private val MAX_HEIGHT_EXPANDED_DP = 900.dp
-private const val SCREEN_PADDING = 0.05
+
+private val SCREEN_HORIZONTAL_PADDING = 12.dp
+private val SCREEN_VERTICAL_PADDING = 24.dp
+
+internal data class DialogTransition(
+    val type: String,
+    val slideInEdge: String?,
+    val slideOutEdge: String?,
+)
+
+internal enum class TransitionEdge {
+    LEADING, TRAILING, TOP, BOTTOM, CENTER
+}
 
 @Composable
 internal fun DialogModal(
     style: ComponentStyle?,
     content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
-    windowInfo: AppcuesWindowInfo
+    windowInfo: AppcuesWindowInfo,
+    transition: DialogTransition,
 ) {
-    val configuration = LocalConfiguration.current
-    val dialogHorizontalMargin = (configuration.screenWidthDp * SCREEN_PADDING).dp
-    val dialogVerticalMargin = (configuration.screenHeightDp * SCREEN_PADDING).dp
     val isDark = isSystemInDarkTheme()
+    val density = LocalDensity.current
 
     val maxWidth = maxWidthDerivedOf(windowInfo)
     val maxHeight = maxHeightDerivedOf(windowInfo)
 
-    AppcuesContentAnimatedVisibility(
-        enter = dialogEnterTransition(),
-        exit = dialogExitTransition(),
+    val horizontalPaddingPx = with(density) { SCREEN_HORIZONTAL_PADDING.roundToPx() }
+    val verticalPaddingPx = with(density) { SCREEN_VERTICAL_PADDING.roundToPx() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = SCREEN_HORIZONTAL_PADDING, vertical = SCREEN_VERTICAL_PADDING)
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
+        AppcuesContentAnimatedVisibility(
+            modifier = Modifier.align(style.getBoxAlignment()),
+            enter = transition.toEnterTransition(style, horizontalPaddingPx, verticalPaddingPx),
+            exit = transition.toExitTransition(style, horizontalPaddingPx, verticalPaddingPx),
+        ) {
             Surface(
                 modifier = Modifier
-                    .align(style.getBoxAlignment())
                     .sizeIn(maxWidth = maxWidth.value, maxHeight = maxHeight.value)
-                    .fillMaxWidth()
-                    // container padding based on screen size
-                    .padding(horizontal = dialogHorizontalMargin, vertical = dialogVerticalMargin)
+                    .styleWidth(style)
                     // default modal style modifiers
-                    .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) },
-                content = {
-                    content(
-                        modifier = Modifier.verticalScroll(rememberScrollState()),
-                        containerPadding = style.getPaddings(),
-                        safeAreaInsets = PaddingValues()
-                    )
-                },
-            )
+                    .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) }
+            ) {
+                content(
+                    modifier = Modifier.verticalScroll(rememberScrollState()),
+                    containerPadding = style.getPaddings(),
+                    safeAreaInsets = PaddingValues()
+                )
+            }
         }
     }
 }
+
+private fun DialogTransition.toEnterTransition(style: ComponentStyle?, horizontalPadding: Int, verticalPadding: Int): EnterTransition {
+    return when (this.type) {
+        "slide" ->
+            slideOutEnterTransition(style.getSlideEdge(this.slideInEdge), horizontalPadding, verticalPadding)
+        else -> dialogEnterTransition()
+    }
+}
+
+private fun DialogTransition.toExitTransition(style: ComponentStyle?, horizontalPadding: Int, verticalPadding: Int): ExitTransition {
+    return when (this.type) {
+        // for the exit edge, if no fixed exit given but a fixed enter edge was used, fall back to that
+        "slide" ->
+            slideOutExitTransition(style.getSlideEdge(this.slideOutEdge ?: this.slideInEdge), horizontalPadding, verticalPadding)
+        else -> dialogExitTransition()
+    }
+}
+
+// determine slide edge based on config, or default based on alignment
+private fun ComponentStyle?.getSlideEdge(fixed: String?): TransitionEdge {
+    val fixedEdge = fixed?.let {
+        when (it) {
+            "top" -> TOP
+            "bottom" -> BOTTOM
+            "leading" -> LEADING
+            "trailing" -> TRAILING
+            "center" -> CENTER
+            else -> null
+        }
+    }
+
+    if (fixedEdge != null) return fixedEdge
+
+    // if no fixed edge provided, find the best default based on the content alignment
+    return when (this?.horizontalAlignment ?: ComponentHorizontalAlignment.CENTER) {
+        ComponentHorizontalAlignment.LEADING -> LEADING
+        ComponentHorizontalAlignment.TRAILING -> TRAILING
+        ComponentHorizontalAlignment.CENTER -> {
+            when (this?.verticalAlignment ?: ComponentVerticalAlignment.CENTER) {
+                ComponentVerticalAlignment.TOP -> TOP
+                ComponentVerticalAlignment.BOTTOM -> BOTTOM
+                ComponentVerticalAlignment.CENTER -> CENTER
+            }
+        }
+    }
+}
+
+private fun Modifier.styleWidth(
+    style: ComponentStyle?,
+) = this.then(
+    when {
+        // if a positive width value is specified, use it, otherwise fill width
+        style?.width != null -> if (style.width < 0.0) Modifier.fillMaxWidth() else Modifier.width(style.width.dp)
+        else -> Modifier
+    }
+)
 
 private fun maxWidthDerivedOf(windowInfo: AppcuesWindowInfo): State<Dp> {
     return derivedStateOf {

--- a/appcues/src/main/java/com/appcues/ui/modal/SharedModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/SharedModal.kt
@@ -7,14 +7,23 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
+import androidx.compose.animation.slideIn
+import androidx.compose.animation.slideOut
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.extensions.getCornerRadius
 import com.appcues.ui.extensions.styleCorner
 import com.appcues.ui.extensions.styleShadow
+import com.appcues.ui.modal.TransitionEdge.BOTTOM
+import com.appcues.ui.modal.TransitionEdge.CENTER
+import com.appcues.ui.modal.TransitionEdge.LEADING
+import com.appcues.ui.modal.TransitionEdge.TOP
+import com.appcues.ui.modal.TransitionEdge.TRAILING
 import com.appcues.ui.utils.AppcuesWindowInfo
 import com.appcues.ui.utils.AppcuesWindowInfo.DeviceType.MOBILE
 import com.appcues.ui.utils.AppcuesWindowInfo.DeviceType.TABLET
@@ -29,6 +38,42 @@ internal fun dialogEnterTransition(): EnterTransition {
 
 internal fun dialogExitTransition(): ExitTransition {
     return fadeOut(tween(durationMillis = 100))
+}
+
+internal fun slideOutEnterTransition(initial: TransitionEdge, horizontalPadding: Int, verticalPadding: Int): EnterTransition {
+    val slide = slideIn(
+        initialOffset = { initial.toOffset(it, horizontalPadding, verticalPadding) },
+        animationSpec = tween(durationMillis = 1000)
+    )
+
+    return if (initial == CENTER) {
+        slide + fadeIn(tween(durationMillis = 1000))
+    } else {
+        slide
+    }
+}
+
+internal fun slideOutExitTransition(target: TransitionEdge, horizontalPadding: Int, verticalPadding: Int): ExitTransition {
+    val slide = slideOut(
+        targetOffset = { target.toOffset(it, horizontalPadding, verticalPadding) },
+        animationSpec = tween(durationMillis = 300)
+    )
+
+    return if (target == CENTER) {
+        slide + fadeOut(tween(durationMillis = 300))
+    } else {
+        slide
+    }
+}
+
+private fun TransitionEdge.toOffset(fullSize: IntSize, horizontalPadding: Int, verticalPadding: Int): IntOffset {
+    return when (this) {
+        LEADING -> IntOffset(-fullSize.width - horizontalPadding, 0)
+        TRAILING -> IntOffset(fullSize.width + horizontalPadding, 0)
+        TOP -> IntOffset(0, -fullSize.height - verticalPadding)
+        BOTTOM -> IntOffset(0, fullSize.height + verticalPadding)
+        CENTER -> IntOffset(0, fullSize.height / 2)
+    }
 }
 
 internal fun Modifier.dialogModifier(style: ComponentStyle, isDark: Boolean) =

--- a/appcues/src/main/java/com/appcues/ui/modal/SharedModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/SharedModal.kt
@@ -19,11 +19,11 @@ import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.extensions.getCornerRadius
 import com.appcues.ui.extensions.styleCorner
 import com.appcues.ui.extensions.styleShadow
-import com.appcues.ui.modal.TransitionEdge.BOTTOM
-import com.appcues.ui.modal.TransitionEdge.CENTER
-import com.appcues.ui.modal.TransitionEdge.LEADING
-import com.appcues.ui.modal.TransitionEdge.TOP
-import com.appcues.ui.modal.TransitionEdge.TRAILING
+import com.appcues.ui.modal.SlideTransitionEdge.BOTTOM
+import com.appcues.ui.modal.SlideTransitionEdge.CENTER
+import com.appcues.ui.modal.SlideTransitionEdge.LEADING
+import com.appcues.ui.modal.SlideTransitionEdge.TOP
+import com.appcues.ui.modal.SlideTransitionEdge.TRAILING
 import com.appcues.ui.utils.AppcuesWindowInfo
 import com.appcues.ui.utils.AppcuesWindowInfo.DeviceType.MOBILE
 import com.appcues.ui.utils.AppcuesWindowInfo.DeviceType.TABLET
@@ -40,7 +40,7 @@ internal fun dialogExitTransition(): ExitTransition {
     return fadeOut(tween(durationMillis = 100))
 }
 
-internal fun slideOutEnterTransition(initial: TransitionEdge, horizontalPadding: Int, verticalPadding: Int): EnterTransition {
+internal fun slideOutEnterTransition(initial: SlideTransitionEdge, horizontalPadding: Int, verticalPadding: Int): EnterTransition {
     val slide = slideIn(
         initialOffset = { initial.toOffset(it, horizontalPadding, verticalPadding) },
         animationSpec = tween(durationMillis = 1000)
@@ -53,7 +53,7 @@ internal fun slideOutEnterTransition(initial: TransitionEdge, horizontalPadding:
     }
 }
 
-internal fun slideOutExitTransition(target: TransitionEdge, horizontalPadding: Int, verticalPadding: Int): ExitTransition {
+internal fun slideOutExitTransition(target: SlideTransitionEdge, horizontalPadding: Int, verticalPadding: Int): ExitTransition {
     val slide = slideOut(
         targetOffset = { target.toOffset(it, horizontalPadding, verticalPadding) },
         animationSpec = tween(durationMillis = 300)
@@ -66,7 +66,7 @@ internal fun slideOutExitTransition(target: TransitionEdge, horizontalPadding: I
     }
 }
 
-private fun TransitionEdge.toOffset(fullSize: IntSize, horizontalPadding: Int, verticalPadding: Int): IntOffset {
+private fun SlideTransitionEdge.toOffset(fullSize: IntSize, horizontalPadding: Int, verticalPadding: Int): IntOffset {
     return when (this) {
         LEADING -> IntOffset(-fullSize.width - horizontalPadding, 0)
         TRAILING -> IntOffset(fullSize.width + horizontalPadding, 0)


### PR DESCRIPTION
This PR adds support for the slideout display style in our dialog modal. The key aspects of this are
* Can have a specific width specified, not always full width
* Can be positioned in any horizontal or vertical alignment combination
* Can include a slide in from edge transition animation (and matching exit)

There were some structural changes in `DialogModal` to support this, and I'll try to call those out specifically. But there should not be any visual difference in a standard dialog modal using the existing "dialog" style and the default fade transition. Will confirm this with UI tests as well.

https://github.com/appcues/appcues-android-sdk/assets/19266448/12af2426-f45c-44bf-90a2-c8c8b102eb71

