### PR TITLE
🐛 Fixed bug where in split-screen android build may have different decorViews not used for content rendering

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt
@@ -25,8 +25,16 @@ internal fun Activity.getParentView(): ViewGroup {
     // to find the top most decorView like below.
 
     val decorView = if (VERSION.SDK_INT >= VERSION_CODES.Q) {
-        // this is the preferred method on API 29+ with the new WindowInspector function
-        WindowInspector.getGlobalWindowViews().last()
+        try {
+            // this is the preferred method on API 29+ with the new WindowInspector function
+            // in case of multiple views, get the one that is hosting android.R.id.content
+            // we get the last one because sometimes stacking activities might be listed in this method,
+            // and we always want the one that is on top
+            WindowInspector.getGlobalWindowViews().last { it.findViewById<View?>(android.R.id.content) != null }
+        } catch (_: NoSuchElementException) {
+            // should never fail but just in case try to use standard decorView
+            window.decorView
+        }
     } else {
         @Suppress("SwallowedException", "TooGenericExceptionCaught")
         try {


### PR DESCRIPTION
This came from a customer that reported small percentage of crashes coming from appcues. 
```
java.lang.IllegalStateException: Horizontally scrollable component was measured with 
an infinity maximum width constraints, which is disallowed. One of the common reasons 
is nesting layouts like LazyRow and Row(Modifier.horizontalScroll()). If you want to add a 
header before the list of items please add a header as a separate item() before the main items() 
inside the LazyRow scope. There are could be other reasons for this to happen: your 
ComposeView was added into a LinearLayout with some weight, you applied 
Modifier.wrapContentSize(unbounded = true) or wrote a custom layout.
 Please try to remove the source of infinite constraints in the hierarchy above the scrolling container.
.
.
at com.samsung.android.multiwindow.OverlayHandlerView.onMeasure(OverlayHandlerView.java:174)
```

I was able to reproduce this by using an Samsung device and opening an appcues app in split-mode (multiwindow), it turns out that samsung builds (and maybe others) create a new DecorView to manage multi-window behavior, so to account for that instead of getting the last() we now get last that contains viewId "android.R.id.content", and this seems to  fix the problem

I tested on various API levels including my personal samsung device in which I was able to reproduce said bug.
