### PR TITLE
Update animation handling for UI tests

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -1,6 +1,7 @@
 package com.appcues
 
 import android.content.Context
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -107,14 +108,13 @@ public fun ComposeContainer(context: Context, stepContentJson: List<String>?, tr
             LocalLogcues provides Logcues(LoggingLevel.DEBUG),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
             LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
-            LocalExperienceCompositionState provides ExperienceCompositionState()
+            LocalExperienceCompositionState provides ExperienceCompositionState(
+                // disables animations
+                isContentVisible = MutableTransitionState(true),
+                isBackdropVisible = MutableTransitionState(true)
+            )
         ) {
             // render the step container on the desired step
-            LocalExperienceCompositionState.current.let {
-                it.isContentVisible.targetState = true // so animated visibility works
-                it.isBackdropVisible.targetState = true // so animated visibility works
-            }
-
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
@@ -34,14 +34,14 @@ internal data class AppcuesPaginationData(
     val scrollOffset: Float
 )
 
-internal class ExperienceCompositionState {
-
-    internal val paginationData = mutableStateOf(AppcuesPaginationData(1, 0, 0.0f))
-
-    internal val isContentVisible = MutableTransitionState(false)
-
-    internal val isBackdropVisible = MutableTransitionState(false)
-}
+internal class ExperienceCompositionState(
+    val paginationData: MutableState<AppcuesPaginationData> =
+        mutableStateOf(AppcuesPaginationData(1, 0, 0.0f)),
+    val isContentVisible: MutableTransitionState<Boolean> =
+        MutableTransitionState(false),
+    val isBackdropVisible: MutableTransitionState<Boolean> =
+        MutableTransitionState(false),
+)
 
 @Composable
 internal fun LaunchOnHideAnimationCompleted(block: () -> Unit) {


### PR DESCRIPTION
Small change corresponding to the test updates in https://github.com/appcues/appcues-mobile-experience-spec/pull/221

This allows us to start the visibility flags `true` rather than starting `false` and transitioning to `true`.