### PR TITLE
three layout fixes

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/ContentWrappingTrait.kt
@@ -22,6 +22,11 @@ internal interface ContentWrappingTrait : ExperienceTrait {
      */
     @Composable
     fun WrapContent(
-        content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit
+        content: @Composable (
+            modifier: Modifier,
+            containerPadding: PaddingValues,
+            safeAreaInsets: PaddingValues,
+            hasVerticalScroll: Boolean,
+        ) -> Unit
     )
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/EmbedTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/EmbedTrait.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -68,7 +66,8 @@ internal class EmbedTrait(
         content: @Composable (
             modifier: Modifier,
             containerPadding: PaddingValues,
-            safeAreaInsets: PaddingValues
+            safeAreaInsets: PaddingValues,
+            hasVerticalScroll: Boolean,
         ) -> Unit
     ) {
         val isDark = isSystemInDarkTheme()
@@ -86,9 +85,10 @@ internal class EmbedTrait(
                         .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) },
                     content = {
                         content(
-                            if (constraints.hasBoundedHeight) Modifier.verticalScroll(rememberScrollState()) else Modifier,
+                            Modifier,
                             style.getPaddings(),
-                            PaddingValues()
+                            PaddingValues(),
+                            constraints.hasBoundedHeight, // support vertical scroll only if bounded height
                         )
                     },
                 )

--- a/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/ModalTrait.kt
@@ -53,7 +53,8 @@ internal class ModalTrait(
         content: @Composable (
             modifier: Modifier,
             containerPadding: PaddingValues,
-            safeAreaInsets: PaddingValues
+            safeAreaInsets: PaddingValues,
+            hasVerticalScroll: Boolean,
         ) -> Unit
     ) {
         val windowInfo = rememberAppcuesWindowInfo()

--- a/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TooltipTrait.kt
@@ -11,9 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.GenericShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
@@ -118,7 +116,8 @@ internal class TooltipTrait(
         content: @Composable (
             modifier: Modifier,
             containerPadding: PaddingValues,
-            safeAreaInsets: PaddingValues
+            safeAreaInsets: PaddingValues,
+            hasVerticalScroll: Boolean,
         ) -> Unit
     ) {
         val metadata = LocalAppcuesStepMetadata.current
@@ -194,9 +193,10 @@ internal class TooltipTrait(
                             .styleBorderPath(style, tooltipPath, isSystemInDarkTheme())
                     ) {
                         content(
-                            Modifier.verticalScroll(rememberScrollState()),
+                            Modifier,
                             style.getPaddings(),
-                            tooltipSettings.getContentPaddingValues()
+                            tooltipSettings.getContentPaddingValues(),
+                            true // support vertical scroll
                         )
                     }
                 }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -112,7 +112,7 @@ internal fun BoxScope.ComposeContainer(stepContainer: StepContainer, stepIndex: 
                 ApplyBackgroundDecoratingTraits(backdropDecoratingTraits.value)
 
                 // create wrapper
-                contentWrappingTrait.WrapContent { modifier, containerPadding, safeAreaInsets ->
+                contentWrappingTrait.WrapContent { modifier, containerPadding, safeAreaInsets, hasVerticalScroll ->
                     Box(contentAlignment = Alignment.TopCenter) {
                         ApplyUnderlayContainerTraits(containerDecoratingTraits.value, containerPadding, safeAreaInsets)
 
@@ -128,7 +128,8 @@ internal fun BoxScope.ComposeContainer(stepContainer: StepContainer, stepIndex: 
                                             modifier = modifier.testTag("page_$it"),
                                             containerPadding = containerPadding,
                                             safeAreaInsets = safeAreaInsets,
-                                            parent = this@Box
+                                            parent = this@Box,
+                                            hasVerticalScroll = hasVerticalScroll,
                                         )
                                 }
                             ).also {

--- a/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
@@ -5,12 +5,15 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.platform.LocalDensity
 import com.appcues.data.model.Step
 import com.appcues.trait.StepDecoratingTrait.StepDecoratingType
@@ -23,7 +26,8 @@ internal fun Step.ComposeStep(
     modifier: Modifier = Modifier,
     containerPadding: PaddingValues,
     safeAreaInsets: PaddingValues,
-    parent: BoxScope
+    parent: BoxScope,
+    hasVerticalScroll: Boolean,
 ) {
     key(id) {
         CompositionLocalProvider(
@@ -36,7 +40,7 @@ internal fun Step.ComposeStep(
 
             ApplyUnderlayStepTraits(parent, containerPadding, safeAreaInsets, stickyContentPadding)
 
-            ComposeStepContent(modifier, containerPadding, safeAreaInsets, stickyContentPadding)
+            ComposeStepContent(modifier, containerPadding, safeAreaInsets, stickyContentPadding, hasVerticalScroll)
 
             ComposeStickyContent(parent, containerPadding, safeAreaInsets, stickyContentPadding)
 
@@ -74,11 +78,13 @@ private fun Step.ComposeStepContent(
     modifier: Modifier,
     containerPadding: PaddingValues,
     safeAreaInsets: PaddingValues,
-    stickyContentPadding: StickyContentPadding
+    stickyContentPadding: StickyContentPadding,
+    hasVerticalScroll: Boolean,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
+            .stepVerticalScroll(hasVerticalScroll)
             .padding(containerPadding)
             .padding(safeAreaInsets)
             .padding(stickyContentPadding.paddingValues.value)
@@ -110,5 +116,15 @@ private fun Step.ComposeStickyContent(
                 .alignStepOverlay(boxScope, Alignment.BottomCenter, stickyContentPadding),
             contentAlignment = Alignment.BottomCenter
         ) { it.Compose() }
+    }
+}
+
+// conditionally add vertical scrolling to the step, only if the given ScrollState is not null.
+// this is used to allow the parent trait to control whether or not step content is scrollable
+private fun Modifier.stepVerticalScroll(enabled: Boolean) = composed {
+    if (enabled) {
+        Modifier.verticalScroll(rememberScrollState())
+    } else {
+        Modifier
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/StepComposition.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,21 +25,23 @@ internal fun Step.ComposeStep(
     safeAreaInsets: PaddingValues,
     parent: BoxScope
 ) {
-    CompositionLocalProvider(
-        LocalAppcuesActions provides actions,
-        LocalExperienceStepFormStateDelegate provides formState
-    ) {
-        // used to get the padding values from step decorating trait and apply to the Column
-        val density = LocalDensity.current
-        val stickyContentPadding = remember(this) { StickyContentPadding(density) }
+    key(id) {
+        CompositionLocalProvider(
+            LocalAppcuesActions provides actions,
+            LocalExperienceStepFormStateDelegate provides formState
+        ) {
+            // used to get the padding values from step decorating trait and apply to the Column
+            val density = LocalDensity.current
+            val stickyContentPadding = remember(this) { StickyContentPadding(density) }
 
-        ApplyUnderlayStepTraits(parent, containerPadding, safeAreaInsets, stickyContentPadding)
+            ApplyUnderlayStepTraits(parent, containerPadding, safeAreaInsets, stickyContentPadding)
 
-        ComposeStepContent(modifier, containerPadding, safeAreaInsets, stickyContentPadding)
+            ComposeStepContent(modifier, containerPadding, safeAreaInsets, stickyContentPadding)
 
-        ComposeStickyContent(parent, containerPadding, safeAreaInsets, stickyContentPadding)
+            ComposeStickyContent(parent, containerPadding, safeAreaInsets, stickyContentPadding)
 
-        ApplyOverlayStepTraits(parent, containerPadding, safeAreaInsets, stickyContentPadding)
+            ApplyOverlayStepTraits(parent, containerPadding, safeAreaInsets, stickyContentPadding)
+        }
     }
 }
 

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -42,7 +40,12 @@ private const val HEIGHT_TABLET = 0.6f
 @Composable
 internal fun BottomSheetModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
+    content: @Composable (
+        modifier: Modifier,
+        containerPadding: PaddingValues,
+        safeAreaInsets: PaddingValues,
+        hasVerticalScroll: Boolean,
+    ) -> Unit,
     appcuesWindowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -74,11 +77,10 @@ internal fun BottomSheetModal(
                         .modalStyle(style, isDark) { Modifier.sheetModifier(appcuesWindowInfo, isDark, it) },
                     content = {
                         content(
-                            Modifier
-                                .fillMaxSize()
-                                .verticalScroll(rememberScrollState()),
+                            Modifier.fillMaxSize(),
                             style.getPaddings(),
-                            PaddingValues()
+                            PaddingValues(),
+                            true, // support vertical scroll
                         )
                     },
                 )

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -59,7 +57,12 @@ internal enum class SlideTransitionEdge {
 @Composable
 internal fun DialogModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
+    content: @Composable (
+        modifier: Modifier,
+        containerPadding: PaddingValues,
+        safeAreaInsets: PaddingValues,
+        hasVerticalScroll: Boolean,
+    ) -> Unit,
     windowInfo: AppcuesWindowInfo,
     transition: DialogTransition,
 ) {
@@ -110,9 +113,10 @@ internal fun DialogModal(
                     .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) }
             ) {
                 content(
-                    Modifier.verticalScroll(rememberScrollState()),
+                    Modifier,
                     style.getPaddings(),
-                    PaddingValues()
+                    PaddingValues(),
+                    true, // support vertical scroll
                 )
             }
         }

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -40,7 +38,12 @@ private const val HEIGHT_TABLET = 0.7f
 @Composable
 internal fun ExpandedBottomSheetModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
+    content: @Composable (
+        modifier: Modifier,
+        containerPadding: PaddingValues,
+        safeAreaInsets: PaddingValues,
+        hasVerticalScroll: Boolean,
+    ) -> Unit,
     windowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -70,11 +73,10 @@ internal fun ExpandedBottomSheetModal(
                         .modalStyle(style, isDark) { Modifier.sheetModifier(windowInfo, isDark, it) },
                     content = {
                         content(
-                            Modifier
-                                .fillMaxSize()
-                                .verticalScroll(rememberScrollState()),
+                            Modifier.fillMaxSize(),
                             style.getPaddings(),
-                            PaddingValues()
+                            PaddingValues(),
+                            true, // support vertical scroll
                         )
                     },
                 )

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -16,8 +16,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -43,7 +41,12 @@ private const val HEIGHT_TABLET = 0.85f
 @Composable
 internal fun FullScreenModal(
     style: ComponentStyle?,
-    content: @Composable (modifier: Modifier, containerPadding: PaddingValues, safeAreaInsets: PaddingValues) -> Unit,
+    content: @Composable (
+        modifier: Modifier,
+        containerPadding: PaddingValues,
+        safeAreaInsets: PaddingValues,
+        hasVerticalScroll: Boolean,
+    ) -> Unit,
     windowInfo: AppcuesWindowInfo,
 ) {
     Box(
@@ -73,11 +76,10 @@ internal fun FullScreenModal(
                         .modalStyle(style, isDark) { Modifier.fullModifier(windowInfo, isDark, it) },
                     content = {
                         content(
-                            Modifier
-                                .fillMaxSize()
-                                .verticalScroll(rememberScrollState()),
+                            Modifier.fillMaxSize(),
                             style.getPaddings(),
-                            PaddingValues()
+                            PaddingValues(),
+                            true, // support vertical scroll
                         )
                     },
                 )


### PR DESCRIPTION
three commits here for three specific fixes that came up recently

1. using `key(id) { ... }` around each step composition, to prevent node re-use causing an issue with our usage of IntrinsicSize.Min on row heights - the original issue in the linked ticket
2. fix the resizing logic on our `text` primitives to resize the span font sizes, not just the root style font size, since now all text content is actually within the spans
3. fix the vertical scroll handling for each individual step - moving the `rememberScrollState()` into the step composition, rather than the outer container composition, to restore expected behavior