### PR TITLE
Improved trait error handling

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -20,6 +20,7 @@ import com.appcues.data.remote.appcues.response.experience.ExperienceResponse
 import com.appcues.data.remote.appcues.response.experience.FailedExperienceResponse
 import com.appcues.data.remote.appcues.response.experience.LossyExperienceResponse
 import com.appcues.data.remote.appcues.response.step.StepContainerResponse
+import com.appcues.trait.AppcuesTraitException
 import com.appcues.trait.ContentHolderTrait
 import com.appcues.trait.ContentWrappingTrait
 import com.appcues.trait.ExperienceTrait
@@ -150,10 +151,9 @@ internal class ExperienceMapper(
     }
 
     private fun List<ExperienceTrait>.getExperiencePresentingTraitOrThrow(): PresentingTrait {
-        return filterIsInstance<PresentingTrait>().firstOrNull() ?: throw AppcuesPresentingTraitNotFound()
+        return filterIsInstance<PresentingTrait>().firstOrNull()
+            ?: throw AppcuesTraitException("Presenting capability trait required")
     }
-
-    private class AppcuesPresentingTraitNotFound : Exception("Presenting capability trait required")
 
     private fun List<ExperimentResponse>.getExperiment(experienceId: UUID) =
         this.firstOrNull { it.experienceId == experienceId }?.let { experimentResponse ->

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -31,6 +31,7 @@ import com.appcues.statemachine.Transitions.Companion.fromRenderingStepToEndingS
 import com.appcues.util.ResultOf
 import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
@@ -77,8 +78,11 @@ internal class StateMachine(
         lifecycleTracker.start(this, { onEndedExperience?.invoke(it) })
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun stopLifecycleTracking() {
         lifecycleTracker.stop()
+        _stateFlow.resetReplayCache()
+        _errorFlow.resetReplayCache()
     }
 
     suspend fun handleAction(action: Action): ResultOf<State, Error> = mutex.withLock {
@@ -132,7 +136,7 @@ internal class StateMachine(
             // if no side effect, return success with current state
             Success(_state)
         }.also {
-            if (state == Idling) {
+            if (_state == Idling) {
                 stopLifecycleTracking()
             }
         }


### PR DESCRIPTION
This update is meant to address two scenarios:
1. A modal trait has a presentationStyle that is unknown
2. There is no valid presenting trait in the experience

Both of these scenarios currently result in sub-optimal behavior:
1. leaves the backdrop overlay on the screen with no content, in a potentially "hung" state
2. throws an exception that is not handled until it hits the root coroutine handler, aborting the entire response processing flow

In both cases, no trackable errors are reported to the backend, and if there are other valid experiences in the response, lower in the priority list, they get skipped instead of attempted.

This change addresses these by (1) supporting traits throwing AppcuesTraitException instances during init, if config is invalid and (2) handling these exceptions in the proper spot to track events and allow fallback experiences to try to render.

Updated handling with errors tracked
| error 1 | error 2 |
| ---- | ---- |
| ![Screenshot 2023-09-20 at 1 06 37 PM](https://github.com/appcues/appcues-android-sdk/assets/19266448/95cc3c5c-89d8-41c3-aeef-a10e97e4192f) | ![Screenshot 2023-09-20 at 1 07 13 PM](https://github.com/appcues/appcues-android-sdk/assets/19266448/c347f11b-f624-4afd-9af4-5ab8802562fd) |
