### PR TITLE
Remove user agent auto-property

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -69,8 +69,6 @@ internal class AutoPropertyDecorator(
         get() = hashMapOf<String, Any>().apply {
             putAll(sessionLatestUserProperties)
             putAll(applicationProperties)
-            // add userAgent if exists (userAgent is a mutable property loaded asynchronously) and can be null
-            getUserAgent()?.let { put("_userAgent", it) }
             putAll(sessionProperties)
             config.additionalAutoProperties.forEach {
                 // additional props cannot overwrite values for existing internal prop keys
@@ -80,8 +78,6 @@ internal class AutoPropertyDecorator(
                 }
             }
         }
-
-    private fun getUserAgent(): String? = contextWrapper.getUserAgent()
 
     fun decorateTrack(event: EventRequest) = event.apply {
         if (event.name == AnalyticsEvent.ScreenView.eventName) {

--- a/appcues/src/main/java/com/appcues/util/ContextWrapper.kt
+++ b/appcues/src/main/java/com/appcues/util/ContextWrapper.kt
@@ -65,8 +65,6 @@ internal class ContextWrapper(private val context: Context) {
         return getCurrentLocale(context).toLanguageTag()
     }
 
-    fun getUserAgent(): String? = System.getProperty("http.agent")
-
     private fun getCurrentLocale(context: Context): Locale {
         return if (VERSION.SDK_INT >= VERSION_CODES.N) {
             context.resources.configuration.locales[0]

--- a/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
@@ -50,12 +50,12 @@ internal class AutoPropertyDecoratorTest {
     }
 
     @Test
-    fun `autoProperties SHOULD contain 21 amount of elements`() {
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(21)
+    fun `autoProperties SHOULD contain 20 amount of elements`() {
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(20)
     }
 
     @Test
-    fun `autoProperties SHOULD contain 22 amount of elements WHEN one ScreenView is decorated`() {
+    fun `autoProperties SHOULD contain 21 amount of elements WHEN one ScreenView is decorated`() {
         // given
         autoPropertyDecorator.decorateTrack(
             EventRequest(
@@ -66,11 +66,11 @@ internal class AutoPropertyDecoratorTest {
             )
         )
         // then
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(22)
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(21)
     }
 
     @Test
-    fun `autoProperties SHOULD contain 23 amount of elements WHEN two or more ScreenView are decorated`() {
+    fun `autoProperties SHOULD contain 22 amount of elements WHEN two or more ScreenView are decorated`() {
         // given
         autoPropertyDecorator.decorateTrack(
             EventRequest(
@@ -89,7 +89,7 @@ internal class AutoPropertyDecoratorTest {
             )
         )
         // then
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(23)
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(22)
     }
 
     @Test
@@ -192,7 +192,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(21)
+            assertThat(profileUpdate).hasSize(20)
         }
     }
 
@@ -208,7 +208,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(22)
+            assertThat(profileUpdate).hasSize(21)
         }
         // then when
         with(autoPropertyDecorator.decorateTrack(EventRequest(name = SessionStarted.eventName))) {
@@ -228,7 +228,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(22)
+            assertThat(profileUpdate).hasSize(21)
             assertThat(profileUpdate!!["_test"]).isEqualTo("Test")
         }
     }


### PR DESCRIPTION
Per discussions, removing this auto property on both iOS (for performance reasons) and Android here (for consistency). It is not believed to be a useful property in mobile for most scenarios, and it can be sent as a custom property if still desired for targeting content.