### PR TITLE
Add support for experience test snapshots

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import coil.ImageLoader
@@ -16,6 +17,7 @@ import com.appcues.data.mapper.experience.ExperienceMapper
 import com.appcues.data.mapper.step.primitives.mapPrimitive
 import com.appcues.data.model.ExperienceStepFormState
 import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.remote.appcues.response.QualifyResponse
 import com.appcues.data.remote.appcues.response.experience.ExperienceResponse
 import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse
 import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.StackPrimitiveResponse
@@ -120,6 +122,76 @@ public fun ComposeContainer(context: Context, stepContentJson: List<String>?, tr
                 contentAlignment = Alignment.Center
             ) {
                 ComposeContainer(container, 0, metadata)
+            }
+        }
+    }
+}
+
+// This helper supports testing any experience JSON content, rendering the given group and step index.
+@Composable
+public fun ComposeContainer(
+    context: Context,
+    experienceJson: String,
+    groupIndex: Int,
+    stepIndex: Int,
+    animated: Boolean,
+    imageLoader: ImageLoader,
+) {
+    // set up a Koin scope for testing - for experience/trait mapping, trait registry, etc
+    val scope = AppcuesKoinContext.createAppcuesScope(context, AppcuesConfig("", ""))
+
+    // this JSON is actually a qualify response, and we'll get the first experience out of it
+    val qualifyResponse = MoshiConfiguration.moshi.adapter(QualifyResponse::class.java).fromJson(experienceJson)!!
+    val experienceResponse = qualifyResponse.experiences[0] as ExperienceResponse
+
+    // update the experience to strip out any actions, as they can rely on injected dependencies
+    // that are not available using the test context
+    val updatedExperienceResponse = experienceResponse.copy(
+        steps = experienceResponse.steps.map { stepContainerResponse ->
+            stepContainerResponse.copy(
+                children = stepContainerResponse.children.map { stepResponse ->
+                    stepResponse.copy(
+                        actions = emptyMap()
+                    )
+                },
+                actions = emptyMap()
+            )
+        },
+    )
+
+    // map the experience
+    val experienceMapper: ExperienceMapper = scope.get()
+    val experience = experienceMapper.map(updatedExperienceResponse, ExperienceTrigger.Preview)
+    val container = experience.stepContainers[groupIndex]
+    val metadataSettingTraits = container.steps[stepIndex].metadataSettingTraits
+    val metadata = hashMapOf<String, Any?>().apply { metadataSettingTraits.forEach { putAll(it.produceMetadata()) } }
+
+    AppcuesTheme {
+        CompositionLocalProvider(
+            LocalImageLoader provides imageLoader,
+            LocalLogcues provides Logcues(LoggingLevel.DEBUG),
+            LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
+            LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
+            LocalExperienceCompositionState provides ExperienceCompositionState(
+                // disables animations
+                isContentVisible = MutableTransitionState(!animated),
+                isBackdropVisible = MutableTransitionState(!animated)
+            )
+        ) {
+            // render the step container on the desired step
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                ComposeContainer(container, stepIndex, metadata)
+            }
+
+            if (animated) {
+                val compositionState = LocalExperienceCompositionState.current
+                LaunchedEffect(Unit) {
+                    compositionState.isContentVisible.targetState = true
+                    compositionState.isBackdropVisible.targetState = true
+                }
             }
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/EmbedHtmlPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/EmbedHtmlPrimitive.kt
@@ -73,9 +73,16 @@ internal fun EmbedHtmlPrimitive.Compose(modifier: Modifier) {
                 WebView(context).apply {
                     isNestedScrollingEnabled = false
                     isScrollContainer = false
-                    with(settings) {
-                        javaScriptEnabled = true
-                        mediaPlaybackRequiresUserGesture = false
+                    @Suppress("SwallowedException")
+                    try {
+                        with(settings) {
+                            javaScriptEnabled = true
+                            mediaPlaybackRequiresUserGesture = false
+                        }
+                    } catch (ex: NoSuchMethodError) {
+                        // in some UI tests, WebView.settings throws a
+                        // NoSuchMethodError, so we're ignoring here for tests. This should
+                        // not impact normal usage at all.
                     }
                     this.layoutParams = layoutParams
                     webChromeClient = chromeClient


### PR DESCRIPTION
These are the changes in debug only test helper to support experience snapshot tests in https://github.com/appcues/appcues-mobile-experience-spec/pull/223

plus one error handling case with WebViews, since accessing WebView.settings [is not supported in Paparazzi tests](https://github.com/cashapp/paparazzi/issues/1058)