### PR TITLE
Revert: add support for custom font asset path in config

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -29,7 +29,6 @@ import com.appcues.ui.composables.AppcuesActionsDelegate
 import com.appcues.ui.composables.ComposeContainer
 import com.appcues.ui.composables.ExperienceCompositionState
 import com.appcues.ui.composables.LocalAppcuesActionDelegate
-import com.appcues.ui.composables.LocalAppcuesConfig
 import com.appcues.ui.composables.LocalExperienceCompositionState
 import com.appcues.ui.composables.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.composables.LocalImageLoader
@@ -49,7 +48,6 @@ public fun ComposeContent(json: String, imageLoader: ImageLoader) {
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
             LocalLogcues provides Logcues(LoggingLevel.DEBUG),
-            LocalAppcuesConfig provides AppcuesConfig("test-account", "test-app"),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
             LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
             LocalExperienceCompositionState provides ExperienceCompositionState(),
@@ -111,7 +109,6 @@ public fun ComposeContainer(context: Context, stepContentJson: List<String>?, tr
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
             LocalLogcues provides Logcues(LoggingLevel.DEBUG),
-            LocalAppcuesConfig provides AppcuesConfig("test-account", "test-app"),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
             LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
             LocalExperienceCompositionState provides ExperienceCompositionState(
@@ -174,7 +171,6 @@ public fun ComposeContainer(
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
             LocalLogcues provides Logcues(LoggingLevel.DEBUG),
-            LocalAppcuesConfig provides AppcuesConfig("test-account", "test-app"),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
             LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
             LocalExperienceCompositionState provides ExperienceCompositionState(

--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -90,12 +90,6 @@ public data class AppcuesConfig internal constructor(
      */
     var additionalAutoProperties: Map<String, Any> = emptyMap()
 
-    /**
-     * Sets a custom path to use when looking for any application-specific fonts in the application assets.
-     * The fonts in /assets/fonts will always be made available. Any custom path here would be in addition.
-     */
-    var fontAssetPath: String? = null
-
     // internally used for ui test on debug variant
     internal var imageLoader: ImageLoader? = null
 }

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerFontManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerFontManager.kt
@@ -7,7 +7,6 @@ import android.os.Build.VERSION_CODES
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.Typeface
-import com.appcues.AppcuesConfig
 import com.appcues.debugger.model.DebuggerFontItem
 import com.appcues.logging.Logcues
 import java.io.File
@@ -16,7 +15,6 @@ import java.io.IOException
 internal class DebuggerFontManager(
     private val context: Context,
     private val logcues: Logcues,
-    private val config: AppcuesConfig,
 ) {
 
     // NOTE: naming conventions here match iOS, rather than Android system defaults
@@ -37,12 +35,7 @@ internal class DebuggerFontManager(
 
         val debugFonts = mutableListOf<DebuggerFontItem>()
         addFontResources(debugFonts)
-        addFontAssets("fonts", debugFonts) // the default path
-        config.fontAssetPath?.let {
-            if (it != "fonts") {
-                addFontAssets(it, debugFonts)
-            }
-        }
+        addFontAssets(debugFonts)
         debugFonts.sortWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
         return debugFonts
     }
@@ -73,18 +66,16 @@ internal class DebuggerFontManager(
         }
     }
 
-    private fun addFontAssets(fontAssetPath: String, debugFonts: MutableList<DebuggerFontItem>) {
-        // also look for any fonts included by the app in /assets
-        // normally in the /fonts subdirectory, but a custom path can be provided in config
+    private fun addFontAssets(debugFonts: MutableList<DebuggerFontItem>) {
+        // also look for any fonts included by the app in /assets/fonts
         try {
-            context.assets.list(fontAssetPath)
+            context.assets.list("fonts")
                 ?.filter {
                     it.endsWith(".ttf")
                 }?.forEach {
                     val name = it.subSequence(0, it.lastIndexOf(".ttf")).toString()
-                    val filePath = if (fontAssetPath.isNotEmpty()) "$fontAssetPath/" else ""
                     val typeface: android.graphics.Typeface =
-                        android.graphics.Typeface.createFromAsset(context.assets, filePath + it)
+                        android.graphics.Typeface.createFromAsset(context.assets, "fonts/$it")
                     val fontFamily = FontFamily(Typeface(typeface))
                     debugFonts.add(DebuggerFontItem(name, fontFamily, FontWeight.Normal))
                 }

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerModule.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerModule.kt
@@ -24,7 +24,7 @@ internal object DebuggerModule : AppcuesModule {
         }
 
         scoped {
-            DebuggerFontManager(context = get(), logcues = get(), config = get())
+            DebuggerFontManager(context = get(), logcues = get())
         }
 
         scoped {

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInteropFilter
 import androidx.compose.ui.platform.testTag
 import coil.ImageLoader
-import com.appcues.AppcuesConfig
 import com.appcues.data.model.StepContainer
 import com.appcues.logging.Logcues
 import com.appcues.trait.BackdropDecoratingTrait
@@ -34,7 +33,6 @@ internal fun AppcuesComposition(
     imageLoader: ImageLoader,
     logcues: Logcues,
     chromeClient: WebChromeClient,
-    config: AppcuesConfig,
 ) {
     // ensure to change some colors to match appropriate design for custom primitive blocks
     AppcuesTheme {
@@ -42,7 +40,6 @@ internal fun AppcuesComposition(
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
             LocalViewModel provides viewModel,
-            LocalAppcuesConfig provides config,
             LocalLogcues provides logcues,
             LocalChromeClient provides chromeClient,
             LocalAppcuesActionDelegate provides DefaultAppcuesActionsDelegate(viewModel),

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import coil.ImageLoader
-import com.appcues.AppcuesConfig
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
 import com.appcues.data.model.Action
@@ -48,8 +47,6 @@ internal val LocalAppcuesPaginationDelegate = compositionLocalOf { AppcuesPagina
 internal data class AppcuesPagination(val onPageChanged: (Int) -> Unit)
 
 internal val LocalViewModel = staticCompositionLocalOf<AppcuesViewModel> { noLocalProvidedFor("AppcuesViewModel") }
-
-internal val LocalAppcuesConfig = staticCompositionLocalOf<AppcuesConfig> { noLocalProvidedFor("AppcuesConfig") }
 
 internal val LocalLogcues = staticCompositionLocalOf<Logcues> { noLocalProvidedFor("LocalLogcues") }
 

--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.appcues.AppcuesConfig
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment
 import com.appcues.data.model.styling.ComponentStyle.ComponentVerticalAlignment
@@ -57,10 +56,10 @@ internal fun ComponentStyle.getTextAlignment(): TextAlign? {
     }
 }
 
-internal fun ComponentStyle.getFontFamily(context: Context, config: AppcuesConfig): FontFamily? {
+internal fun ComponentStyle.getFontFamily(context: Context): FontFamily? {
     return FontFamily.getSystemFontFamily(fontName)
         ?: FontFamily.getFontResource(context, fontName)
-        ?: FontFamily.getFontAsset(context, config, fontName)
+        ?: FontFamily.getFontAsset(context, fontName)
         ?: FontFamily.getSystemFont(fontName)
 }
 
@@ -109,19 +108,12 @@ private fun FontFamily.Companion.getFontResource(context: Context, fontName: Str
 }
 
 // try to load a custom font from an embedded asset in the host application
-private fun FontFamily.Companion.getFontAsset(context: Context, config: AppcuesConfig, fontName: String?): FontFamily? {
-    // try to find it in /assets/fonts by default, but also try in any custom path provided in config, if available
-    return getFontAsset(context, "fonts", fontName)
-        ?: getFontAsset(context, config.fontAssetPath, fontName)
-}
-
-private fun FontFamily.Companion.getFontAsset(context: Context, fontAssetPath: String?, fontName: String?): FontFamily? {
-    if (fontName != null && fontAssetPath != null) {
+private fun FontFamily.Companion.getFontAsset(context: Context, fontName: String?): FontFamily? {
+    if (fontName != null) {
         val assetName = "$fontName.ttf"
-        val fontsInAssets = context.assets.list(fontAssetPath)
+        val fontsInAssets = context.assets.list("fonts")
         if (fontsInAssets != null && fontsInAssets.contains(assetName)) {
-            val filePath = if (fontAssetPath.isNotEmpty()) "$fontAssetPath/" else ""
-            val typeface = Typeface.createFromAsset(context.assets, "$filePath$fontName.ttf")
+            val typeface = Typeface.createFromAsset(context.assets, "fonts/$fontName.ttf")
             if (typeface != null) {
                 return FontFamily(typeface)
             }
@@ -238,13 +230,13 @@ internal fun getBoxAlignment(
     return BiasAlignment(horizontalBias, verticalBias)
 }
 
-internal fun ComponentStyle.getTextStyle(context: Context, config: AppcuesConfig, isDark: Boolean): TextStyle {
+internal fun ComponentStyle.getTextStyle(context: Context, isDark: Boolean): TextStyle {
     return TextStyle(
         color = foregroundColor.getColor(isDark) ?: Color.Unspecified,
         fontSize = fontSize?.sp ?: TextUnit.Unspecified,
         lineHeight = lineHeight?.sp ?: TextUnit.Unspecified,
         textAlign = getTextAlignment(),
-        fontFamily = getFontFamily(context, config),
+        fontFamily = getFontFamily(context),
         letterSpacing = letterSpacing?.sp ?: TextUnit.Unspecified,
         fontWeight = getFontWeight(),
     )

--- a/appcues/src/main/java/com/appcues/ui/extensions/TextStyleExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/TextStyleExt.kt
@@ -9,37 +9,36 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
-import com.appcues.AppcuesConfig
 import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentStyle
 
-internal fun TextStyle.applyStyle(style: ComponentStyle, context: Context, config: AppcuesConfig, isDark: Boolean): TextStyle {
+internal fun TextStyle.applyStyle(style: ComponentStyle, context: Context, isDark: Boolean): TextStyle {
     return copy(
         color = style.foregroundColor.getColor(isDark) ?: color,
         fontSize = style.fontSize?.sp ?: fontSize,
         lineHeight = style.lineHeight?.sp ?: lineHeight,
         textAlign = style.getTextAlignment() ?: textAlign,
-        fontFamily = style.getFontFamily(context, config) ?: fontFamily,
+        fontFamily = style.getFontFamily(context) ?: fontFamily,
         letterSpacing = style.letterSpacing?.sp ?: letterSpacing,
         fontWeight = style.getFontWeight() ?: fontWeight,
     )
 }
 
-internal fun List<TextSpanPrimitive>.toAnnotatedString(context: Context, config: AppcuesConfig, isDark: Boolean): AnnotatedString {
+internal fun List<TextSpanPrimitive>.toAnnotatedString(context: Context, isDark: Boolean): AnnotatedString {
     return buildAnnotatedString {
         forEach {
-            withStyle(style = it.style.toSpanStyle(context, config, isDark)) {
+            withStyle(style = it.style.toSpanStyle(context, isDark)) {
                 append(it.text)
             }
         }
     }
 }
 
-private fun ComponentStyle.toSpanStyle(context: Context, config: AppcuesConfig, isDark: Boolean): SpanStyle {
+private fun ComponentStyle.toSpanStyle(context: Context, isDark: Boolean): SpanStyle {
     return SpanStyle(
         color = foregroundColor.getColor(isDark) ?: Color.Unspecified,
         fontSize = fontSize?.sp ?: TextUnit.Unspecified,
-        fontFamily = getFontFamily(context, config),
+        fontFamily = getFontFamily(context),
         letterSpacing = letterSpacing?.sp ?: TextUnit.Unspecified,
         fontWeight = getFontWeight(),
     )

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -89,7 +89,6 @@ internal abstract class ViewPresenter(
                         logcues = get(),
                         imageLoader = get(),
                         chromeClient = EmbedChromeClient(this),
-                        config = get(),
                     )
                 }
             }

--- a/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.appcues.data.model.ExperiencePrimitive.BoxPrimitive
-import com.appcues.ui.composables.LocalAppcuesConfig
 import com.appcues.ui.extensions.getBoxAlignment
 import com.appcues.ui.extensions.getTextStyle
 
@@ -17,7 +16,7 @@ internal fun BoxPrimitive.Compose(modifier: Modifier) {
         modifier = modifier,
         contentAlignment = style.getBoxAlignment(),
     ) {
-        ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalAppcuesConfig.current, isSystemInDarkTheme())) {
+        ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
             items.forEach { it.Compose() }
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import com.appcues.data.model.ExperiencePrimitive.ButtonPrimitive
 import com.appcues.data.model.styling.ComponentStyle
-import com.appcues.ui.composables.LocalAppcuesConfig
 import com.appcues.ui.extensions.getBoxAlignment
 import com.appcues.ui.extensions.getTextStyle
 
@@ -21,7 +20,7 @@ internal fun ButtonPrimitive.Compose(modifier: Modifier) {
         modifier = modifier,
         color = Color.Transparent,
     ) {
-        ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalAppcuesConfig.current, isSystemInDarkTheme())) {
+        ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
             Box(
                 contentAlignment = content.style.getBoxAlignment(),
                 modifier = Modifier.styleButtonContentWidth(style),

--- a/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
@@ -21,7 +21,6 @@ import com.appcues.data.model.ExperiencePrimitive.SpacerPrimitive
 import com.appcues.data.model.styling.ComponentDistribution
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment
-import com.appcues.ui.composables.LocalAppcuesConfig
 import com.appcues.ui.composables.LocalStackScope
 import com.appcues.ui.composables.StackScope
 import com.appcues.ui.extensions.getTextStyle
@@ -39,7 +38,7 @@ internal fun HorizontalStackPrimitive.Compose(modifier: Modifier) {
         verticalAlignment = verticalAlignment
     ) {
         CompositionLocalProvider(LocalStackScope provides StackScope.ROW) {
-            ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalAppcuesConfig.current, isSystemInDarkTheme())) {
+            ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
                 items.forEach {
                     ItemBox(distribution = distribution, primitive = it, parentVerticalAlignment = verticalAlignment) {
                         it.Compose()

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -48,7 +48,6 @@ import com.appcues.data.model.styling.ComponentDataType.PHONE
 import com.appcues.data.model.styling.ComponentDataType.TEXT
 import com.appcues.data.model.styling.ComponentDataType.URL
 import com.appcues.data.model.styling.ComponentStyle
-import com.appcues.ui.composables.LocalAppcuesConfig
 import com.appcues.ui.composables.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.extensions.applyStyle
 import com.appcues.ui.extensions.checkErrorStyle
@@ -88,7 +87,6 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
     val textStyle = LocalTextStyle.current.applyStyle(
         style = textFieldStyle,
         context = LocalContext.current,
-        config = LocalAppcuesConfig.current,
         isDark = isDark,
     )
 

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
-import com.appcues.ui.composables.LocalAppcuesConfig
 import com.appcues.ui.extensions.applyStyle
 import com.appcues.ui.extensions.toAnnotatedString
 
@@ -25,8 +24,7 @@ private const val TEXT_SCALE_REDUCTION_INTERVAL = 0.9f
 internal fun TextPrimitive.Compose(modifier: Modifier) {
     val isDark = isSystemInDarkTheme()
     val context = LocalContext.current
-    val config = LocalAppcuesConfig.current
-    val style = LocalTextStyle.current.applyStyle(style, context, config, isDark)
+    val style = LocalTextStyle.current.applyStyle(style, context, isDark)
 
     var resizedStyle by remember(style) { mutableStateOf(style) }
     var resizedSpans by remember(style) { mutableStateOf(spans) }
@@ -38,7 +36,7 @@ internal fun TextPrimitive.Compose(modifier: Modifier) {
             modifier = modifier
                 .clipToBounds()
                 .drawWithContent { if (readyToDraw) drawContent() },
-            text = resizedSpans.toAnnotatedString(context, config, isDark),
+            text = resizedSpans.toAnnotatedString(context, isDark),
             style = resizedStyle,
             overflow = TextOverflow.Ellipsis,
             onTextLayout = { textLayoutResult ->

--- a/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.ExperiencePrimitive.VerticalStackPrimitive
-import com.appcues.ui.composables.LocalAppcuesConfig
 import com.appcues.ui.composables.LocalStackScope
 import com.appcues.ui.composables.StackScope
 import com.appcues.ui.extensions.getHorizontalAlignment
@@ -25,7 +24,7 @@ internal fun VerticalStackPrimitive.Compose(modifier: Modifier) {
         verticalArrangement = Arrangement.spacedBy(spacing.dp, Alignment.CenterVertically)
     ) {
         CompositionLocalProvider(LocalStackScope provides StackScope.COLUMN) {
-            ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalAppcuesConfig.current, isSystemInDarkTheme())) {
+            ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
                 items.forEach {
                     it.Compose()
                 }


### PR DESCRIPTION
This reverts the changes in https://github.com/appcues/appcues-android-sdk/pull/505 as another approach is being taken for React Native Expo now.