### PR TITLE
Fix reporting of missing render context errors

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -4,13 +4,19 @@ import com.appcues.data.model.Experience
 import com.appcues.data.model.RenderContext
 import java.util.UUID
 
-internal sealed class Error(open val message: String) {
+internal sealed class Error(open val message: String, errorId: UUID? = null) {
 
-    val id: UUID = UUID.randomUUID()
+    val id: UUID = errorId ?: UUID.randomUUID()
 
     object ExperienceAlreadyActive : Error("Experience already active")
 
     data class RenderContextNotActive(val renderContext: RenderContext) : Error("RenderContext $renderContext is not active.")
-    data class ExperienceError(val experience: Experience, override val message: String) : Error(message)
+
+    data class ExperienceError(
+        val experience: Experience,
+        override val message: String,
+        val errorId: UUID? = null
+    ) : Error(message, errorId)
+
     data class StepError(val experience: Experience, val stepIndex: Int, override val message: String) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -5,8 +5,8 @@ import com.appcues.AppcuesFrameView
 import com.appcues.SessionMonitor
 import com.appcues.analytics.AnalyticsTracker
 import com.appcues.analytics.track
-import com.appcues.analytics.trackExperienceError
 import com.appcues.analytics.trackExperienceRecovery
+import com.appcues.analytics.trackRecoverableExperienceError
 import com.appcues.data.AppcuesRepository
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePriority.NORMAL
@@ -95,7 +95,7 @@ internal class ExperienceRenderer(override val scope: Scope) : KoinScopeComponen
         if (!canShow) return WontDisplay
 
         val stateMachine = stateMachines.getOwner(renderContext)?.stateMachine ?: return NoRenderContext(experience, renderContext)
-            .also { analyticsTracker.trackExperienceError(experience, "no render context $renderContext") }
+            .also { analyticsTracker.trackRecoverableExperienceError(experience, "no render context $renderContext") }
 
         if (stateMachine.checkPriority(this)) {
             return when (val result = stateMachine.handleAction(EndExperience(markComplete = false, destroyed = false))) {


### PR DESCRIPTION
Discovered this bug while testing some other analytics changes in 3.1. We had an issue with how we were reporting experience errors for the "no render context found" case, related to embeds.

1. (less severe) It was not including any of the experience properties like normal lifecycle events
2. (primary issue) it can potentially end up reporting the same error over and over each 10 sec interval as it is flushed and a new (empty) qualify response comes back

The key thing was that we were missing this guard that iOS has: https://github.com/appcues/appcues-ios-sdk/blob/e8308edbf160cd7b3b6bd2e70982a8e08f110f26/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift#L118 -- this ensures that a recoverable error is only tracked once - when it initially gets processed and the error ID is null. If the error ID is not null, that means it was already sent and we should just ignore and wait until if/when it recovers.

We now have the similar check in the function used in AnalyticsTrackerExt here.