### PR TITLE
Fix element target visibility check

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
@@ -104,17 +104,20 @@ private fun View.asCaptureView(screenBounds: Rect): ViewElement? {
     val displayMetrics = context.resources.displayMetrics
     val density = displayMetrics.density
 
-    // this is the position of the view relative to the entire screen
-    val actualPosition = Rect()
-    getGlobalVisibleRect(actualPosition)
+    // the coordinates of the non-clipped area of this view in the coordinate space of the view's root view
+    val globalVisibleRect = Rect()
 
-    // if the view is not currently in the screenshot image (scrolled away), ignore
-    if (Rect.intersects(actualPosition, screenBounds).not()) {
-        return null
-    }
-
-    // ignore the Appcues SDK content that has been injected into the view hierarchy
-    if (this.isAppcuesView()) {
+    if (
+        // ignore the Appcues SDK content that has been injected into the view hierarchy
+        this.isAppcuesView() ||
+        // if getGlobalVisibleRect returns false, that indicates that none of the view is
+        // visible within the root view, and we will not include it in our capture
+        getGlobalVisibleRect(globalVisibleRect).not() ||
+        // if the view is not currently in the screenshot image (scrolled away), ignore
+        // (this is possibly a redundant check to item above, but keeping for now)
+        Rect.intersects(globalVisibleRect, screenBounds).not()
+    ) {
+        // if any of these conditions failed, this view is not captured
         return null
     }
 
@@ -160,10 +163,10 @@ private fun View.asCaptureView(screenBounds: Rect): ViewElement? {
 
     return selector().let {
         ViewElement(
-            x = actualPosition.left.toDp(density),
-            y = actualPosition.top.toDp(density),
-            width = actualPosition.width().toDp(density),
-            height = actualPosition.height().toDp(density),
+            x = globalVisibleRect.left.toDp(density),
+            y = globalVisibleRect.top.toDp(density),
+            width = globalVisibleRect.width().toDp(density),
+            height = globalVisibleRect.height().toDp(density),
             displayName = it?.displayName,
             selector = it,
             type = it?.type ?: this::class.java.simpleName,


### PR DESCRIPTION
This is a defect discovered while doing other tooltip testing. We were previously not checking the return value of [getGlobalVisibleRect](https://developer.android.com/reference/android/view/View#getGlobalVisibleRect(android.graphics.Rect)). However, a false value returned means none of the view is visible, and "If the method returns false, the contents of r are undefined." This means we were previously allowing some undefined rect values to flow through as target element rects, incorrectly.

This could lead to undesired behavior like this:

| incorrect target | target button is actually behind bottom nav |
| --- | --- |
|  ![Screenshot 2023-10-30 at 4 40 51 PM](https://github.com/appcues/appcues-android-sdk/assets/19266448/558c3f54-de44-4fb8-ba68-318488f26c2e) | ![Screenshot 2023-10-30 at 4 41 51 PM](https://github.com/appcues/appcues-android-sdk/assets/19266448/7fa673ef-ce72-409f-91ed-1bc1498949cd) |

This change updates to actually check the return value and ignore the view if no valid Rect is found. There is another check to confirm that the screen bounds contains the rect, which was already in place - this may be redundant really, based on the documentation for getGlobalVisibleRect, but I was not sure and did not want to cause any regressions from previous behavior, so leaving that as-is for now.