### PR TITLE
Fix unit test warnings

### DIFF
--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -20,7 +20,6 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -28,7 +27,6 @@ import org.junit.Test
 import org.koin.core.component.get
 import java.util.UUID
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class AppcuesTest : AppcuesScopeTest {
 
     @get:Rule
@@ -49,7 +47,6 @@ internal class AppcuesTest : AppcuesScopeTest {
         // GIVEN
         val userId = ""
         val tracker: AnalyticsTracker = get()
-        val sessionMonitor: SessionMonitor = get()
 
         // WHEN
         appcues.identify(userId)
@@ -59,12 +56,11 @@ internal class AppcuesTest : AppcuesScopeTest {
     }
 
     @Test
-    fun `identify SHOULD update Storage AND call AnalyticsTracker identify function AND start session`() {
+    fun `identify SHOULD update Storage AND call AnalyticsTracker identify`() {
         // GIVEN
         val userId = "default-0000"
         val properties = mapOf<String, Any>("prop" to "value")
         val storage: Storage = get()
-        val sessionMonitor: SessionMonitor = get()
         val tracker: AnalyticsTracker = get()
 
         // WHEN
@@ -205,7 +201,6 @@ internal class AppcuesTest : AppcuesScopeTest {
         // GIVEN
         val storage: Storage = get()
         val tracker: AnalyticsTracker = get()
-        val sessionMonitor: SessionMonitor = get()
 
         // WHEN
         appcues.anonymous()

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -197,7 +197,7 @@ internal class AppcuesTest : AppcuesScopeTest {
     }
 
     @Test
-    fun `anonymous SHOULD set Storage userId equal to the deviceId AND identify AND start a session`() {
+    fun `anonymous SHOULD set Storage userId equal to the deviceId AND identify`() {
         // GIVEN
         val storage: Storage = get()
         val tracker: AnalyticsTracker = get()

--- a/appcues/src/test/java/com/appcues/data/mapper/step/StepMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/StepMapperTest.kt
@@ -129,13 +129,16 @@ internal class StepMapperTest {
 
         val groupTraits = listOf(groupDecoratingTrait to ExperienceTraitLevel.GROUP)
 
+        // helper to avoid nested this@mockk references
+        fun getMockTrait(type: String): TestStepDecoratingTrait = mockk(relaxed = true) {
+            every { this@mockk.type } answers { type }
+        }
+
         val slot = slot<List<LeveledTraitResponse>>()
         val traitMapper = mockk<TraitsMapper>(relaxed = true) {
             every { map(RenderContext.Modal, capture(slot)) } answers {
                 slot.captured.map { leveledTrait ->
-                    mockk<TestStepDecoratingTrait>(relaxed = true) {
-                        every { this@mockk.type } answers { leveledTrait.first.type }
-                    }
+                    getMockTrait(leveledTrait.first.type)
                 }
             }
         }
@@ -166,13 +169,16 @@ internal class StepMapperTest {
 
         val groupTraits = listOf(groupDecoratingTrait to ExperienceTraitLevel.GROUP)
 
+        // helper to avoid nested this@mockk references
+        fun getMockTrait(level: ExperienceTraitLevel): TestStepDecoratingTrait = mockk(relaxed = true) {
+            every { this@mockk.level } answers { level }
+        }
+
         val slot = slot<List<LeveledTraitResponse>>()
         val traitMapper = mockk<TraitsMapper>(relaxed = true) {
             every { map(RenderContext.Modal, capture(slot)) } answers {
                 slot.captured.map { leveledTrait ->
-                    mockk<TestStepDecoratingTrait>(relaxed = true) {
-                        every { this@mockk.level } answers { leveledTrait.second }
-                    }
+                    getMockTrait(leveledTrait.second)
                 }
             }
         }


### PR DESCRIPTION
Recent test CI worked revealed a few small warnings in the unit test build. These updates will resolve those.

```
> Task :*******:*******:compileDebugUnitTestKotlin
w: file:///home/circleci/project/*******-android-sdk/*******/src/test/java/com/*******/AppcuesTest.kt:52:13 Variable 'sessionMonitor' is never used
w: file:///home/circleci/project/*******-android-sdk/*******/src/test/java/com/*******/AppcuesTest.kt:67:13 Variable 'sessionMonitor' is never used
w: file:///home/circleci/project/*******-android-sdk/*******/src/test/java/com/*******/AppcuesTest.kt:208:13 Variable 'sessionMonitor' is never used
w: file:///home/circleci/project/*******-android-sdk/*******/src/test/java/com/*******/data/mapper/step/StepMapperTest.kt:137:37 There is more than one label with such a name in this scope
w: file:///home/circleci/project/*******-android-sdk/*******/src/test/java/com/*******/data/mapper/step/StepMapperTest.kt:174:37 There is more than one label with such a name in this scope
```