### PR TITLE
Add locale name and id in analytics

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleEvent.kt
@@ -89,10 +89,8 @@ internal sealed class ExperienceLifecycleEvent(
             "experienceType" to experience.type,
             "frameId" to experience.renderContext.getFrameId(),
             "version" to experience.publishedAt,
-            // items in the spec that we are not ready for yet:
-            // "version" to experience.version -- not included in response?
-            // "localeName" to "", -- add locale values to analytics for localized experiences
-            // "localeId" to "", -- add locale values to analytics for localized experiences
+            "localeName" to experience.localeName,
+            "localeId" to experience.localeId,
         ).apply {
             flatStepIndex?.let {
                 experience.flatSteps.getOrNull(it)?.let { step ->

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -70,6 +70,8 @@ internal class ExperienceMapper(
             type = from.type ?: "",
             renderContext = from.getRenderContext(),
             publishedAt = from.publishedAt,
+            localeId = from.context?.localeId,
+            localeName = from.context?.localeName,
             experiment = experiments?.getExperiment(from.id),
             completionActions = emptyList(),
             trigger = trigger,
@@ -97,6 +99,8 @@ internal class ExperienceMapper(
             type = from.type,
             renderContext = renderContext,
             publishedAt = from.publishedAt,
+            localeId = from.context?.localeId,
+            localeName = from.context?.localeName,
             experiment = experiments?.getExperiment(from.id),
             completionActions = arrayListOf<ExperienceAction>().apply {
                 from.redirectUrl?.let {

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -12,6 +12,8 @@ internal data class Experience(
     val type: String?,
     val renderContext: RenderContext,
     val publishedAt: Long?,
+    val localeId: String?,
+    val localeName: String?,
     val experiment: Experiment?,
     val completionActions: List<ExperienceAction>,
     val trigger: ExperienceTrigger,

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/response/experience/ExperienceResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/response/experience/ExperienceResponse.kt
@@ -2,6 +2,7 @@ package com.appcues.data.remote.appcues.response.experience
 
 import com.appcues.data.remote.appcues.response.step.StepContainerResponse
 import com.appcues.data.remote.appcues.response.trait.TraitResponse
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.UUID
 
@@ -17,6 +18,7 @@ internal data class ExperienceResponse(
     val publishedAt: Long?,
     val nextContentId: String?,
     val redirectUrl: String?,
+    val context: ContextResponse?,
 ) : LossyExperienceResponse()
 
 @JsonClass(generateAdapter = true)
@@ -25,7 +27,17 @@ internal data class FailedExperienceResponse(
     val name: String?,
     val type: String?,
     val publishedAt: Long?,
+    val context: ContextResponse?,
     var error: String? = null
 ) : LossyExperienceResponse()
 
 internal sealed class LossyExperienceResponse
+
+@JsonClass(generateAdapter = true)
+internal data class ContextResponse(
+    // this value should be a UUID, but it is just for analytics, so capture and return string verbatim
+    @Json(name = "locale_id")
+    val localeId: String?,
+    @Json(name = "locale_name")
+    val localeName: String?,
+)

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/response/experience/ExperienceResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/response/experience/ExperienceResponse.kt
@@ -35,7 +35,8 @@ internal sealed class LossyExperienceResponse
 
 @JsonClass(generateAdapter = true)
 internal data class ContextResponse(
-    // this value should be a UUID, but it is just for analytics, so capture and return string verbatim
+    // this value is a UUID if a locale is used, or "default" if not - so needs to be a string
+    // and just returned verbatim in analytics
     @Json(name = "locale_id")
     val localeId: String?,
     @Json(name = "locale_name")

--- a/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/SubmitFormActionTest.kt
@@ -285,6 +285,8 @@ internal class SubmitFormActionTest : AppcuesScopeTest {
         type = "mobile",
         renderContext = RenderContext.Modal,
         publishedAt = Date().time,
+        localeId = null,
+        localeName = null,
         completionActions = listOf(),
         trigger = ExperienceTrigger.ShowCall,
         experiment = null,

--- a/appcues/src/test/java/com/appcues/data/mapper/experience/ExperienceMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/experience/ExperienceMapperTest.kt
@@ -1,42 +1,100 @@
 package com.appcues.data.mapper.experience
 
+import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.remote.appcues.response.experience.ContextResponse
+import com.appcues.data.remote.appcues.response.experience.ExperienceResponse
+import com.appcues.data.remote.appcues.response.experience.FailedExperienceResponse
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import org.junit.Test
+import java.util.UUID
+
 internal class ExperienceMapperTest {
 
-    //    private val mapper = ExperienceMapper(
-    //        traitMapper = traitMapper,
-    //        stepMapper = stepMapper
-    //    )
-    //
-    //    @Test
-    //    fun `map SHOULD transform ExperienceResponse into Experience`() {
-    //        // GIVEN
-    //        val randomId = UUID.randomUUID()
-    //
-    //        val stepResponse = mockk<StepResponse>()
-    //        val step = mockk<Step>()
-    //        val actions = hashMapOf<UUID, List<ActionResponse>>()
-    //        every { stepMapper.map(stepResponse, actions) } returns step
-    //        val traitResponse = mockk<TraitResponse>()
-    //        val trait = mockk<Trait>()
-    //        every { traitMapper.map(traitResponse) } returns trait
-    //        val from = ExperienceResponse(
-    //            id = randomId,
-    //            name = "Test Experience",
-    //            theme = ExperienceThemeResponse(),
-    //            actions = actions,
-    //            traits = arrayListOf(traitResponse),
-    //            steps = arrayListOf(stepResponse),
-    //        )
-    //        // WHEN
-    //        val result = mapper.map(from)
-    //        // THEN
-    //        with(result) {
-    //            assertThat(id).isEqualTo(randomId)
-    //            assertThat(name).isEqualTo("Test Experience")
-    //            assertThat(steps).hasSize(1)
-    //            assertThat(steps[0]).isEqualTo(step)
-    //            assertThat(traits).hasSize(1)
-    //            assertThat(traits[0]).isEqualTo(trait)
-    //        }
-    //    }
+    @Test
+    fun `mapDecoded SHOULD set locale properties from ExperienceResponse context`() {
+        // GIVEN
+        val mapper = ExperienceMapper(
+            stepMapper = mockk(relaxed = true),
+            actionsMapper = mockk(relaxed = true),
+            traitsMapper = mockk(relaxed = true),
+            scope = mockk(relaxed = true)
+        )
+        val response = ExperienceResponse(
+            id = UUID.randomUUID(),
+            name = "name",
+            theme = null,
+            traits = listOf(),
+            steps = listOf(),
+            state = null,
+            type = null,
+            publishedAt = null,
+            nextContentId = null,
+            redirectUrl = null,
+            context = ContextResponse("locale-id", "locale-name")
+        )
+
+        // WHEN
+        val experience = mapper.mapDecoded(response, ExperienceTrigger.ShowCall)
+
+        // THEN
+        assertThat(experience.localeId).isEqualTo("locale-id")
+        assertThat(experience.localeName).isEqualTo("locale-name")
+    }
+
+    @Test
+    fun `mapDecoded SHOULD NOT set locale properties from ExperienceResponse WHEN context is null`() {
+        // GIVEN
+        val mapper = ExperienceMapper(
+            stepMapper = mockk(relaxed = true),
+            actionsMapper = mockk(relaxed = true),
+            traitsMapper = mockk(relaxed = true),
+            scope = mockk(relaxed = true)
+        )
+        val response = ExperienceResponse(
+            id = UUID.randomUUID(),
+            name = "name",
+            theme = null,
+            traits = listOf(),
+            steps = listOf(),
+            state = null,
+            type = null,
+            publishedAt = null,
+            nextContentId = null,
+            redirectUrl = null,
+            context = null
+        )
+
+        // WHEN
+        val experience = mapper.mapDecoded(response, ExperienceTrigger.ShowCall)
+
+        // THEN
+        assertThat(experience.localeId).isNull()
+        assertThat(experience.localeName).isNull()
+    }
+
+    @Test
+    fun `mapDecoded SHOULD set locale properties from FailedExperienceResponse context`() {
+        // GIVEN
+        val mapper = ExperienceMapper(
+            stepMapper = mockk(relaxed = true),
+            actionsMapper = mockk(relaxed = true),
+            traitsMapper = mockk(relaxed = true),
+            scope = mockk(relaxed = true)
+        )
+        val response = FailedExperienceResponse(
+            id = UUID.randomUUID(),
+            name = "name",
+            type = null,
+            publishedAt = null,
+            context = ContextResponse("locale-id", "locale-name")
+        )
+
+        // WHEN
+        val experience = mapper.mapDecoded(response, ExperienceTrigger.ShowCall)
+
+        // THEN
+        assertThat(experience.localeId).isEqualTo("locale-id")
+        assertThat(experience.localeName).isEqualTo("locale-name")
+    }
 }

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/stubs/ContentModalOneStubs.kt
@@ -28,6 +28,7 @@ internal val contentModalOneStubs = ExperienceResponse(
     theme = null,
     nextContentId = null,
     redirectUrl = null,
+    context = null,
     traits = arrayListOf(),
     steps = arrayListOf(
         StepContainerResponse(

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -173,3 +173,31 @@ internal fun mockExperienceNavigateActions(actions: List<Action>, presentingTrai
         localeId = null,
         localeName = null,
     )
+
+internal fun mockLocalizedExperience(localeName: String, localeId: String) =
+    Experience(
+        id = UUID.fromString("d84c9d01-aa27-4cbb-b832-ee03720e04fc"),
+        name = "Mock Localized Experience",
+        type = "mobile",
+        renderContext = RenderContext.Modal,
+        stepContainers = listOf(
+            StepContainer(
+                id = UUID.fromString("e062bd81-b736-44c4-abba-633dfff966aa"),
+                steps = listOf(
+                    mockStep(UUID.fromString("01d8a05a-3a55-4ecc-872d-d140cd628902")),
+                ),
+                presentingTrait = mockPresentingTrait(),
+                contentHolderTrait = mockk(relaxed = true),
+                contentWrappingTrait = mockk(relaxed = true),
+                actions = emptyMap(),
+            )
+        ),
+        published = true,
+        priority = LOW,
+        publishedAt = 1652895835000,
+        experiment = null,
+        completionActions = arrayListOf(TrackEventAction(hashMapOf(), appcues = mockk(relaxed = true))),
+        trigger = ShowCall,
+        localeId = localeId,
+        localeName = localeName,
+    )

--- a/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
+++ b/appcues/src/test/java/com/appcues/mocks/ExperienceMocks.kt
@@ -58,6 +58,8 @@ internal fun mockExperience(onPresent: (() -> Unit)? = null) =
         experiment = null,
         completionActions = arrayListOf(TrackEventAction(hashMapOf(), appcues = mockk(relaxed = true))),
         trigger = ShowCall,
+        localeId = null,
+        localeName = null,
     )
 
 internal fun mockStep(id: UUID) =
@@ -98,7 +100,9 @@ internal fun mockExperienceExperiment(experiment: Experiment) =
         publishedAt = 1652895835000,
         experiment = experiment,
         completionActions = emptyList(),
-        trigger = ExperienceTrigger.ShowCall,
+        trigger = ShowCall,
+        localeId = null,
+        localeName = null,
     )
 
 internal fun mockEmbedExperience(frameId: String, onPresent: (() -> Unit)? = null) =
@@ -125,6 +129,8 @@ internal fun mockEmbedExperience(frameId: String, onPresent: (() -> Unit)? = nul
         experiment = null,
         completionActions = emptyList(),
         trigger = ExperienceTrigger.Qualification("screen_view"),
+        localeId = null,
+        localeName = null,
     )
 
 // An experience with two step containers, each with one step. The given list of actions are applied to both
@@ -164,4 +170,6 @@ internal fun mockExperienceNavigateActions(actions: List<Action>, presentingTrai
         experiment = null,
         completionActions = emptyList(),
         trigger = trigger,
+        localeId = null,
+        localeName = null,
     )

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -341,6 +341,8 @@ internal class StateMachineTest : AppcuesScopeTest {
             publishedAt = 1652895835000,
             completionActions = arrayListOf(),
             experiment = null,
+            localeId = null,
+            localeName = null,
             trigger = ExperienceTrigger.ShowCall,
         )
         val initialState = Idling
@@ -370,6 +372,8 @@ internal class StateMachineTest : AppcuesScopeTest {
             completionActions = arrayListOf(),
             experiment = null,
             error = "Failed decode",
+            localeId = null,
+            localeName = null,
             trigger = ExperienceTrigger.ShowCall,
         )
         val initialState = Idling


### PR DESCRIPTION
Quick update here to capture a `context` object in the experience response that will contain the locale id and name, in the case of localized content, when this is returned from the server in the future. This info is then returned verbatim in the experience analytics to denote which version of an experience the user saw.

Per Andy, the response property at the root of the experience will look like 
```js
"context": {
    "locale_id": "the-id",
    "locale_name": "the-name"
}
```

and the name and id value is "default" when no localization matched