### PR TITLE
Add test support for screen capture flow

### DIFF
--- a/appcues/src/debug/java/com/appcues/ExperienceTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/ExperienceTestHelper.kt
@@ -15,11 +15,13 @@ public fun Appcues(
     accountId: String,
     applicationId: String,
     imageLoader: ImageLoader?,
+    configApiBasePath: String? = null,
     config: (AppcuesConfig.() -> Unit)? = null,
 ): Appcues = Bootstrap.createScope(
     context = context,
     config = AppcuesConfig(accountId, applicationId).apply {
         config?.invoke(this)
         this.imageLoader = imageLoader
+        this.configApiBasePath = configApiBasePath
     }
 ).get()

--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -92,4 +92,5 @@ public data class AppcuesConfig internal constructor(
 
     // internally used for ui test on debug variant
     internal var imageLoader: ImageLoader? = null
+    internal var configApiBasePath: String? = null
 }

--- a/appcues/src/main/java/com/appcues/data/remote/DataRemoteModule.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/DataRemoteModule.kt
@@ -35,9 +35,10 @@ internal object DataRemoteModule : AppcuesModule {
         }
 
         scoped {
+            val config: AppcuesConfig = get()
             SdkSettingsRemoteSource(
                 service = RetrofitWrapper(
-                    baseUrl = SdkSettingsRemoteSource.BASE_URL.toHttpUrl()
+                    baseUrl = (config.configApiBasePath ?: SdkSettingsRemoteSource.BASE_URL).toHttpUrl(),
                 ).create(SdkSettingsService::class),
                 config = get(),
             )

--- a/appcues/src/main/java/com/appcues/data/remote/customerapi/CustomerApiRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/customerapi/CustomerApiRemoteSource.kt
@@ -61,6 +61,7 @@ internal class CustomerApiBaseUrlInterceptor : Interceptor {
         val newUrl = request.url.newBuilder()
             .scheme(baseUrl.scheme)
             .host(baseUrl.host)
+            .port(baseUrl.port)
             .build()
 
         request = request.newBuilder()

--- a/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
@@ -37,16 +37,17 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import coil.compose.rememberAsyncImagePainter
 import com.appcues.R.string
 import com.appcues.ViewElement
 import com.appcues.debugger.DebuggerViewModel
@@ -124,8 +125,8 @@ private fun CaptureContents(debuggerViewModel: DebuggerViewModel, capture: Captu
         ) {
             // Captured screenshot
             Image(
+                bitmap = capture.screenshot.asImageBitmap(),
                 modifier = Modifier.border(1.dp, AppcuesColors.CaptureImageBorder),
-                painter = rememberAsyncImagePainter(capture.screenshot),
                 contentDescription = stringResource(id = string.appcues_screen_capture_image_description),
                 contentScale = ContentScale.Fit,
             )
@@ -140,6 +141,7 @@ private fun CaptureContents(debuggerViewModel: DebuggerViewModel, capture: Captu
         }
 
         OutlinedTextField(
+            modifier = Modifier.testTag("screen-capture-name"),
             value = text.value,
             singleLine = true,
             onValueChange = { text.value = it },

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.Event
 import androidx.lifecycle.Lifecycle.Event.ON_ANY
@@ -51,6 +52,7 @@ internal fun DebuggerComposition(viewModel: DebuggerViewModel, onDismiss: () -> 
         modifier = Modifier
             .fillMaxSize()
             .onSizeChanged { debuggerState.initFabOffsets(it) }
+            .testTag("debugger-root")
     ) {
 
         DebuggerOnDrag(

--- a/appcues/src/main/java/com/appcues/debugger/ui/ToastView.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/ToastView.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -57,6 +58,7 @@ internal fun BoxScope.SuccessToast(toast: ScreenCaptureSuccess, debuggerState: M
                 interactionSource = remember { MutableInteractionSource() },
                 onClick = toast.onDismiss
             )
+            .testTag("capture-success-toast")
     )
 
     AnimatedVisibility(
@@ -106,6 +108,7 @@ internal fun BoxScope.FailureToast(toast: ScreenCaptureFailure, debuggerState: M
                 interactionSource = remember { MutableInteractionSource() },
                 onClick = toast.onDismiss
             )
+            .testTag("capture-failure-toast")
     )
 
     AnimatedVisibility(


### PR DESCRIPTION
Some proposed updates in the SDK to support automated testing of the screen capture flow

1. a debug-only config value to supply an override to the api path used to look up the sdk config (normally fast.appcues.com path), so we can handle the screen capture flow with a MockWebServer
2. slightly change how the bitmap is shown on the confirm dialog, to work with Robolectric
3. a few `.testTag` modifiers to identify elements more easily in the debugger code