### PR TITLE
♻️  Debugger improvements

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -117,4 +117,5 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2"
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
+    testImplementation 'app.cash.turbine:turbine:1.0.0'
 }

--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -47,7 +47,7 @@ public fun ComposeContent(json: String, imageLoader: ImageLoader) {
     AppcuesTheme {
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
-            LocalLogcues provides Logcues(LoggingLevel.DEBUG),
+            LocalLogcues provides Logcues(),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
             LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
             LocalExperienceCompositionState provides ExperienceCompositionState(),
@@ -108,7 +108,7 @@ public fun ComposeContainer(context: Context, stepContentJson: List<String>?, tr
     AppcuesTheme {
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
-            LocalLogcues provides Logcues(LoggingLevel.DEBUG),
+            LocalLogcues provides Logcues(),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
             LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
             LocalExperienceCompositionState provides ExperienceCompositionState(
@@ -170,7 +170,7 @@ public fun ComposeContainer(
     AppcuesTheme {
         CompositionLocalProvider(
             LocalImageLoader provides imageLoader,
-            LocalLogcues provides Logcues(LoggingLevel.DEBUG),
+            LocalLogcues provides Logcues(),
             LocalExperienceStepFormStateDelegate provides ExperienceStepFormState(),
             LocalAppcuesActionDelegate provides FakeAppcuesActionDelegate(),
             LocalExperienceCompositionState provides ExperienceCompositionState(

--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -16,6 +16,7 @@ import com.appcues.di.Bootstrap
 import com.appcues.di.scope.AppcuesScope
 import com.appcues.di.scope.get
 import com.appcues.di.scope.inject
+import com.appcues.logging.LogcatDestination
 import com.appcues.logging.Logcues
 import com.appcues.trait.ExperienceTrait
 import com.appcues.trait.ExperienceTraitLevel
@@ -109,6 +110,8 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
                 analyticsPublisher.publish(analyticsListener, it)
             }
         }
+
+        scope.get<LogcatDestination>().init()
     }
 
     /**
@@ -273,7 +276,7 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
      * @param activity The Activity to launch the debugger over.
      */
     public fun debug(activity: Activity) {
-        debuggerManager.start(activity, Debugger(null))
+        debuggerManager.start(activity, Debugger)
     }
 
     /**

--- a/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
@@ -57,7 +57,7 @@ internal class DeepLinkHandler(
             }
             segments.any() && segments[0] == "debugger" -> {
                 val deepLinkPath = if (segments.count() > 1) segments[1] else null
-                debuggerManager.start(activity, Debugger(deepLinkPath))
+                debuggerManager.start(activity, Debugger, deepLinkPath)
                 true
             }
             segments.any() && segments[0] == "capture_screen" -> {

--- a/appcues/src/main/java/com/appcues/MainModule.kt
+++ b/appcues/src/main/java/com/appcues/MainModule.kt
@@ -6,6 +6,7 @@ import com.appcues.data.AppcuesRepository
 import com.appcues.debugger.AppcuesDebuggerManager
 import com.appcues.di.AppcuesModule
 import com.appcues.di.scope.AppcuesScopeDSL
+import com.appcues.logging.LogcatDestination
 import com.appcues.logging.Logcues
 import com.appcues.statemachine.StateMachine
 import com.appcues.trait.TraitRegistry
@@ -22,10 +23,8 @@ internal object MainModule : AppcuesModule {
         scoped { ActionRegistry(get()) }
         scoped { ActionProcessor(get()) }
         scoped { AppcuesCoroutineScope(logcues = get()) }
-        scoped {
-            val config: AppcuesConfig = get()
-            Logcues(config.loggingLevel)
-        }
+        scoped { Logcues() }
+        scoped { LogcatDestination(get(), get<AppcuesConfig>().loggingLevel) }
         scoped { Storage(context = get(), config = get()) }
         scoped {
             DeepLinkHandler(
@@ -44,7 +43,7 @@ internal object MainModule : AppcuesModule {
                 appcuesLocalSource = get(),
                 experienceMapper = get(),
                 config = get(),
-                logcues = get(),
+                dataLogcues = get(),
                 storage = get(),
             )
         }

--- a/appcues/src/main/java/com/appcues/data/remote/DataLogcues.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/DataLogcues.kt
@@ -8,6 +8,10 @@ import okhttp3.Response
 import okhttp3.internal.http.promisesBody
 import okio.Buffer
 
+/**
+ * This class wrappers Logcues and provide specific log methods for Http Request, Response
+ * and general error logging where the "reason" should be formatted(beautify)
+ */
 internal class DataLogcues(private val logcues: Logcues) {
 
     companion object {

--- a/appcues/src/main/java/com/appcues/data/remote/DataLogcues.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/DataLogcues.kt
@@ -1,0 +1,168 @@
+package com.appcues.data.remote
+
+import com.appcues.logging.Logcues
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.internal.http.promisesBody
+import okio.Buffer
+
+internal class DataLogcues(private val logcues: Logcues) {
+
+    companion object {
+
+        private const val indent = "  "
+    }
+
+    fun error(description: String, reason: String) {
+        logcues.error("$description.\nReason: ${reason.beautify()}")
+    }
+
+    fun debug(request: Request) {
+        val message = StringBuffer()
+
+        message.appendLine("REQUEST: ${request.method}")
+        message.appendLine("URL: ${request.url}")
+        message.appendLine()
+        message.appendHeader(request.headers)
+
+        val body = request.body
+        if (body == null) {
+            message.appendLine("(no request body)")
+        } else if (body.isDuplex()) {
+            message.appendLine("(duplex request body omitted)")
+        } else if (body.isOneShot()) {
+            message.appendLine("(one-shot body omitted)")
+        } else if (bodyIsImage(body.contentType())) {
+            message.appendLine("(encoded image)")
+        } else {
+            val buffer = Buffer()
+            body.writeTo(buffer)
+            val decodedBody = buffer.readString(body.contentType().charsetOrUTF8())
+            message.appendBody(decodedBody, body.contentLength())
+        }
+        logcues.debug(message.toString())
+    }
+
+    fun debug(response: Response) {
+        val message = StringBuffer()
+        val responseTime = response.receivedResponseAtMillis - response.sentRequestAtMillis
+
+        message.appendLine("RESPONSE: ${response.code} (${responseTime}ms)")
+        message.appendLine("URL: ${response.request.url}")
+        message.appendLine()
+        message.appendHeader(response.headers)
+
+        val body = response.body
+        if (body == null || !response.promisesBody()) {
+            message.appendLine("(no response body)")
+        } else {
+            val source = body.source()
+            source.request(Long.MAX_VALUE) // Buffer the entire body.
+            val decodedBody = source.buffer.clone().readString(body.contentType().charsetOrUTF8())
+            message.appendBody(decodedBody, body.contentLength())
+        }
+        logcues.debug(message.toString())
+    }
+
+    private fun bodyIsImage(mediaType: MediaType?): Boolean {
+        return mediaType != null && mediaType.type.contains("image")
+    }
+
+    private fun StringBuffer.appendLine(message: String) {
+        append("$message\n")
+    }
+
+    private fun StringBuffer.appendHeader(headers: Headers) {
+        if (headers.size > 0) {
+            appendLine("Headers: {")
+            headers.forEach { appendLine("$indent[${it.first}] = ${it.second}") }
+            appendLine("}")
+        }
+    }
+
+    private fun StringBuffer.appendBody(decodedBody: String, contentLength: Long) {
+        appendLine("Body($contentLength bytes): ${decodedBody.beautify()}")
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    fun String.beautify(): String {
+        try {
+            val builder = StringBuilder()
+            var indentation = 0
+            var quoting = false
+
+            forEachIndexed { index, char ->
+                if (char == '"') quoting = !quoting
+
+                if (quoting) {
+                    builder.append(char)
+                } else if (!builder.handle(char, indentation)) {
+                    indentation = beautifyAtIndex(builder, char, index, indentation)
+                }
+            }
+
+            return builder.toString()
+        } catch (e: Exception) {
+            // in case any parsing goes wrong just return existing text
+            return this
+        }
+    }
+
+    private fun StringBuilder.handle(char: Char, sourceIndentation: Int): Boolean {
+        return when {
+            // break line and keep indentation
+            char == ',' -> {
+                appendLine(char)
+                append(indent.repeat(sourceIndentation))
+                true
+            }
+            // skip empty spaces when we are indenting
+            char == ' ' && sourceIndentation > 0 -> true
+            else -> false
+        }
+    }
+
+    private fun String.beautifyAtIndex(prettyJson: StringBuilder, char: Char, index: Int, sourceIndentation: Int): Int {
+        var indentation = sourceIndentation
+        when {
+            char == '(' && get(index + 1) != ')' -> {
+                prettyJson.appendLine(char)
+                indentation++
+                prettyJson.append(indent.repeat(indentation))
+            }
+            char == '{' && get(index + 1) != '}' -> {
+                prettyJson.appendLine(char)
+                indentation++
+                prettyJson.append(indent.repeat(indentation))
+            }
+            char == '[' && get(index + 1) != ']' -> {
+                prettyJson.appendLine(char)
+                indentation++
+                prettyJson.append(indent.repeat(indentation))
+            }
+            char == ']' && get(index - 1) != '[' -> {
+                prettyJson.appendLine()
+                indentation--
+                prettyJson.append(indent.repeat(indentation))
+                prettyJson.append(char)
+            }
+            char == '}' && get(index - 1) != '{' -> {
+                prettyJson.appendLine()
+                indentation--
+                prettyJson.append(indent.repeat(indentation))
+                prettyJson.append(char)
+            }
+            char == ')' && get(index - 1) != '(' -> {
+                prettyJson.appendLine()
+                indentation--
+                prettyJson.append(indent.repeat(indentation))
+                prettyJson.append(char)
+            }
+            else -> prettyJson.append(char)
+        }
+
+        return indentation
+    }
+}

--- a/appcues/src/main/java/com/appcues/data/remote/HttpExt.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/HttpExt.kt
@@ -1,0 +1,9 @@
+package com.appcues.data.remote
+
+import okhttp3.MediaType
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+internal fun MediaType?.charsetOrUTF8(): Charset {
+    return this?.charset(null) ?: StandardCharsets.UTF_8
+}

--- a/appcues/src/main/java/com/appcues/data/remote/RetrofitWrapper.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/RetrofitWrapper.kt
@@ -1,33 +1,25 @@
 package com.appcues.data.remote
 
-import com.appcues.BuildConfig
 import com.appcues.data.MoshiConfiguration
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import kotlin.reflect.KClass
 
 internal class RetrofitWrapper(
     private val baseUrl: HttpUrl?,
-    private val isDebug: Boolean = BuildConfig.DEBUG,
     private val interceptors: List<Interceptor> = listOf(),
     private val okhttpConfig: (OkHttpClient.Builder) -> OkHttpClient.Builder = { it }
 ) {
+
     private val retrofit: Retrofit by lazy {
         val okHttp = OkHttpClient.Builder()
             .also {
                 okhttpConfig(it)
-                if (isDebug) {
-                    it.addInterceptor(
-                        HttpLoggingInterceptor().apply {
-                            level = HttpLoggingInterceptor.Level.BODY
-                        }
-                    )
-                }
+
                 interceptors.forEach { interceptor ->
                     it.addInterceptor(interceptor)
                 }

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/AppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/AppcuesRemoteSource.kt
@@ -2,18 +2,14 @@ package com.appcues.data.remote.appcues
 
 import com.appcues.AppcuesConfig
 import com.appcues.Storage
-import com.appcues.analytics.SdkMetrics
 import com.appcues.data.remote.NetworkRequest
 import com.appcues.data.remote.RemoteError
 import com.appcues.data.remote.appcues.response.ActivityResponse
 import com.appcues.data.remote.appcues.response.QualifyResponse
 import com.appcues.data.remote.appcues.response.experience.ExperienceResponse
 import com.appcues.util.ResultOf
-import okhttp3.Interceptor
-import okhttp3.Interceptor.Chain
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
 import java.util.UUID
 
 internal class AppcuesRemoteSource(
@@ -21,7 +17,9 @@ internal class AppcuesRemoteSource(
     private val config: AppcuesConfig,
     private val storage: Storage,
 ) {
+
     companion object {
+
         const val BASE_URL = "https://api.appcues.net/"
 
         // we should not show an experience response if it takes > 5 seconds to return
@@ -91,22 +89,5 @@ internal class AppcuesRemoteSource(
                 is ResultOf.Success -> it.value.ok
             }
         }
-    }
-}
-
-// an interceptor used on Appcues requests to track the timing of SDK requests
-// related to experience rendering, for SDK metrics
-internal class MetricsInterceptor : Interceptor {
-    override fun intercept(chain: Chain): Response {
-        val request = chain.request()
-        val requestId = request.header("appcues-request-id")
-        val requestBuilder = request
-            .newBuilder()
-            .method(request.method, request.body)
-            .removeHeader("appcues-request-id")
-        SdkMetrics.requested(requestId)
-        val response = chain.proceed(requestBuilder.build())
-        SdkMetrics.responded(requestId)
-        return response
     }
 }

--- a/appcues/src/main/java/com/appcues/data/remote/customerapi/CustomerApiRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/customerapi/CustomerApiRemoteSource.kt
@@ -7,16 +7,14 @@ import com.appcues.data.remote.RemoteError
 import com.appcues.data.remote.customerapi.response.PreUploadScreenshotResponse
 import com.appcues.debugger.screencapture.Capture
 import com.appcues.util.ResultOf
-import okhttp3.HttpUrl
-import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
 
 internal class CustomerApiRemoteSource(
     private val service: CustomerApiService,
     private val config: AppcuesConfig,
 ) {
+
     suspend fun preUploadScreenshot(
         capture: Capture,
         token: String,
@@ -43,31 +41,5 @@ internal class CustomerApiRemoteSource(
                 screen = captureJson.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
             )
         }
-    }
-}
-
-internal class CustomerApiBaseUrlInterceptor : Interceptor {
-
-    companion object {
-        // customer API host is looked up in settings, and must be set here
-        // before any usage
-        lateinit var baseUrl: HttpUrl
-    }
-
-    override fun intercept(chain: Interceptor.Chain): Response {
-
-        var request = chain.request()
-
-        val newUrl = request.url.newBuilder()
-            .scheme(baseUrl.scheme)
-            .host(baseUrl.host)
-            .port(baseUrl.port)
-            .build()
-
-        request = request.newBuilder()
-            .url(newUrl)
-            .build()
-
-        return chain.proceed(request)
     }
 }

--- a/appcues/src/main/java/com/appcues/data/remote/interceptor/CustomerApiBaseUrlInterceptor.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/interceptor/CustomerApiBaseUrlInterceptor.kt
@@ -1,0 +1,32 @@
+package com.appcues.data.remote.interceptor
+
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.Response
+
+internal class CustomerApiBaseUrlInterceptor : Interceptor {
+
+    companion object {
+
+        // customer API host is looked up in settings, and must be set here
+        // before any usage
+        lateinit var baseUrl: HttpUrl
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+
+        var request = chain.request()
+
+        val newUrl = request.url.newBuilder()
+            .scheme(baseUrl.scheme)
+            .host(baseUrl.host)
+            .port(baseUrl.port)
+            .build()
+
+        request = request.newBuilder()
+            .url(newUrl)
+            .build()
+
+        return chain.proceed(request)
+    }
+}

--- a/appcues/src/main/java/com/appcues/data/remote/interceptor/HttpLogcuesInterceptor.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/interceptor/HttpLogcuesInterceptor.kt
@@ -1,0 +1,27 @@
+package com.appcues.data.remote.interceptor
+
+import com.appcues.data.remote.DataLogcues
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+
+internal class HttpLogcuesInterceptor(private val dataLogcues: DataLogcues) : Interceptor {
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun intercept(chain: Chain): Response {
+        val request = chain.request()
+
+        dataLogcues.debug(request)
+
+        val response = try {
+            chain.proceed(request)
+        } catch (e: Exception) {
+            dataLogcues.error("Failed to send request", e.message.toString())
+            throw e
+        }
+
+        dataLogcues.debug(response)
+
+        return response
+    }
+}

--- a/appcues/src/main/java/com/appcues/data/remote/interceptor/SdkMetricsInterceptor.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/interceptor/SdkMetricsInterceptor.kt
@@ -1,0 +1,24 @@
+package com.appcues.data.remote.interceptor
+
+import com.appcues.analytics.SdkMetrics
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+
+// an interceptor used on Appcues requests to track the timing of SDK requests
+// related to experience rendering, for SDK metrics
+internal class SdkMetricsInterceptor : Interceptor {
+
+    override fun intercept(chain: Chain): Response {
+        val request = chain.request()
+        val requestId = request.header("appcues-request-id")
+        val requestBuilder = request
+            .newBuilder()
+            .method(request.method, request.body)
+            .removeHeader("appcues-request-id")
+        SdkMetrics.requested(requestId)
+        val response = chain.proceed(requestBuilder.build())
+        SdkMetrics.responded(requestId)
+        return response
+    }
+}

--- a/appcues/src/main/java/com/appcues/debugger/DebugMode.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebugMode.kt
@@ -1,6 +1,6 @@
 package com.appcues.debugger
 
 internal sealed class DebugMode {
-    data class Debugger(val deepLinkPath: String?) : DebugMode()
+    object Debugger : DebugMode()
     data class ScreenCapture(val token: String) : DebugMode()
 }

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerFontManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerFontManager.kt
@@ -32,7 +32,6 @@ internal class DebuggerFontManager(
     )
 
     fun getAppSpecificFonts(): List<DebuggerFontItem> {
-
         val debugFonts = mutableListOf<DebuggerFontItem>()
         addFontResources(debugFonts)
         addFontAssets(debugFonts)

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerLogMessageManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerLogMessageManager.kt
@@ -1,0 +1,52 @@
+package com.appcues.debugger
+
+import com.appcues.logging.LogMessage
+import com.appcues.logging.Logcues
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+internal class DebuggerLogMessageManager(private val logcues: Logcues) : CoroutineScope {
+
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Default
+
+    private val messages: ArrayList<LogMessage> = arrayListOf()
+
+    private val _data = MutableStateFlow<List<LogMessage>>(arrayListOf())
+    val data: StateFlow<List<LogMessage>>
+        get() = _data
+
+    private var isStarted = false
+    fun start() {
+        if (isStarted) return
+
+        launch {
+            logcues.messageFlow.collect { onMessage(it) }
+        }
+
+        isStarted = true
+    }
+
+    fun reset() {
+        coroutineContext.cancelChildren()
+        isStarted = false
+        messages.clear()
+
+        launch { updateData() }
+    }
+
+    private suspend fun onMessage(logMessage: LogMessage) {
+        messages.add(0, logMessage)
+
+        updateData()
+    }
+
+    suspend fun updateData() {
+        _data.emit(messages)
+    }
+}

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerModule.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerModule.kt
@@ -14,18 +14,22 @@ internal object DebuggerModule : AppcuesModule {
                 appcuesRemoteSource = get(),
                 contextWrapper = get(),
                 context = get(),
+                analyticsTracker = get(),
             )
         }
 
         scoped {
             DebuggerRecentEventsManager(
-                contextWrapper = get()
+                contextWrapper = get(),
+                analyticsTracker = get(),
             )
         }
 
         scoped {
             DebuggerFontManager(context = get(), logcues = get())
         }
+
+        scoped { DebuggerLogMessageManager(get()) }
 
         scoped {
             ScreenCaptureProcessor(

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/ScreenCaptureProcessor.kt
@@ -13,10 +13,10 @@ import com.appcues.AppcuesConfig
 import com.appcues.R
 import com.appcues.Screenshot
 import com.appcues.data.remote.RemoteError
-import com.appcues.data.remote.customerapi.CustomerApiBaseUrlInterceptor
 import com.appcues.data.remote.customerapi.CustomerApiRemoteSource
 import com.appcues.data.remote.customerapi.response.PreUploadScreenshotResponse
 import com.appcues.data.remote.imageupload.ImageUploadRemoteSource
+import com.appcues.data.remote.interceptor.CustomerApiBaseUrlInterceptor
 import com.appcues.data.remote.sdksettings.SdkSettingsRemoteSource
 import com.appcues.monitor.AppcuesActivityMonitor
 import com.appcues.ui.utils.getParentView
@@ -34,6 +34,7 @@ internal class ScreenCaptureProcessor(
     private val customerApiRemoteSource: CustomerApiRemoteSource,
     private val imageUploadRemoteSource: ImageUploadRemoteSource,
 ) {
+
     fun captureScreen(): Capture? {
         return AppcuesActivityMonitor.activity?.getParentView()?.let {
             prepare(it)

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionEvents.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionEvents.kt
@@ -67,15 +67,15 @@ internal fun BoxScope.DebuggerFloatingActionEvents(
                 .align(
                     when {
                         eventsProperties.anchorToStart && eventsProperties.drawTop -> Alignment.BottomStart
-                        eventsProperties.anchorToStart && eventsProperties.drawTop.not() -> Alignment.TopStart
-                        eventsProperties.anchorToStart.not() && eventsProperties.drawTop -> Alignment.BottomEnd
+                        eventsProperties.anchorToStart -> Alignment.TopStart
+                        eventsProperties.drawTop -> Alignment.BottomEnd
                         else -> Alignment.TopEnd
                     }
                 )
                 .offset { eventsProperties.positionOffset },
             contentAlignment = Alignment.TopEnd
         ) {
-            val shouldDisplayEvents = debuggerState.debugMode.value is Debugger &&
+            val shouldDisplayEvents = debuggerState.debugMode is Debugger &&
                 debuggerState.isDragging.targetState.not() &&
                 debuggerState.isExpanded.targetState.not()
 
@@ -103,7 +103,10 @@ internal fun BoxScope.DebuggerFloatingActionEvents(
 private fun LazyItemScope.Item(event: DebuggerEventItem, isAnchoredStart: Boolean, eventTimedOut: () -> Unit) {
     val visibility = remember { MutableTransitionState(false) }.apply { targetState = event.showOnFab }
     val displayed = remember { mutableStateOf(false) }
-    val alpha = animateFloatAsState(targetValue = if (displayed.value) FAB_EVENT_DISPLAYED_ALPHA else 1f)
+    val alpha = animateFloatAsState(
+        targetValue = if (displayed.value) FAB_EVENT_DISPLAYED_ALPHA else 1f,
+        label = "Floating actions Alpha"
+    )
 
     AnimatedVisibility(
         enter = slideInHorizontally(initialOffsetX = { if (isAnchoredStart) -it else it }),

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerOnDrag.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerOnDrag.kt
@@ -26,12 +26,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.appcues.R
 import com.appcues.R.drawable
+import com.appcues.debugger.DebuggerViewModel
+import com.appcues.debugger.DebuggerViewModel.UIState.Dismissing
 import com.appcues.ui.theme.AppcuesColors
 
 @Composable
 internal fun BoxScope.DebuggerOnDrag(
     debuggerState: MutableDebuggerState,
-    onDismiss: () -> Unit,
+    debuggerViewModel: DebuggerViewModel,
 ) {
     // don't show if current debugger is paused
     if (debuggerState.isPaused.value) return
@@ -51,7 +53,7 @@ internal fun BoxScope.DebuggerOnDrag(
     with(debuggerState.isDragging) {
         LaunchedEffect(targetState) {
             if (targetState.not() && debuggerState.isDraggingOverDismiss.value) {
-                onDismiss()
+                debuggerViewModel.transition(Dismissing(debuggerState.debugMode))
             }
         }
     }
@@ -63,8 +65,14 @@ private const val ROTATE_NONE = 0f
 @Composable
 private fun DismissDebuggerArea(debuggerState: MutableDebuggerState, onGloballyPositioned: (LayoutCoordinates) -> Unit) {
     val isDraggingAndColliding = debuggerState.isDragging.targetState && debuggerState.isDraggingOverDismiss.value
-    val size = animateDpAsState(if (isDraggingAndColliding) 50.dp else 44.dp)
-    val rotate = animateFloatAsState(if (isDraggingAndColliding) ROTATE_90_DEGREES else ROTATE_NONE)
+    val size = animateDpAsState(
+        if (isDraggingAndColliding) 50.dp else 44.dp,
+        label = "Fab dismissing Size"
+    )
+    val rotate = animateFloatAsState(
+        if (isDraggingAndColliding) ROTATE_90_DEGREES else ROTATE_NONE,
+        label = "Fab dismissing Rotation"
+    )
 
     Box(
         modifier = Modifier

--- a/appcues/src/main/java/com/appcues/debugger/ui/MutableDebuggerState.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/MutableDebuggerState.kt
@@ -1,6 +1,7 @@
 package com.appcues.debugger.ui
 
 import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -18,7 +19,7 @@ import com.appcues.debugger.screencapture.Capture
 import kotlin.math.roundToInt
 
 internal class MutableDebuggerState(
-    mode: DebugMode,
+    val debugMode: DebugMode,
     private val density: Density,
     private val isCreating: Boolean,
     val fabSize: Dp = 56.dp
@@ -40,12 +41,9 @@ internal class MutableDebuggerState(
     val isPaused = mutableStateOf(value = false)
     val toast = MutableTransitionState<DebuggerToast?>(null)
 
-    val fabXOffset = mutableStateOf(value = -1f)
-    val fabYOffset = mutableStateOf(value = -1f)
+    val fabXOffset = mutableFloatStateOf(value = -1f)
+    val fabYOffset = mutableFloatStateOf(value = -1f)
     val isDraggingOverDismiss = mutableStateOf(value = false)
-
-    val deepLinkPath = mutableStateOf<String?>(value = null)
-    val debugMode = mutableStateOf(mode)
 
     private var boxSize = IntSize(0, 0)
     private var dismissRect = Rect(Offset(0f, 0f), Size(0f, 0f))
@@ -73,29 +71,29 @@ internal class MutableDebuggerState(
 
     fun getFabPositionAsIntOffset(): IntOffset? {
         // in case the value is initial value we return null
-        if (fabXOffset.value < 0f || fabYOffset.value < 0f) return null
+        if (fabXOffset.floatValue < 0f || fabYOffset.floatValue < 0f) return null
 
-        return IntOffset(fabXOffset.value.roundToInt(), fabYOffset.value.roundToInt())
+        return IntOffset(fabXOffset.floatValue.roundToInt(), fabYOffset.floatValue.roundToInt())
     }
 
     fun getEventsProperties(): EventsProperties {
         with(density) {
-            val isStart = fabXOffset.value + (fabSize.toPx() / 2) < boxSize.width / 2
-            val drawTop = fabYOffset.value + (fabSize.toPx() / 2) > boxSize.height / 2
+            val isStart = fabXOffset.floatValue + (fabSize.toPx() / 2) < boxSize.width / 2
+            val drawTop = fabYOffset.floatValue + (fabSize.toPx() / 2) > boxSize.height / 2
 
             // calculate X/Y based on anchor position
             val offset = when {
                 isStart && drawTop -> {
-                    IntOffset(0, fabYOffset.value.toInt() - boxSize.height)
+                    IntOffset(0, fabYOffset.floatValue.toInt() - boxSize.height)
                 }
-                isStart && drawTop.not() -> {
-                    IntOffset(0, fabYOffset.value.toInt() + fabSize.toPx().toInt())
+                isStart -> {
+                    IntOffset(0, fabYOffset.floatValue.toInt() + fabSize.toPx().toInt())
                 }
-                isStart.not() && drawTop -> {
-                    IntOffset(0, fabYOffset.value.toInt() - boxSize.height)
+                drawTop -> {
+                    IntOffset(0, fabYOffset.floatValue.toInt() - boxSize.height)
                 }
                 else -> {
-                    IntOffset(0, fabYOffset.value.toInt() + fabSize.toPx().toInt())
+                    IntOffset(0, fabYOffset.floatValue.toInt() + fabSize.toPx().toInt())
                 }
             }
 
@@ -116,8 +114,8 @@ internal class MutableDebuggerState(
     fun dragFabOffsets(dragAmount: Offset) {
         with(density) {
             updatePosition(
-                x = (fabXOffset.value + dragAmount.x).coerceIn(0f, boxSize.width.toFloat() - fabSize.toPx()),
-                y = (fabYOffset.value + dragAmount.y).coerceIn(0f, boxSize.height.toFloat() - fabSize.toPx())
+                x = (fabXOffset.floatValue + dragAmount.x).coerceIn(0f, boxSize.width.toFloat() - fabSize.toPx()),
+                y = (fabYOffset.floatValue + dragAmount.y).coerceIn(0f, boxSize.height.toFloat() - fabSize.toPx())
             )
 
             isDraggingOverDismiss.value = dismissRect.overlaps(fabRect)
@@ -125,8 +123,8 @@ internal class MutableDebuggerState(
     }
 
     private fun updatePosition(x: Float, y: Float) {
-        fabXOffset.value = x
-        fabYOffset.value = y
+        fabXOffset.floatValue = x
+        fabYOffset.floatValue = y
         updateFabRect(x, y)
 
         // update global offset value with latest update

--- a/appcues/src/main/java/com/appcues/debugger/ui/events/DebuggerEventDetails.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/events/DebuggerEventDetails.kt
@@ -1,51 +1,43 @@
-package com.appcues.debugger.ui.details
+package com.appcues.debugger.ui.events
 
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
 import com.appcues.R
 import com.appcues.debugger.model.DebuggerEventItem
 import com.appcues.debugger.ui.getTitleString
 import com.appcues.debugger.ui.lazyColumnScrollIndicator
+import com.appcues.debugger.ui.shared.FloatingBackButton
 import com.appcues.ui.theme.AppcuesColors
 import java.sql.Timestamp
 
-private val FIRST_VISIBLE_ITEM_OFFSET_THRESHOLD = 56.dp
+private val firstVisibleItemOffsetThreshold = 56.dp
 
 @Composable
-internal fun DebuggerEventDetails(debuggerEventItem: DebuggerEventItem?, onBackPressed: () -> Unit) {
-    if (debuggerEventItem == null) return
-
+internal fun DebuggerEventDetails(debuggerEventItem: DebuggerEventItem, navController: NavHostController) {
     val lazyListState = rememberLazyListState()
 
     LazyColumn(
@@ -60,38 +52,24 @@ internal fun DebuggerEventDetails(debuggerEventItem: DebuggerEventItem?, onBackP
         details(debuggerEventItem)
 
         debuggerEventItem.propertySections.forEach {
-            if (it.properties != null && it.properties.isNotEmpty()) {
+            if (!it.properties.isNullOrEmpty()) {
                 propertiesTitle(it.title)
                 properties(it.properties)
             }
         }
     }
 
-    val keepBackButtonDocked = lazyListState.firstVisibleItemIndex == 0 &&
-        with(LocalDensity.current) { lazyListState.firstVisibleItemScrollOffset.toDp() < FIRST_VISIBLE_ITEM_OFFSET_THRESHOLD }
+    val isFirstVisible = remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
+    val isOverThreshold = with(LocalDensity.current) {
+        lazyListState.firstVisibleItemScrollOffset.toDp() < firstVisibleItemOffsetThreshold
+    }
+    val docked = isFirstVisible.value == 0 && isOverThreshold
 
-    val elevation = animateDpAsState(if (keepBackButtonDocked) 0.dp else 12.dp)
-
-    Box(
-        modifier = Modifier
-            .padding(top = 12.dp, start = 8.dp)
-            .size(48.dp)
-            .clickable { onBackPressed() },
-        contentAlignment = Alignment.Center
+    FloatingBackButton(
+        modifier = Modifier.padding(top = 12.dp, start = 8.dp),
+        docked = docked
     ) {
-        Box(
-            modifier = Modifier
-                .shadow(elevation.value, RoundedCornerShape(percent = 100))
-                .clip(RoundedCornerShape(percent = 100))
-                .size(32.dp)
-                .background(MaterialTheme.colors.surface),
-            contentAlignment = Alignment.Center
-        ) {
-            Image(
-                painter = painterResource(id = R.drawable.appcues_ic_back),
-                contentDescription = LocalContext.current.getString(R.string.appcues_debugger_back_description)
-            )
-        }
+        navController.popBackStack()
     }
 }
 

--- a/appcues/src/main/java/com/appcues/debugger/ui/fonts/DebuggerFontList.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/fonts/DebuggerFontList.kt
@@ -1,7 +1,6 @@
 package com.appcues.debugger.ui.fonts
 
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -17,68 +16,64 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
 import com.appcues.R
 import com.appcues.R.string
+import com.appcues.debugger.DebuggerViewModel
 import com.appcues.debugger.model.DebuggerFontItem
 import com.appcues.debugger.ui.AppcuesSearchView
 import com.appcues.debugger.ui.lazyColumnScrollIndicator
+import com.appcues.debugger.ui.shared.FloatingBackButton
+import com.appcues.debugger.ui.shared.copyToClipboardAndToast
 import com.appcues.ui.theme.AppcuesColors
 
-private val FIRST_VISIBLE_ITEM_OFFSET_THRESHOLD = 32.dp
+private val firstVisibleItemOffsetThreshold = 56.dp
 
 @Composable
-internal fun DebuggerFontDetails(
-    appSpecificFonts: List<DebuggerFontItem>,
-    systemFonts: List<DebuggerFontItem>,
-    allFonts: List<DebuggerFontItem>,
-    onFontTap: (DebuggerFontItem) -> Unit,
-    onBackPressed: () -> Unit,
+internal fun DebuggerFontList(
+    viewModel: DebuggerViewModel,
+    navController: NavHostController,
 ) {
 
     val filter = remember { mutableStateOf(String()) }
     val appSpecificFontsFiltered = remember {
         derivedStateOf {
             if (filter.value.isNotEmpty()) {
-                appSpecificFonts.filter { it.name.lowercase().contains(filter.value) }
-            } else appSpecificFonts
+                viewModel.appSpecificFonts.filter { it.name.lowercase().contains(filter.value) }
+            } else viewModel.appSpecificFonts
         }
     }
 
     val systemFontsFiltered = remember {
         derivedStateOf {
             if (filter.value.isNotEmpty()) {
-                systemFonts.filter { it.name.lowercase().contains(filter.value) }
-            } else systemFonts
+                viewModel.systemFonts.filter { it.name.lowercase().contains(filter.value) }
+            } else viewModel.systemFonts
         }
     }
 
     val allFontsFiltered = remember {
         derivedStateOf {
             if (filter.value.isNotEmpty()) {
-                allFonts.filter { it.name.lowercase().contains(filter.value) }
-            } else allFonts
+                viewModel.allFonts.filter { it.name.lowercase().contains(filter.value) }
+            } else viewModel.allFonts
         }
     }
 
@@ -97,32 +92,34 @@ internal fun DebuggerFontDetails(
 
         if (appSpecificFontsFiltered.value.any()) {
             sectionTitle(R.string.appcues_debugger_font_details_app_specific_title)
-            fonts(appSpecificFontsFiltered.value, onFontTap)
+            fonts(appSpecificFontsFiltered.value)
         }
 
         if (systemFontsFiltered.value.any()) {
             sectionTitle(R.string.appcues_debugger_font_details_system_title)
-            fonts(systemFontsFiltered.value, onFontTap)
+            fonts(systemFontsFiltered.value)
         }
 
         if (allFontsFiltered.value.any()) {
             sectionTitle(R.string.appcues_debugger_font_details_all_title)
-            fonts(allFontsFiltered.value, onFontTap)
+            fonts(allFontsFiltered.value)
         }
     }
 
-    val keepBackButtonDocked = lazyListState.firstVisibleItemIndex == 0 &&
-        with(LocalDensity.current) { lazyListState.firstVisibleItemScrollOffset.toDp() < FIRST_VISIBLE_ITEM_OFFSET_THRESHOLD }
-    val elevation = animateDpAsState(if (keepBackButtonDocked) 0.dp else 12.dp)
+    val isFirstVisible = remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
+    val isOverThreshold = with(LocalDensity.current) {
+        lazyListState.firstVisibleItemScrollOffset.toDp() < firstVisibleItemOffsetThreshold
+    }
+    val docked = isFirstVisible.value == 0 && isOverThreshold
 
-    FontDetailsOverlay(elevation, onBackPressed, filter)
+    FontDetailsOverlay(docked, navController, filter)
 }
 
 @Composable
 private fun FontDetailsOverlay(
-    elevation: State<Dp>,
-    onBackPressed: () -> Unit,
-    filter: MutableState<String>
+    docked: Boolean,
+    navController: NavHostController,
+    filter: MutableState<String>,
 ) {
     Box(
         modifier = Modifier
@@ -130,13 +127,16 @@ private fun FontDetailsOverlay(
             .padding(vertical = 32.dp, horizontal = 8.dp)
     ) {
 
-        BackButton(
+        FloatingBackButton(
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .padding(top = 8.dp),
-            elevation = elevation.value
-        ) { onBackPressed() }
+            docked = docked,
+        ) {
+            navController.popBackStack()
+        }
 
+        val elevation = animateDpAsState(if (docked) 0.dp else 12.dp, label = "search elevation")
         AppcuesSearchView(
             modifier = Modifier
                 .align(Alignment.TopEnd)
@@ -147,36 +147,6 @@ private fun FontDetailsOverlay(
             hint = LocalContext.current.getString(string.appcues_debugger_font_details_hint),
             inputDelay = 300,
         ) { filter.value = it.lowercase() }
-    }
-}
-
-@Composable
-private fun BackButton(
-    modifier: Modifier = Modifier,
-    elevation: Dp,
-    onBackPressed: () -> Unit
-) {
-    Box(
-        modifier = Modifier
-            .then(modifier)
-            .size(48.dp)
-            .clip(RoundedCornerShape(percent = 100))
-            .clickable { onBackPressed() },
-        contentAlignment = Alignment.Center
-    ) {
-        Box(
-            modifier = Modifier
-                .shadow(elevation, RoundedCornerShape(percent = 100))
-                .clip(RoundedCornerShape(percent = 100))
-                .size(32.dp)
-                .background(MaterialTheme.colors.surface),
-            contentAlignment = Alignment.Center
-        ) {
-            Image(
-                painter = painterResource(id = R.drawable.appcues_ic_back),
-                contentDescription = LocalContext.current.getString(R.string.appcues_debugger_back_description)
-            )
-        }
     }
 }
 
@@ -192,9 +162,9 @@ private fun LazyListScope.sectionTitle(resId: Int) {
     }
 }
 
-private fun LazyListScope.fonts(properties: List<DebuggerFontItem>, onFontTap: (DebuggerFontItem) -> Unit) {
+private fun LazyListScope.fonts(properties: List<DebuggerFontItem>) {
     items(properties.toList()) { item ->
-        ListItem(item, onFontTap)
+        ListItem(item)
     }
 
     item {
@@ -203,11 +173,14 @@ private fun LazyListScope.fonts(properties: List<DebuggerFontItem>, onFontTap: (
 }
 
 @Composable
-private fun LazyItemScope.ListItem(debuggerFont: DebuggerFontItem, onFontTap: (DebuggerFontItem) -> Unit) {
+private fun LazyItemScope.ListItem(debuggerFont: DebuggerFontItem) {
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+
     Row(
         modifier = Modifier
             .fillParentMaxWidth()
-            .clickable { onFontTap(debuggerFont) }
+            .clickable { copyToClipboardAndToast(context, clipboard, debuggerFont.name) }
             .padding(horizontal = 20.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/appcues/src/main/java/com/appcues/debugger/ui/logs/DateExt.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/logs/DateExt.kt
@@ -1,0 +1,9 @@
+package com.appcues.debugger.ui.logs
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+internal fun Date.toLogFormat(): String {
+    return SimpleDateFormat("yyyy-MM-dd hh:mm:ss", Locale.getDefault()).format(this)
+}

--- a/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogDetails.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogDetails.kt
@@ -1,0 +1,110 @@
+@file:JvmName("DebuggerLogDetailsKt")
+
+package com.appcues.debugger.ui.logs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.appcues.R
+import com.appcues.debugger.ui.shared.FloatingBackButton
+import com.appcues.debugger.ui.shared.copyToClipboardAndToast
+import com.appcues.logging.LogMessage
+import com.appcues.logging.LogType.DEBUG
+import com.appcues.logging.LogType.ERROR
+import com.appcues.logging.LogType.INFO
+import com.appcues.ui.theme.AppcuesColors
+
+private val firstVisibleItemOffsetThreshold = 56.dp
+
+@Composable
+internal fun DebuggerLogDetails(message: LogMessage, navController: NavHostController) {
+    val scrollState = rememberScrollState()
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val color = when (message.type) {
+        INFO, DEBUG -> AppcuesColors.Infinity
+        ERROR -> Color.Red
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(AppcuesColors.DebuggerBackground)
+            .verticalScroll(scrollState)
+            .padding(16.dp)
+    ) {
+        val text = stringResource(id = R.string.appcues_debugger_log_copy_log)
+        TextButton(
+            modifier = Modifier
+                .semantics {
+                    this.contentDescription = text
+                }
+                .align(Alignment.End),
+            onClick = { copyToClipboardAndToast(context, clipboard, message.message) }) {
+            Text(text = text, color = AppcuesColors.Blurple)
+        }
+
+        Text(
+            text = stringResource(id = R.string.appcues_debugger_log_level, message.type.displayName),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = FontFamily.Monospace,
+            color = color
+        )
+        Text(
+            text = stringResource(id = R.string.appcues_debugger_log_timestamp, message.timestamp),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = FontFamily.Monospace,
+            color = color
+        )
+        Divider(
+            modifier = Modifier.padding(vertical = 12.dp),
+            color = AppcuesColors.WhisperBlue,
+            thickness = 1.dp,
+        )
+        Text(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            softWrap = false,
+            text = message.message,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Normal,
+            fontFamily = FontFamily.Monospace,
+            color = color
+        )
+
+        Spacer(modifier = Modifier.padding(bottom = 16.dp))
+    }
+
+    val docked = with(LocalDensity.current) { scrollState.value.toDp() < firstVisibleItemOffsetThreshold }
+
+    FloatingBackButton(
+        modifier = Modifier.padding(top = 12.dp, start = 8.dp),
+        docked = docked
+    ) {
+        navController.popBackStack()
+    }
+}

--- a/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogDetails.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogDetails.kt
@@ -75,7 +75,7 @@ internal fun DebuggerLogDetails(message: LogMessage, navController: NavHostContr
             color = color
         )
         Text(
-            text = stringResource(id = R.string.appcues_debugger_log_timestamp, message.timestamp),
+            text = stringResource(id = R.string.appcues_debugger_log_timestamp, message.timestamp.toLogFormat()),
             fontSize = 12.sp,
             fontWeight = FontWeight.SemiBold,
             fontFamily = FontFamily.Monospace,

--- a/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogList.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogList.kt
@@ -106,7 +106,7 @@ private fun LazyItemScope.ListItem(index: Int, logMessage: LogMessage, onItemCli
                 text = stringResource(
                     id = R.string.appcues_debugger_item_title,
                     logMessage.type.displayName,
-                    logMessage.timestamp.toString()
+                    logMessage.timestamp.toLogFormat()
                 ),
                 fontSize = 12.sp,
                 fontWeight = FontWeight.SemiBold,

--- a/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogList.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogList.kt
@@ -1,0 +1,132 @@
+package com.appcues.debugger.ui.logs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.appcues.R
+import com.appcues.debugger.DebuggerViewModel
+import com.appcues.debugger.ui.lazyColumnScrollIndicator
+import com.appcues.debugger.ui.shared.FloatingBackButton
+import com.appcues.logging.LogMessage
+import com.appcues.logging.LogType.DEBUG
+import com.appcues.logging.LogType.ERROR
+import com.appcues.logging.LogType.INFO
+import com.appcues.ui.theme.AppcuesColors
+
+private val firstVisibleItemOffsetThreshold = 56.dp
+
+@Composable
+internal fun DebuggerLogList(
+    viewModel: DebuggerViewModel,
+    navController: NavHostController,
+    onLogMessageSelected: (LogMessage) -> Unit
+) {
+    val lazyListState = rememberLazyListState()
+    val messages = viewModel.logMessages.collectAsState()
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(AppcuesColors.DebuggerBackground)
+            .lazyColumnScrollIndicator(lazyListState),
+        state = lazyListState
+    ) {
+        item {
+            Spacer(modifier = Modifier.height(80.dp))
+        }
+
+        itemsIndexed(messages.value) { index, item ->
+            ListItem(index, item, onLogMessageSelected)
+        }
+
+        item {
+            Spacer(modifier = Modifier.padding(bottom = 16.dp))
+        }
+    }
+
+    val firstVisible = remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
+    val docked = firstVisible.value == 0 &&
+        with(LocalDensity.current) { lazyListState.firstVisibleItemScrollOffset.toDp() < firstVisibleItemOffsetThreshold }
+
+    FloatingBackButton(
+        modifier = Modifier.padding(top = 12.dp, start = 8.dp),
+        docked = docked
+    ) {
+        navController.popBackStack()
+    }
+}
+
+@Composable
+private fun LazyItemScope.ListItem(index: Int, logMessage: LogMessage, onItemClicked: (LogMessage) -> Unit) {
+    Row(
+        modifier = Modifier
+            .clickable { onItemClicked(logMessage) }
+            .fillParentMaxWidth()
+            .padding(horizontal = 20.dp)
+            .testTag("log-message-$index"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(vertical = 8.dp, horizontal = 20.dp),
+            verticalArrangement = Arrangement.Center
+        ) {
+            val color = when (logMessage.type) {
+                INFO, DEBUG -> AppcuesColors.Infinity
+                ERROR -> Color.Red
+            }
+            Text(
+                text = stringResource(
+                    id = R.string.appcues_debugger_item_title,
+                    logMessage.type.displayName,
+                    logMessage.timestamp.toString()
+                ),
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = FontFamily.Monospace,
+                color = color
+            )
+            Text(
+                text = logMessage.message,
+                fontSize = 12.sp,
+                maxLines = 10,
+                fontWeight = FontWeight.Normal,
+                fontFamily = FontFamily.Monospace,
+                color = color
+            )
+        }
+    }
+
+    Divider(
+        modifier = Modifier.padding(horizontal = 20.dp),
+        color = AppcuesColors.WhisperBlue,
+        thickness = 1.dp,
+    )
+}

--- a/appcues/src/main/java/com/appcues/debugger/ui/shared/CopyAndToast.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/shared/CopyAndToast.kt
@@ -1,0 +1,14 @@
+package com.appcues.debugger.ui.shared
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import com.appcues.R
+
+internal fun copyToClipboardAndToast(context: Context, clipboardManager: ClipboardManager, text: String) {
+    clipboardManager.setText(AnnotatedString(text))
+    val message = context.getString(R.string.appcues_debugger_clipboard_copy_message)
+
+    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+}

--- a/appcues/src/main/java/com/appcues/debugger/ui/shared/FloatingBackButton.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/shared/FloatingBackButton.kt
@@ -1,0 +1,48 @@
+package com.appcues.debugger.ui.shared
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.appcues.R.drawable
+import com.appcues.R.string
+
+@Composable
+internal fun FloatingBackButton(modifier: Modifier = Modifier, docked: Boolean, onTap: () -> Unit) {
+    val elevation = animateDpAsState(if (docked) 0.dp else 12.dp, label = "back icon elevation")
+
+    Box(
+        modifier = Modifier
+            .then(modifier)
+            .size(48.dp)
+            .clip(RoundedCornerShape(percent = 100))
+            .clickable { onTap() },
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .shadow(elevation.value, RoundedCornerShape(percent = 100))
+                .clip(RoundedCornerShape(percent = 100))
+                .size(32.dp)
+                .background(MaterialTheme.colors.surface),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                painter = painterResource(id = drawable.appcues_ic_back),
+                contentDescription = LocalContext.current.getString(string.appcues_debugger_back_description)
+            )
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/logging/LogMessage.kt
+++ b/appcues/src/main/java/com/appcues/logging/LogMessage.kt
@@ -1,0 +1,9 @@
+package com.appcues.logging
+
+import java.util.Date
+
+internal data class LogMessage(
+    val message: String,
+    val type: LogType,
+    val timestamp: Date
+)

--- a/appcues/src/main/java/com/appcues/logging/LogType.kt
+++ b/appcues/src/main/java/com/appcues/logging/LogType.kt
@@ -1,0 +1,5 @@
+package com.appcues.logging
+
+internal enum class LogType(val displayName: String) {
+    INFO("Info"), DEBUG("Debug"), ERROR("Error")
+}

--- a/appcues/src/main/java/com/appcues/logging/LogcatDestination.kt
+++ b/appcues/src/main/java/com/appcues/logging/LogcatDestination.kt
@@ -2,6 +2,7 @@ package com.appcues.logging
 
 import android.util.Log
 import com.appcues.LoggingLevel
+import com.appcues.LoggingLevel.NONE
 import com.appcues.logging.LogType.DEBUG
 import com.appcues.logging.LogType.ERROR
 import com.appcues.logging.LogType.INFO
@@ -26,16 +27,18 @@ internal class LogcatDestination(
         get() = dispatcher
 
     fun init() {
+        if (level == NONE) return
+
         launch { logcues.messageFlow.collect { it.log() } }
     }
 
     private fun LogMessage.log() {
-        if (type == INFO && level >= LoggingLevel.INFO) {
+        if (type == INFO) {
             Log.i(TAG, message)
+        } else if (type == ERROR) {
+            Log.e(TAG, message)
         } else if (type == DEBUG && level == LoggingLevel.DEBUG) {
             Log.d(TAG, message)
-        } else if (type == ERROR && level > LoggingLevel.NONE) {
-            Log.e(TAG, message)
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/logging/LogcatDestination.kt
+++ b/appcues/src/main/java/com/appcues/logging/LogcatDestination.kt
@@ -1,0 +1,41 @@
+package com.appcues.logging
+
+import android.util.Log
+import com.appcues.LoggingLevel
+import com.appcues.logging.LogType.DEBUG
+import com.appcues.logging.LogType.ERROR
+import com.appcues.logging.LogType.INFO
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+internal class LogcatDestination(
+    private val logcues: Logcues,
+    private val level: LoggingLevel,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) : CoroutineScope {
+
+    companion object {
+
+        private const val TAG = "Appcues"
+    }
+
+    override val coroutineContext: CoroutineContext
+        get() = dispatcher
+
+    fun init() {
+        launch { logcues.messageFlow.collect { it.log() } }
+    }
+
+    private fun LogMessage.log() {
+        if (type == INFO && level >= LoggingLevel.INFO) {
+            Log.i(TAG, message)
+        } else if (type == DEBUG && level == LoggingLevel.DEBUG) {
+            Log.d(TAG, message)
+        } else if (type == ERROR && level > LoggingLevel.NONE) {
+            Log.e(TAG, message)
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/logging/Logcues.kt
+++ b/appcues/src/main/java/com/appcues/logging/Logcues.kt
@@ -1,31 +1,38 @@
 package com.appcues.logging
 
-import android.util.Log
-import com.appcues.LoggingLevel
-import com.appcues.LoggingLevel.NONE
+import com.appcues.logging.LogType.DEBUG
+import com.appcues.logging.LogType.ERROR
+import com.appcues.logging.LogType.INFO
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import java.util.Date
+import kotlin.coroutines.CoroutineContext
 
-internal class Logcues(private val loggingLevel: LoggingLevel) {
+internal class Logcues(private val dispatcher: CoroutineDispatcher = Dispatchers.Default) : CoroutineScope {
 
-    companion object {
+    override val coroutineContext: CoroutineContext
+        get() = dispatcher
 
-        private const val TAG = "Appcues"
-    }
+    private val _messageFlow = MutableSharedFlow<LogMessage>(replay = 15)
+    val messageFlow: SharedFlow<LogMessage> = _messageFlow
 
     fun info(message: String) {
-        if (loggingLevel > NONE) {
-            Log.i(TAG, message)
-        }
+        launch { _messageFlow.emit(LogMessage(message, INFO, Date())) }
+    }
+
+    fun debug(message: String) {
+        launch { _messageFlow.emit(LogMessage(message, DEBUG, Date())) }
     }
 
     fun error(message: String) {
-        if (loggingLevel > NONE) {
-            Log.e(TAG, message)
-        }
+        launch { _messageFlow.emit(LogMessage(message, ERROR, Date())) }
     }
 
     fun error(throwable: Throwable) {
-        if (loggingLevel > NONE) {
-            Log.e(TAG, throwable.message.toString())
-        }
+        error(throwable.message.toString())
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/theme/AppcuesTheme.kt
+++ b/appcues/src/main/java/com/appcues/ui/theme/AppcuesTheme.kt
@@ -1,29 +1,12 @@
 package com.appcues.ui.theme
 
-import android.content.res.Configuration
-import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Colors
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.unit.dp
-import com.appcues.LoggingLevel.NONE
-import com.appcues.action.ExperienceAction
-import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
-import com.appcues.data.model.ExperiencePrimitive
-import com.appcues.logging.Logcues
-import com.appcues.ui.composables.AppcuesActionsDelegate
-import com.appcues.ui.composables.LocalAppcuesActionDelegate
-import com.appcues.ui.composables.LocalLogcues
-import com.appcues.ui.primitive.Compose
 
 /**
  * Official AppcuesTheme for all compositions
@@ -54,36 +37,4 @@ private fun getColors(isDark: Boolean): Colors {
             onBackground = Color.Transparent,
             surface = Color.Transparent
         )
-}
-
-/**
- * This is supposed to be used during inspection mode (Preview) only.
- */
-@Composable
-internal fun AppcuesPreviewPrimitive(
-    isDark: Boolean = isSystemInDarkTheme(),
-    primitiveBuilder: () -> ExperiencePrimitive
-) {
-    LocalConfiguration.current.uiMode = if (isDark) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
-
-    AppcuesTheme {
-        CompositionLocalProvider(
-            LocalLogcues provides Logcues(NONE),
-            LocalAppcuesActionDelegate provides PreviewAppcuesActionDelegate(),
-        ) {
-            Column(
-                modifier = Modifier.background(MaterialTheme.colors.surface),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                primitiveBuilder().Compose()
-            }
-        }
-    }
-}
-
-private class PreviewAppcuesActionDelegate : AppcuesActionsDelegate {
-
-    override fun onActions(actions: List<ExperienceAction>, interactionType: InteractionType, viewDescription: String?) {
-        // do nothing
-    }
 }

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
 
     <string name="appcues_debugger_info_title">Info</string>
     <string name="appcues_debugger_info_fonts">Available Fonts</string>
+    <string name="appcues_debugger_info_detailed_log">Detailed Log</string>
     <string name="appcues_debugger_recent_events_title">Recent events</string>
     <string name="appcues_debugger_recent_events_item_icon_description">Event icon</string>
     <string name="appcues_debugger_recent_events_timestamp_icon_description">Timestamp icon</string>
@@ -84,10 +85,16 @@
     <string name="appcues_debugger_font_details_app_specific_title">App-Specific Fonts</string>
     <string name="appcues_debugger_font_details_system_title">System Fonts</string>
     <string name="appcues_debugger_font_details_all_title">All Fonts</string>
-    <string name="appcues_debugger_font_details_clipboard_message">"Copied to clipboard"</string>
     <string name="appcues_debugger_font_details_copy_icon_description">Copy icon</string>
     <string name="appcues_debugger_font_details_clean_filter">Clear</string>
     <string name="appcues_debugger_font_details_hint">"Search…"</string>
+
+    <string name="appcues_debugger_log_copy_log">Copy Log</string>
+    <string name="appcues_debugger_log_level">Level: %1$s</string>
+    <string name="appcues_debugger_log_timestamp">Timestamp: %1$s</string>
+    <string name="appcues_debugger_item_title">%1$s: %2$s</string>
+
+    <string name="appcues_debugger_clipboard_copy_message">Copied to clipboard</string>
 
     <!-- Screen Capture Dialog -->
     <string name="appcues_screen_capture_dismiss">dismiss</string>

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -282,7 +282,7 @@ internal class AppcuesTest : AppcuesScopeTest {
         appcues.debug(activity)
 
         // THEN
-        verify { debuggerManager.start(activity, Debugger(null)) }
+        verify { debuggerManager.start(activity, Debugger) }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/DeeplinkHandlerTest.kt
+++ b/appcues/src/test/java/com/appcues/DeeplinkHandlerTest.kt
@@ -2,7 +2,6 @@ package com.appcues
 
 import android.app.Activity
 import android.content.Intent
-import com.appcues.LoggingLevel.NONE
 import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperienceTrigger.DeepLink
 import com.appcues.debugger.AppcuesDebuggerManager
@@ -38,7 +37,7 @@ internal class DeeplinkHandlerTest {
 
     private val config: AppcuesConfig = mockk(relaxed = true)
     private val experienceRenderer: ExperienceRenderer = mockk(relaxed = true)
-    private val appcuesCoroutineScope: AppcuesCoroutineScope = AppcuesCoroutineScope(Logcues(NONE))
+    private val appcuesCoroutineScope: AppcuesCoroutineScope = AppcuesCoroutineScope(Logcues())
     private val debuggerManager: AppcuesDebuggerManager = mockk(relaxed = true)
 
     @Before
@@ -272,7 +271,7 @@ internal class DeeplinkHandlerTest {
         deepLinkHandler.handle(activity, intent)
 
         // THEN
-        coVerify { debuggerManager.start(activity, Debugger(null)) }
+        coVerify { debuggerManager.start(activity, Debugger) }
     }
 
     @Test
@@ -292,7 +291,7 @@ internal class DeeplinkHandlerTest {
         deepLinkHandler.handle(activity, intent)
 
         // THEN
-        coVerify { debuggerManager.start(activity, Debugger("deeplink-path")) }
+        coVerify { debuggerManager.start(activity, Debugger, "deeplink-path") }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
@@ -1,7 +1,6 @@
 package com.appcues.analytics
 
 import com.appcues.AppcuesCoroutineScope
-import com.appcues.LoggingLevel.NONE
 import com.appcues.data.AppcuesRepository
 import com.appcues.data.model.ExperienceTrigger.Qualification
 import com.appcues.data.model.QualificationResult
@@ -33,7 +32,7 @@ internal class AnalyticsQueueProcessorTest {
     private val mockkQualificationResult: QualificationResult =
         QualificationResult(Qualification("screen_view"), arrayListOf(mockk()))
 
-    private val coroutineScope = AppcuesCoroutineScope(Logcues(NONE))
+    private val coroutineScope = AppcuesCoroutineScope(Logcues())
     private val experienceRenderer: ExperienceRenderer = mockk()
     private val repository: AppcuesRepository = mockk<AppcuesRepository>().apply {
         coEvery { trackActivity(any()) } returns mockkQualificationResult

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
@@ -2,7 +2,6 @@ package com.appcues.analytics
 
 import com.appcues.AnalyticType
 import com.appcues.AppcuesCoroutineScope
-import com.appcues.LoggingLevel.NONE
 import com.appcues.SessionMonitor
 import com.appcues.analytics.AnalyticsEvent.SessionStarted
 import com.appcues.data.model.Experiment
@@ -24,7 +23,7 @@ internal class AnalyticsTrackerExtTest {
     @get:Rule
     val dispatcherRule = MainDispatcherRule()
 
-    private val coroutineScope = AppcuesCoroutineScope(Logcues(NONE))
+    private val coroutineScope = AppcuesCoroutineScope(Logcues())
     private val activityBuilder: ActivityRequestBuilder = mockk()
     private val sessionMonitor: SessionMonitor = mockk(relaxed = true)
     private val analyticsQueueProcessor: AnalyticsQueueProcessor = mockk(relaxed = true)

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
@@ -2,7 +2,6 @@ package com.appcues.analytics
 
 import com.appcues.AnalyticType
 import com.appcues.AppcuesCoroutineScope
-import com.appcues.LoggingLevel.NONE
 import com.appcues.SessionMonitor
 import com.appcues.data.remote.appcues.request.ActivityRequest
 import com.appcues.logging.Logcues
@@ -23,7 +22,7 @@ internal class AnalyticsTrackerTest {
     @get:Rule
     val dispatcherRule = MainDispatcherRule()
 
-    private val coroutineScope = AppcuesCoroutineScope(Logcues(NONE))
+    private val coroutineScope = AppcuesCoroutineScope(Logcues())
     private val activityBuilder: ActivityRequestBuilder = mockk()
     private val sessionMonitor: SessionMonitor = mockk(relaxed = true)
     private val analyticsQueueProcessor: AnalyticsQueueProcessor = mockk(relaxed = true)

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -9,13 +9,13 @@ import com.appcues.data.model.Experience
 import com.appcues.data.model.ExperiencePriority.LOW
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.data.model.ExperienceTrigger
+import com.appcues.data.remote.DataLogcues
 import com.appcues.data.remote.RemoteError.HttpError
 import com.appcues.data.remote.RemoteError.NetworkError
 import com.appcues.data.remote.appcues.AppcuesRemoteSource
 import com.appcues.data.remote.appcues.request.ActivityRequest
 import com.appcues.data.remote.appcues.response.QualifyResponse
 import com.appcues.data.remote.appcues.response.experience.ExperienceResponse
-import com.appcues.logging.Logcues
 import com.appcues.rules.MainDispatcherRule
 import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
@@ -41,7 +41,7 @@ internal class AppcuesRepositoryTest {
     private val appcuesRemoteSource: AppcuesRemoteSource = mockk(relaxed = true)
     private val appcuesLocalSource: AppcuesLocalSource = mockk(relaxed = true)
     private val experienceMapper: ExperienceMapper = mockk()
-    private val logcues: Logcues = mockk(relaxed = true)
+    private val dataLogcues: DataLogcues = mockk(relaxed = true)
     private val storage: Storage = mockk(relaxed = true)
 
     private lateinit var config: AppcuesConfig
@@ -55,7 +55,7 @@ internal class AppcuesRepositoryTest {
             appcuesLocalSource = appcuesLocalSource,
             experienceMapper = experienceMapper,
             config = config,
-            logcues = logcues,
+            dataLogcues = dataLogcues,
             storage = storage,
         )
     }

--- a/appcues/src/test/java/com/appcues/data/remote/DataLogcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/DataLogcuesTest.kt
@@ -1,0 +1,378 @@
+package com.appcues.data.remote
+
+import com.appcues.logging.Logcues
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifySequence
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Test
+
+internal class DataLogcuesTest {
+
+    private val logcues = mockk<Logcues>(relaxed = true)
+
+    private val dataLogcues = DataLogcues(logcues)
+
+    @Test
+    fun `error SHOULD log error properly`() {
+        // WHEN
+        dataLogcues.error("description", "test exception message")
+        // THEN
+        verifySequence {
+            logcues.error("description.\nReason: test exception message")
+        }
+    }
+
+    @Test
+    fun `error SHOULD log error pretty`() {
+        // GIVEN
+        val reason =
+            """
+            HttpError(code=401,    error=ErrorResponse(error="error (1), {2}, [3]", statusCode=401, message=ErrorMessageResponse()))
+            """.trimIndent()
+
+        // WHEN
+        dataLogcues.error("description", reason)
+        // THEN
+        verifySequence {
+            logcues.error(
+                """
+                description.
+                Reason: HttpError(
+                  code=401,
+                  error=ErrorResponse(
+                    error="error (1), {2}, [3]",
+                    statusCode=401,
+                    message=ErrorMessageResponse()
+                  )
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `debug request SHOULD log WHEN null body`() {
+        // GIVEN
+        val request = mockk<Request> {
+            every { method } returns "GET"
+            every { url } returns "http://www.appcues.com/".toHttpUrl()
+            every { headers } returns Headers.headersOf()
+            every { body } returns null
+        }
+        // WHEN
+        dataLogcues.debug(request)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                REQUEST: GET
+                URL: http://www.appcues.com/
+                
+                (no request body)
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug request SHOULD log WHEN body isDuplex`() {
+        // GIVEN
+        val request = mockk<Request> {
+            every { method } returns "HEAD"
+            every { url } returns "http://www.appcues.com/".toHttpUrl()
+            every { headers } returns Headers.headersOf()
+            every { body } returns mockk {
+                every { isDuplex() } returns true
+            }
+        }
+        // WHEN
+        dataLogcues.debug(request)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                REQUEST: HEAD
+                URL: http://www.appcues.com/
+                
+                (duplex request body omitted)
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug request SHOULD log WHEN body isOneShot`() {
+        // GIVEN
+        val request = mockk<Request> {
+            every { method } returns "HEAD"
+            every { url } returns "http://www.appcues.com/".toHttpUrl()
+            every { headers } returns Headers.headersOf()
+            every { body } returns mockk {
+                every { isDuplex() } returns false
+                every { isOneShot() } returns true
+            }
+        }
+        // WHEN
+        dataLogcues.debug(request)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                REQUEST: HEAD
+                URL: http://www.appcues.com/
+                
+                (one-shot body omitted)
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug request SHOULD log WHEN body is content type image`() {
+        // GIVEN
+        val request = mockk<Request> {
+            every { method } returns "HEAD"
+            every { url } returns "http://www.appcues.com/".toHttpUrl()
+            every { headers } returns Headers.headersOf()
+            every { body } returns mockk {
+                every { isDuplex() } returns false
+                every { isOneShot() } returns false
+                every { contentType() } returns "image/png".toMediaType()
+            }
+        }
+        // WHEN
+        dataLogcues.debug(request)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                REQUEST: HEAD
+                URL: http://www.appcues.com/
+                
+                (encoded image)
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug request SHOULD log WHEN body is valid`() {
+        // GIVEN
+        val requestBody = """{"result":true,"empty_array":[],"array":[{"value":1},{"value":2}]}"""
+            .toRequestBody("application/json".toMediaType())
+        val request = mockk<Request> {
+            every { method } returns "GET"
+            every { url } returns "http://www.appcues.com/".toHttpUrl()
+            every { headers } returns Headers.headersOf()
+            every { body } returns requestBody
+        }
+        // WHEN
+        dataLogcues.debug(request)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                REQUEST: GET
+                URL: http://www.appcues.com/
+                
+                Body(${requestBody.contentLength()} bytes): {
+                  "result":true,
+                  "empty_array":[],
+                  "array":[
+                    {
+                      "value":1
+                    },
+                    {
+                      "value":2
+                    }
+                  ]
+                }
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug request SHOULD log WHEN headers and body are valid`() {
+        // GIVEN
+        val requestBody = """{"result":200}"""
+            .toRequestBody("application/json".toMediaType())
+        val request = mockk<Request> {
+            every { method } returns "GET"
+            every { url } returns "http://www.appcues.com/".toHttpUrl()
+            every { headers } returns Headers.headersOf("Content-Test", "test value")
+            every { body } returns requestBody
+        }
+        // WHEN
+        dataLogcues.debug(request)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                REQUEST: GET
+                URL: http://www.appcues.com/
+                
+                Headers: {
+                  [Content-Test] = test value
+                }
+                Body(${requestBody.contentLength()} bytes): {
+                  "result":200
+                }
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug request SHOULD log WHEN body not pretty AND content type null`() {
+        // GIVEN
+        val requestBody = """{"result":true[}}}""".toRequestBody(null)
+        val request = mockk<Request> {
+            every { method } returns "GET"
+            every { url } returns "http://www.appcues.com/".toHttpUrl()
+            every { headers } returns Headers.headersOf()
+            every { body } returns requestBody
+        }
+        // WHEN
+        dataLogcues.debug(request)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                REQUEST: GET
+                URL: http://www.appcues.com/
+                
+                Body(${requestBody.contentLength()} bytes): {"result":true[}}}
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug response SHOULD log WHEN null body`() {
+        // GIVEN
+        val response = mockk<Response> {
+            every { receivedResponseAtMillis } returns 100L
+            every { sentRequestAtMillis } returns 0L
+            every { code } returns 200
+            every { request.url } returns "http://www.appcues.com/".toHttpUrl()
+            every { headers } returns Headers.headersOf()
+            every { body } returns null
+        }
+        // WHEN
+        dataLogcues.debug(response)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                RESPONSE: 200 (100ms)
+                URL: http://www.appcues.com/
+                
+                (no response body)
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug response SHOULD log WHEN promisesBody is false`() {
+        // GIVEN
+        val response = mockk<Response> {
+            every { receivedResponseAtMillis } returns 100L
+            every { sentRequestAtMillis } returns 0L
+            every { code } returns 200
+            every { request.url } returns "http://www.appcues.com/".toHttpUrl()
+            every { request.method } returns "HEAD"
+            every { headers } returns Headers.headersOf()
+            every { body } returns mockk(relaxed = true)
+        }
+        // WHEN
+        dataLogcues.debug(response)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                RESPONSE: 200 (100ms)
+                URL: http://www.appcues.com/
+                
+                (no response body)
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug response SHOULD log WHEN headers and body are valid`() {
+        // GIVEN
+        val responseBody = """{"result":200}"""
+            .toResponseBody("application/json".toMediaType())
+
+        // GIVEN
+        val response = mockk<Response> {
+            every { receivedResponseAtMillis } returns 100L
+            every { sentRequestAtMillis } returns 0L
+            every { code } returns 200
+            every { request.url } returns "http://www.appcues.com/".toHttpUrl()
+            every { request.method } returns "GET"
+            every { headers } returns Headers.headersOf("Content-Test", "test value")
+            every { body } returns responseBody
+        }
+        // WHEN
+        dataLogcues.debug(response)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                RESPONSE: 200 (100ms)
+                URL: http://www.appcues.com/
+                
+                Headers: {
+                  [Content-Test] = test value
+                }
+                Body(${responseBody.contentLength()} bytes): {
+                  "result":200
+                }
+                """.trimln()
+            )
+        }
+    }
+
+    @Test
+    fun `debug response SHOULD log WHEN body is not pretty AND content type null`() {
+        // GIVEN
+        val responseBody = """{"result":]]200}""".toResponseBody(null)
+
+        // GIVEN
+        val response = mockk<Response> {
+            every { receivedResponseAtMillis } returns 100L
+            every { sentRequestAtMillis } returns 0L
+            every { code } returns 200
+            every { request.url } returns "http://www.appcues.com/".toHttpUrl()
+            every { request.method } returns "GET"
+            every { headers } returns Headers.headersOf()
+            every { body } returns responseBody
+        }
+        // WHEN
+        dataLogcues.debug(response)
+        // THEN
+        verifySequence {
+            logcues.debug(
+                """
+                RESPONSE: 200 (100ms)
+                URL: http://www.appcues.com/
+                
+                Body(${responseBody.contentLength()} bytes): {"result":]]200}
+                """.trimln()
+            )
+        }
+    }
+
+    private fun String.trimln(): String = trimIndent() + "\n"
+}

--- a/appcues/src/test/java/com/appcues/data/remote/HttpExtTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/HttpExtTest.kt
@@ -1,0 +1,45 @@
+package com.appcues.data.remote
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.MediaType
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+internal class HttpExtTest {
+
+    @Test
+    fun `charsetOrUTF8 SHOULD return charset UTF-8 WHEN MediaType is null log error properly`() {
+        // GIVEN
+        val contentType: MediaType? = null
+        // WHEN
+        val charset = contentType.charsetOrUTF8()
+        // THEN
+        assertThat(charset).isEqualTo(StandardCharsets.UTF_8)
+    }
+
+    @Test
+    fun `charsetOrUTF8 SHOULD return charset UTF-8 WHEN MediaType charset is null`() {
+        // GIVEN
+        val contentType: MediaType = mockk {
+            every { charset(any()) } returns null
+        }
+        // WHEN
+        val charset = contentType.charsetOrUTF8()
+        // THEN
+        assertThat(charset).isEqualTo(StandardCharsets.UTF_8)
+    }
+
+    @Test
+    fun `charsetOrUTF8 SHOULD return charset UTF-8 WHEN MediaType has charset`() {
+        // GIVEN
+        val contentType: MediaType = mockk {
+            every { charset(any()) } returns StandardCharsets.UTF_16BE
+        }
+        // WHEN
+        val charset = contentType.charsetOrUTF8()
+        // THEN
+        assertThat(charset).isEqualTo(StandardCharsets.UTF_16BE)
+    }
+}

--- a/appcues/src/test/java/com/appcues/data/remote/interceptor/DataLogcuesInterceptorTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/interceptor/DataLogcuesInterceptorTest.kt
@@ -1,0 +1,56 @@
+package com.appcues.data.remote.interceptor
+
+import com.appcues.data.remote.DataLogcues
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifySequence
+import okhttp3.Interceptor.Chain
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Test
+
+internal class DataLogcuesInterceptorTest {
+
+    private val dataLogcues = mockk<DataLogcues>(relaxed = true)
+    private val chain = mockk<Chain>(relaxed = true)
+
+    private val interceptor = HttpLogcuesInterceptor(dataLogcues)
+
+    @Test
+    fun `intercept SHOULD call dependencies in sequence`() {
+        // GIVEN
+        val request = mockk<Request>(relaxed = true)
+        val response = mockk<Response>(relaxed = true)
+        every { chain.request() } returns request
+        every { chain.proceed(request) } returns response
+        // WHEN
+        val result = interceptor.intercept(chain)
+        // THEN
+        verifySequence {
+            chain.request()
+            dataLogcues.debug(request)
+            chain.proceed(request)
+            dataLogcues.debug(response)
+        }
+
+        assertThat(result).isEqualTo(response)
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `intercept SHOULD call dependencies in sequence when proceed throws AND throw same exception`() {
+        // GIVEN
+        val request = mockk<Request>(relaxed = true)
+        every { chain.request() } returns request
+        every { chain.proceed(request) } throws RuntimeException("test")
+        // WHEN
+        interceptor.intercept(chain)
+        // THEN
+        verifySequence {
+            chain.request()
+            dataLogcues.debug(request)
+            chain.proceed(request)
+            dataLogcues.error("Failed to send request", "test")
+        }
+    }
+}

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/AppcuesServiceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/AppcuesServiceTest.kt
@@ -8,7 +8,6 @@ import com.appcues.data.remote.retrofit.stubs.contentModalOneStubs
 import com.appcues.util.appcuesFormatted
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonDataException
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.mockwebserver.MockWebServer
@@ -17,13 +16,11 @@ import org.junit.Assert
 import org.junit.Test
 import java.util.UUID
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class AppcuesServiceTest {
 
     private val mockWebServer = MockWebServer()
 
-    private val api = RetrofitWrapper(mockWebServer.url("/"), false)
-        .create(AppcuesService::class)
+    private val api = RetrofitWrapper(mockWebServer.url("/")).create(AppcuesService::class)
 
     @After
     fun tearDown() {

--- a/appcues/src/test/java/com/appcues/logging/LogcatDestinationTest.kt
+++ b/appcues/src/test/java/com/appcues/logging/LogcatDestinationTest.kt
@@ -1,0 +1,84 @@
+package com.appcues.logging
+
+import android.util.Log
+import com.appcues.LoggingLevel.DEBUG
+import com.appcues.LoggingLevel.INFO
+import com.appcues.LoggingLevel.NONE
+import io.mockk.called
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import io.mockk.verifySequence
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+
+internal class LogcatDestinationTest {
+
+    private val logcues = mockk<Logcues>()
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.i(any(), any()) } returns 1
+        every { Log.d(any(), any()) } returns 1
+        every { Log.e(any(), any()) } returns 1
+    }
+
+    @Test
+    fun `info SHOULD log messages WHEN level is INFO`() = runTest {
+        // GIVEN
+        val sharedFlow = MutableSharedFlow<LogMessage>()
+        coEvery { logcues.messageFlow } returns sharedFlow
+        LogcatDestination(logcues, INFO, Dispatchers.Unconfined).apply { init() }
+
+        // WHEN
+        sharedFlow.emit(LogMessage("message1", LogType.INFO, Date()))
+        sharedFlow.emit(LogMessage("message2", LogType.ERROR, Date()))
+        sharedFlow.emit(LogMessage("message3", LogType.DEBUG, Date()))
+        // THEN
+        verifySequence {
+            Log.i("Appcues", "message1")
+            Log.e("Appcues", "message2")
+        }
+    }
+
+    @Test
+    fun `info SHOULD log nothing WHEN level is NONE`() = runTest {
+        // GIVEN
+        val sharedFlow = MutableSharedFlow<LogMessage>()
+        coEvery { logcues.messageFlow } returns sharedFlow
+        LogcatDestination(logcues, NONE, Dispatchers.Unconfined).apply { init() }
+
+        // WHEN
+        sharedFlow.emit(LogMessage("message1", LogType.INFO, Date()))
+        sharedFlow.emit(LogMessage("message2", LogType.ERROR, Date()))
+        sharedFlow.emit(LogMessage("message3", LogType.DEBUG, Date()))
+        // THEN
+        verify { Log::class.java wasNot called }
+    }
+
+    @Test
+    fun `info SHOULD log messages WHEN level is DEBUG`() = runTest {
+        // GIVEN
+        val sharedFlow = MutableSharedFlow<LogMessage>()
+        coEvery { logcues.messageFlow } returns sharedFlow
+        LogcatDestination(logcues, DEBUG, Dispatchers.Unconfined).apply { init() }
+
+        // WHEN
+        sharedFlow.emit(LogMessage("message1", LogType.INFO, Date()))
+        sharedFlow.emit(LogMessage("message2", LogType.ERROR, Date()))
+        sharedFlow.emit(LogMessage("message3", LogType.DEBUG, Date()))
+        // THEN
+        verifySequence {
+            Log.i("Appcues", "message1")
+            Log.e("Appcues", "message2")
+            Log.d("Appcues", "message3")
+        }
+    }
+}

--- a/appcues/src/test/java/com/appcues/logging/LogcatDestinationTest.kt
+++ b/appcues/src/test/java/com/appcues/logging/LogcatDestinationTest.kt
@@ -6,6 +6,7 @@ import com.appcues.LoggingLevel.INFO
 import com.appcues.LoggingLevel.NONE
 import io.mockk.called
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -13,6 +14,7 @@ import io.mockk.verify
 import io.mockk.verifySequence
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -31,7 +33,7 @@ internal class LogcatDestinationTest {
     }
 
     @Test
-    fun `info SHOULD log messages WHEN level is INFO`() = runTest {
+    fun `emit messages SHOULD log messages WHEN level is INFO`() = runTest {
         // GIVEN
         val sharedFlow = MutableSharedFlow<LogMessage>()
         coEvery { logcues.messageFlow } returns sharedFlow
@@ -49,7 +51,7 @@ internal class LogcatDestinationTest {
     }
 
     @Test
-    fun `info SHOULD log nothing WHEN level is NONE`() = runTest {
+    fun `emit messages SHOULD log nothing WHEN level is NONE`() = runTest {
         // GIVEN
         val sharedFlow = MutableSharedFlow<LogMessage>()
         coEvery { logcues.messageFlow } returns sharedFlow
@@ -64,7 +66,18 @@ internal class LogcatDestinationTest {
     }
 
     @Test
-    fun `info SHOULD log messages WHEN level is DEBUG`() = runTest {
+    fun `collect SHOULD not be called WHEN level is NONE`() = runTest {
+        // GIVEN
+        val sharedFlow = mockk<SharedFlow<LogMessage>>(relaxed = true)
+        coEvery { logcues.messageFlow } returns sharedFlow
+        // WHEN
+        LogcatDestination(logcues, NONE, Dispatchers.Unconfined).apply { init() }
+        // THEN
+        coVerify { sharedFlow wasNot called }
+    }
+
+    @Test
+    fun `emit messages SHOULD log messages WHEN level is DEBUG`() = runTest {
         // GIVEN
         val sharedFlow = MutableSharedFlow<LogMessage>()
         coEvery { logcues.messageFlow } returns sharedFlow

--- a/appcues/src/test/java/com/appcues/rules/TestScopeRule.kt
+++ b/appcues/src/test/java/com/appcues/rules/TestScopeRule.kt
@@ -15,6 +15,7 @@ import com.appcues.di.AppcuesModule
 import com.appcues.di.Bootstrap
 import com.appcues.di.scope.AppcuesScope
 import com.appcues.di.scope.AppcuesScopeDSL
+import com.appcues.logging.LogcatDestination
 import com.appcues.logging.Logcues
 import com.appcues.mocks.storageMockk
 import com.appcues.statemachine.StateMachine
@@ -34,6 +35,7 @@ internal class TestScopeRule : TestWatcher() {
             modules = arrayListOf(
                 object : AppcuesModule {
                     override fun AppcuesScopeDSL.install() {
+                        scoped { mockk<LogcatDestination>(relaxed = true) }
                         scoped { AppcuesConfig("00000", "123") }
                         scoped { AppcuesCoroutineScope(get()) }
                         scoped { mockk<AnalyticsTracker>(relaxed = true) }

--- a/appcues/src/test/java/com/appcues/ui/presentation/AppcuesViewModelTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/presentation/AppcuesViewModelTest.kt
@@ -3,7 +3,6 @@ package com.appcues.ui.presentation
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.viewModelScope
 import com.appcues.AppcuesCoroutineScope
-import com.appcues.LoggingLevel.NONE
 import com.appcues.action.ActionProcessor
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
@@ -55,7 +54,7 @@ internal class AppcuesViewModelTest {
 
     private val renderContext: RenderContext = RenderContext.Modal
 
-    private val coroutineScope: AppcuesCoroutineScope = AppcuesCoroutineScope(Logcues(NONE))
+    private val coroutineScope: AppcuesCoroutineScope = AppcuesCoroutineScope(Logcues())
 
     private val experienceStates = MutableSharedFlow<State>(1)
     private val experienceRenderer: ExperienceRenderer = mockk {


### PR DESCRIPTION
Initially trying to mirror the iOS new behavior for log messages, but this change also contains a lot of quality of life changes on our debugger, including:

1. More general approach to [navigation](https://github.com/appcues/appcues-android-sdk/pull/524/files#diff-8adf22268222a92641b9bfc1856af1551a5dd997eb371479ea38ea53b5e64981R97), which made so navigation is now made easy (we know view routes, parents and children so we have more general way for handling [transition](https://github.com/appcues/appcues-android-sdk/pull/524/files#diff-8adf22268222a92641b9bfc1856af1551a5dd997eb371479ea38ea53b5e64981R181)
2. updated FabX [offset and FabY offset to mutableFloatState](https://github.com/appcues/appcues-android-sdk/pull/524/files#diff-b484960491ecc6b642141bc733e2ea3940031d3c7ee42d71baed61469c77fb7dR44), this impacted some other places where I had to change from .value to .floatValue (this was a warning from probably new version of compose)
3. Similarly added label to various animated values solving some warnings
4. Reorganized some compositions and changed some method parameters to make it more [similar to each other](![image](https://github.com/appcues/appcues-android-sdk/assets/5244805/410eff99-5b6f-4cfe-920a-66d919b288e0)).
5. made Floating back button reusable across pages.
6. Fixed: bug related to deeplink where it wasnt properly being consumed and cleared, also made so deeplinks are not tied to just the debugger, not usefull for today but its better if for some reason we want to deeplink in the future to screen capture or another mode
7. Fixed: Bug where closing and opening the debugger made so the last event would be doubled on the event list

To make the debugger properly show logs we needed some changes to our current log approach, so instead of Logcues pushing logs to android.Log, we now emit it as an item to logMessages, that can be subscribed by anyone, this includes the new LogcatLogging that is initialized once on Appcues [init](https://github.com/appcues/appcues-android-sdk/pull/524/files#diff-c7d0ea17e5eb17acc00c0f1a629ae660eb7c73612ef28ddee6e0aa189a89c3c3R114) and the newly added [DebuggerLogMessageManager](https://github.com/appcues/appcues-android-sdk/pull/524/files#diff-266bdc6591169726a74e9c207b2f9ae650650dba7479f9cf4b426efb496da0feR13) that pushes this a logMessage list to our Detailed Log page.

Also another required change to how we intercept retrofit request, the original HttpLoggingInterceptor pushes log in a different format (one line, one entry) and what we needed was [an entire log entry containing the whole request/response.](https://github.com/appcues/appcues-android-sdk/pull/524/files#diff-ec2165164a86fa36a6f7f68c7225ddacf80c0b2f5421dde2dddf51c745b885c8R8)

+ printPretty to make it look awesome. in both Logcat and for the debugger.
+ improved some general error logging coming from remote requests.
+ broke up interceptors into separate files for better vistualization.

here is what the updated version of the debugger looks like.

|Menu item|List|Detail|
|-|-|-|
|![panel](https://github.com/appcues/appcues-android-sdk/assets/5244805/1e3d4630-41b3-46e5-969d-e665d41ad531)|![list](https://github.com/appcues/appcues-android-sdk/assets/5244805/1429f82a-f3c0-4d60-8c7b-cfce8673dbed)|![detail](https://github.com/appcues/appcues-android-sdk/assets/5244805/10ef4c14-8a22-4226-9474-01a2472b1d2c)|

updated [specs tests](https://github.com/appcues/appcues-mobile-experience-spec/pull/241)