### PR TITLE
♻️  StateMachine transition improvements

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/SideEffect.kt
@@ -2,13 +2,19 @@ package com.appcues.statemachine
 
 import com.appcues.action.ActionProcessor
 import com.appcues.action.ExperienceAction
-import com.appcues.util.ResultOf
 import kotlinx.coroutines.CompletableDeferred
 
 internal sealed class SideEffect {
     data class ContinuationEffect(val action: Action) : SideEffect()
     data class PresentContainerEffect(val presentContainer: suspend (ActionProcessor) -> Action) : SideEffect()
     data class ReportErrorEffect(val error: Error) : SideEffect()
-    data class AwaitEffect(val completion: CompletableDeferred<ResultOf<State, Error>>) : SideEffect()
+    data class AwaitEffect(val effect: SideEffect) : SideEffect() {
+
+        private val task = CompletableDeferred<Unit>()
+
+        suspend fun await() = task.await()
+        fun complete() = task.complete(Unit)
+    }
+
     data class ProcessActions(val actions: List<ExperienceAction>) : SideEffect()
 }

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -22,7 +22,7 @@ internal sealed class State {
         // send to the state machine once it's done dismissing the current container
         // the presence of a non-null value is what tells the UI to dismiss the current container,
         // and it should be set to null if a dismiss is not requested (i.e. moving to next step in same container)
-        val dismissAndContinue: (() -> Unit)?,
+        val onUiDismissed: (() -> Unit)?,
     ) : State()
 
     data class EndingExperience(

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -72,10 +72,7 @@ private fun MainSurface() {
 
             // will run when transition from visible to gone is completed
             LaunchOnHideAnimationCompleted {
-                // if state is dismissing then finish activity
-                if (state.value is Dismissing) {
-                    viewModel.dismiss()
-                }
+                (state.value as? Dismissing)?.run { viewModel.onDismissed(onUiDismissed) }
             }
 
             val experienceState = LocalExperienceCompositionState.current

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
@@ -54,17 +54,6 @@ internal fun LaunchOnHideAnimationCompleted(block: () -> Unit) {
     }
 }
 
-@Composable
-internal fun LaunchOnShowAnimationCompleted(block: () -> Unit) {
-    val isContentVisible = LocalExperienceCompositionState.current.isContentVisible
-    with(remember { mutableStateOf(isContentVisible) }.value) {
-        // if show animation is completed
-        if (isIdle && currentState) {
-            block()
-        }
-    }
-}
-
 /**
  * rememberAppcuesPaginationState is used by traits that wants to know updates about pagination data
  * returns a State of AppcuesPaginationData containing pageCount, currentPage index and scrollingOffset

--- a/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
@@ -164,7 +164,7 @@ internal class ExperienceLifecycleTrackerTest : KoinTest {
             machine.stateFlow.collect {
                 when (it) {
                     is EndingStep -> {
-                        it.dismissAndContinue?.invoke()
+                        it.onUiDismissed?.invoke()
                     }
                     // ignore other state changes
                     else -> Unit

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -35,7 +35,6 @@ import com.appcues.statemachine.StepReference.StepOffset
 import com.appcues.trait.AppcuesTraitException
 import com.appcues.trait.PresentingTrait
 import com.appcues.util.ResultOf
-import com.appcues.util.ResultOf.Success
 import com.google.common.truth.Truth.assertThat
 import io.mockk.Called
 import io.mockk.coVerify
@@ -761,7 +760,7 @@ internal class StateMachineTest : AppcuesScopeTest {
                 onStateChange?.invoke(it)
                 when (it) {
                     is EndingStep -> {
-                        it.dismissAndContinue?.invoke()
+                        it.onUiDismissed?.invoke()
                     }
                     // ignore other state changes
                     else -> Unit


### PR DESCRIPTION
This is a followup PR to ViewModel improvements.

1. AppcuesViewModel will call Dismiss if getStateFlow is null
2. When we receive EndingStep + UiDismissed we cancel the collect job instead of running a if (uiState == Dismissing) during collect
3. calling onUiDismissed from composition (viewModel.onDismissed(onUiDismissed) to avoid checking for dismissing state, since it was already being checked by the composition.
4. ViewPresenter has viewModel as nullable var, so we can unset it whenever onCompositionDismiss
5. Removed unused `LaunchOnShowAnimationCompleted`
6. Turns out we can simplify how AwaitEffect is currently, given that we dont need to pass in AppcuesCoroutineScope (any suspend thread can call complete()) and also we can have it all inside AwaitEffect class, since we dont actually need the result from the await.
7. update to handleInternalAction to support new AwaitEffect more efficiently.
