### PR TITLE
Use language tag for _lastBrowserLanguage auto property

### DIFF
--- a/appcues/src/main/java/com/appcues/util/ContextResources.kt
+++ b/appcues/src/main/java/com/appcues/util/ContextResources.kt
@@ -57,7 +57,7 @@ internal class ContextResources(private val context: Context) {
     }
 
     fun getLanguage(): String {
-        return getCurrentLocale(context).language
+        return getCurrentLocale(context).toLanguageTag()
     }
 
     fun getUserAgent(): String? = System.getProperty("http.agent")


### PR DESCRIPTION
This update will capture the primary language with the region subtag, like "en-US" rather than just "en".