### PR TITLE
✨ Add Extra texts regarding captured screen and link to docs

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/screencapture/Capture.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/Capture.kt
@@ -22,6 +22,15 @@ internal data class Capture(
     val metadata: Metadata,
     val timestamp: Date,
 ) {
+
+    val targetableElementCount: Int = getTargetableElementCount(layout)
+
+    private fun getTargetableElementCount(element: ViewElement): Int {
+        val selectableElement = if (element.selector != null) 1 else 0
+
+        return selectableElement + (element.children?.sumOf { getTargetableElementCount(it) } ?: 0)
+    }
+
     // this is a lateinit var instead of a constructor arg so we can ignore it in JSON
     // serialization and a default value is not needed for the Moshi generated adapter
     @Json(ignore = true)

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -99,4 +99,7 @@
     <string name="appcues_screen_capture_toast_upload_failed">Upload failed</string>
     <string name="appcues_screen_capture_toast_try_again">Try again</string>
     <string name="appcues_screen_capture_toast_success_suffix">is now available for preview and targeting.</string>
+    <string name="appcues_screen_capture_not_seeing_element">Not seeing the element you want highlighted?</string>
+    <string name="appcues_screen_capture_no_element">Warning: this screen capture does not have any targetable elements identified.</string>
+    <string name="appcues_screen_capture_troubleshoot">Tap to view troubleshooting documentation.</string>
 </resources>


### PR DESCRIPTION
Completing the task to match iOS when capturing screen

when we get to the confirmation dialog we show extra information and give a link to docs where users can troubleshoot in case they are not finding what they are trying to target.

|Some selectors|No selectors|
|-|-|
|![](https://github.com/appcues/appcues-android-sdk/assets/5244805/caf69ebc-880e-402d-a22f-cd2d09691377)|![](https://github.com/appcues/appcues-android-sdk/assets/5244805/2b34f520-c3f6-4e3b-8f43-d581c47ab641)|
