### PR TITLE
Ensure manually shown embeds are cached properly

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -195,6 +195,11 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
         if (sessionMonitor.sessionId == null) return false
 
         repository.getExperienceContent(experienceId, trigger)?.let {
+            if (it.renderContext != Modal) {
+                // No caching required for modals since they can't be lazy-loaded.
+                potentiallyRenderableExperiences[it.renderContext] = listOf(it)
+            }
+
             return when (show(it)) {
                 RenderingResult.Success -> true
                 else -> false


### PR DESCRIPTION
Reviewing the iOS cleanup in https://github.com/appcues/appcues-ios-sdk/commit/92e0d64c807bc3a30e21c2c238de5b4618ff25f1 revealed that the Android side was missing cache handling for embeds the in the case of a `show(experienceId)` call (manually show, deep link, or launch from another flow)