### PR TITLE
Add state machine capabilities for FailingState and Retry action

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTrackerExt.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTrackerExt.kt
@@ -30,11 +30,13 @@ internal fun AnalyticsTracker.trackRecoverableExperienceError(experience: Experi
     if (experience.renderErrorId != null) return
 
     experience.renderErrorId = UUID.randomUUID()
-    val error = ExperienceError(Error.ExperienceError(experience, message, experience.renderErrorId))
+    val error = Error.ExperienceError(experience, message)
+    error.errorId = experience.renderErrorId
+    val experienceError = ExperienceError(error)
 
     track(
-        name = error.name,
-        properties = error.properties,
+        name = experienceError.name,
+        properties = experienceError.properties,
         interactive = false,
         isInternal = true,
     )

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
@@ -171,7 +171,7 @@ private fun View.asCaptureView(screenBounds: Rect): ViewElement? {
             displayName = it?.displayName,
             selector = it,
             type = it?.type ?: this::class.java.simpleName,
-            children = if (children.isEmpty()) null else children,
+            children = children.ifEmpty { null },
         )
     }
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Action.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Action.kt
@@ -15,5 +15,6 @@ internal sealed class Action {
     ) : Action()
 
     object Reset : Action()
-    data class ReportError(val error: Error, val fatal: Boolean) : Action()
+    data class ReportError(val error: Error, var retryEffect: SideEffect) : Action()
+    object Retry : Action()
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -16,5 +16,10 @@ internal sealed class Error(open val message: String) {
     object ExperienceAlreadyActive : Error("Experience already active")
 
     data class ExperienceError(val experience: Experience, override val message: String) : Error(message)
-    data class StepError(val experience: Experience, val stepIndex: Int, override val message: String) : Error(message)
+    data class StepError(
+        val experience: Experience,
+        val stepIndex: Int,
+        override val message: String,
+        var recoverable: Boolean = false,
+    ) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -3,17 +3,18 @@ package com.appcues.statemachine
 import com.appcues.data.model.Experience
 import java.util.UUID
 
-internal sealed class Error(open val message: String, errorId: UUID? = null) {
+internal sealed class Error(open val message: String) {
+    private val _id = UUID.randomUUID()
 
-    val id: UUID = errorId ?: UUID.randomUUID()
+    // allows for override of error ID with a value driven by the experience.renderErrorId
+    // for matching error/recovery IDs on render retry
+    var errorId: UUID? = null
+
+    val id: UUID
+        get() = errorId ?: _id
 
     object ExperienceAlreadyActive : Error("Experience already active")
 
-    data class ExperienceError(
-        val experience: Experience,
-        override val message: String,
-        val errorId: UUID? = null
-    ) : Error(message, errorId)
-
+    data class ExperienceError(val experience: Experience, override val message: String) : Error(message)
     data class StepError(val experience: Experience, val stepIndex: Int, override val message: String) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -20,6 +20,6 @@ internal sealed class Error(open val message: String) {
         val experience: Experience,
         val stepIndex: Int,
         override val message: String,
-        var recoverable: Boolean = false,
+        val recoverable: Boolean = false,
     ) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -1,7 +1,6 @@
 package com.appcues.statemachine
 
 import com.appcues.data.model.Experience
-import com.appcues.statemachine.states.IdlingState
 
 internal interface State {
 
@@ -13,7 +12,7 @@ internal interface State {
 
     fun State.next(state: State, sideEffect: SideEffect? = null) = Transition(state, null, sideEffect)
 
-    fun State.keep(error: Error? = null) = Transition(this, error, null)
+    fun State.next(state: State, error: Error) = Transition(state, error, null)
 
-    fun State.exit(error: Error) = Transition(IdlingState, error, null)
+    fun State.keep(error: Error? = null) = Transition(this, error, null)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/State.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/State.kt
@@ -1,6 +1,7 @@
 package com.appcues.statemachine
 
 import com.appcues.data.model.Experience
+import com.appcues.statemachine.states.IdlingState
 
 internal interface State {
 
@@ -15,4 +16,6 @@ internal interface State {
     fun State.next(state: State, error: Error) = Transition(state, error, null)
 
     fun State.keep(error: Error? = null) = Transition(this, error, null)
+
+    fun State.exit(error: Error) = Transition(IdlingState, error, null)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -7,6 +7,7 @@ import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.Action.ReportError
 import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.Error.ExperienceAlreadyActive
+import com.appcues.statemachine.states.FailingState
 import com.appcues.statemachine.states.IdlingState
 import com.appcues.util.ResultOf
 import com.appcues.util.ResultOf.Failure
@@ -100,8 +101,8 @@ internal class StateMachine(
         return take(action) ?: when (action) {
             // start experience action when experience is already active
             is StartExperience -> keep(ExperienceAlreadyActive)
-            // report error action
-            is ReportError -> if (action.fatal) exit(action.error) else keep(action.error)
+            // handle presentation failure
+            is ReportError -> next(FailingState(this, action.retryEffect), action.error)
             // undefined transition - no-op
             else -> keep()
         }

--- a/appcues/src/main/java/com/appcues/statemachine/Transition.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Transition.kt
@@ -1,6 +1,6 @@
 package com.appcues.statemachine
 
-internal class Transition(
+internal data class Transition(
     val newState: State,
     val error: Error?,
     val sideEffect: SideEffect?

--- a/appcues/src/main/java/com/appcues/statemachine/effects/PresentationEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/effects/PresentationEffect.kt
@@ -6,7 +6,7 @@ import com.appcues.data.model.ExperienceTrigger.Qualification
 import com.appcues.statemachine.Action
 import com.appcues.statemachine.Action.RenderStep
 import com.appcues.statemachine.Action.ReportError
-import com.appcues.statemachine.Error.ExperienceError
+import com.appcues.statemachine.Error.StepError
 import com.appcues.statemachine.SideEffect
 import com.appcues.trait.AppcuesTraitException
 import kotlinx.coroutines.delay
@@ -50,7 +50,10 @@ internal data class PresentationEffect(
         } catch (exception: AppcuesTraitException) {
             presentingTrait.remove()
             
-            return ReportError(ExperienceError(experience, exception.message), true)
+            return ReportError(
+                error = StepError(experience, flatStepIndex, exception.message),
+                retryEffect = this.copy(shouldPresent = true)
+            )
         }
     }
 

--- a/appcues/src/main/java/com/appcues/statemachine/states/FailingState.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/states/FailingState.kt
@@ -25,10 +25,10 @@ internal data class FailingState(
         return when (action) {
             is Retry -> next(targetState, retryEffect)
             // a new start means recovery never happened, move to Idling and continue with the new start attempt
-            is StartExperience -> Transition(IdlingState, null, ContinuationEffect(action))
+            is StartExperience -> next(IdlingState, ContinuationEffect(action))
             // an explicit request to EndExperience just moves directly to IdlingState
             // can happen in ExperienceRender if a new higher priority experience is starting
-            is EndExperience -> Transition(IdlingState, null, null)
+            is EndExperience -> next(IdlingState)
             else -> null
         }
     }

--- a/appcues/src/main/java/com/appcues/statemachine/states/FailingState.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/states/FailingState.kt
@@ -1,0 +1,35 @@
+package com.appcues.statemachine.states
+
+import com.appcues.data.model.Experience
+import com.appcues.statemachine.Action
+import com.appcues.statemachine.Action.EndExperience
+import com.appcues.statemachine.Action.Retry
+import com.appcues.statemachine.Action.StartExperience
+import com.appcues.statemachine.SideEffect
+import com.appcues.statemachine.State
+import com.appcues.statemachine.Transition
+import com.appcues.statemachine.effects.ContinuationEffect
+
+internal data class FailingState(
+    // this is the desired state to return to, if the failure can be recovered
+    val targetState: State,
+    val retryEffect: SideEffect,
+) : State {
+
+    override val currentExperience: Experience?
+        get() = targetState.currentExperience
+    override val currentStepIndex: Int?
+        get() = targetState.currentStepIndex
+
+    override fun take(action: Action): Transition? {
+        return when (action) {
+            is Retry -> next(targetState, retryEffect)
+            // a new start means recovery never happened, move to Idling and continue with the new start attempt
+            is StartExperience -> Transition(IdlingState, null, ContinuationEffect(action))
+            // an explicit request to EndExperience just moves directly to IdlingState
+            // can happen in ExperienceRender if a new higher priority experience is starting
+            is EndExperience -> Transition(IdlingState, null, null)
+            else -> null
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/trait/AppcuesTraitException.kt
+++ b/appcues/src/main/java/com/appcues/trait/AppcuesTraitException.kt
@@ -11,4 +11,11 @@ internal class AppcuesTraitException(
      *  of traits can be attempted, to try to auto-recover from this error.
      */
     val retryMilliseconds: Int? = null,
+
+    /**
+     * When true, this means that the issue may be recoverable at a later time, for instance
+     * if a target element is not found, but future layout updates to scroll other content
+     * into view could resolve the target.
+     */
+    val recoverable: Boolean = false
 ) : Exception(message)

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetElementTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetElementTrait.kt
@@ -81,6 +81,7 @@ internal class TargetElementTrait(
             throw AppcuesTraitException(
                 message = "no view matching selector ${selector.toMap()}",
                 retryMilliseconds = retryMilliseconds,
+                recoverable = true,
             )
         }
 
@@ -117,6 +118,7 @@ internal class TargetElementTrait(
         throw AppcuesTraitException(
             message = "multiple non-distinct views (${weightedViews.count()}) matched selector ${selector.toMap()}",
             retryMilliseconds = retryMilliseconds,
+            recoverable = true,
         )
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -56,8 +56,6 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
     private val potentiallyRenderableExperiences = hashMapOf<RenderContext, List<Experience>>()
     private val previewExperiences = hashMapOf<RenderContext, Experience>()
 
-    private val modalStateMachineOwner = ModalStateMachineOwner(get(::onExperienceEnded), get())
-
     private fun onExperienceEnded(experience: Experience) {
         // when an experience completes, remove this render context from the cache, until a new set of
         // qualified experiences is processed
@@ -67,7 +65,7 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
     init {
         // sets up the single state machine used for modal experiences (mobile flows, not embeds)
         // that lives indefinitely and handles one experience at a time
-        stateMachines.setOwner(modalStateMachineOwner)
+        stateMachines.setOwner(ModalStateMachineOwner(get(::onExperienceEnded), get()))
     }
 
     fun getStateFlow(renderContext: RenderContext): Flow<State>? {
@@ -137,10 +135,7 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
         if (qualificationResult.trigger.reason == "screen_view") {
             // clear list in case this was a screen_view qualification
             potentiallyRenderableExperiences.clear()
-            stateMachines.cleanup()
-
-            // and stop any Modal retry processing ongoing when screen changes
-            modalStateMachineOwner.stopRetryHandling()
+            stateMachines.onScreenChange()
         }
 
         // Add new experiences, replacing any existing ones

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -56,6 +56,8 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
     private val potentiallyRenderableExperiences = hashMapOf<RenderContext, List<Experience>>()
     private val previewExperiences = hashMapOf<RenderContext, Experience>()
 
+    private val modalStateMachineOwner = ModalStateMachineOwner(get(::onExperienceEnded), get())
+
     private fun onExperienceEnded(experience: Experience) {
         // when an experience completes, remove this render context from the cache, until a new set of
         // qualified experiences is processed
@@ -65,7 +67,7 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
     init {
         // sets up the single state machine used for modal experiences (mobile flows, not embeds)
         // that lives indefinitely and handles one experience at a time
-        stateMachines.setOwner(ModalStateMachineOwner(get(::onExperienceEnded)))
+        stateMachines.setOwner(modalStateMachineOwner)
     }
 
     fun getStateFlow(renderContext: RenderContext): Flow<State>? {
@@ -136,6 +138,9 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
             // clear list in case this was a screen_view qualification
             potentiallyRenderableExperiences.clear()
             stateMachines.cleanup()
+
+            // and stop any Modal retry processing ongoing when screen changes
+            modalStateMachineOwner.stopRetryHandling()
         }
 
         // Add new experiences, replacing any existing ones

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -68,6 +68,8 @@ internal class ModalStateMachineOwner(
     private fun stopRetryHandling() {
         viewTreeUpdateHandler.detach()
         viewTreeObserver = null
+        uiIdleDebounceTimer?.cancel()
+        uiIdleDebounceTimer = null
     }
 
     private fun startRetryHandling() {

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -59,7 +59,13 @@ internal class ModalStateMachineOwner(
         }
     }
 
-    fun stopRetryHandling() {
+    // gets called by the StateMachineDirectory onScreenChange, which occurs when a new screen view
+    // is processed in ExperienceRenderer - stop any active retry in that case
+    override fun onScreenChange() {
+        stopRetryHandling()
+    }
+
+    private fun stopRetryHandling() {
         viewTreeUpdateHandler.detach()
         viewTreeObserver = null
     }

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -1,0 +1,178 @@
+package com.appcues.ui
+
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.ViewTreeObserver.OnDrawListener
+import android.view.ViewTreeObserver.OnGlobalFocusChangeListener
+import android.view.ViewTreeObserver.OnGlobalLayoutListener
+import android.view.ViewTreeObserver.OnScrollChangedListener
+import android.view.ViewTreeObserver.OnTouchModeChangeListener
+import android.view.ViewTreeObserver.OnWindowAttachListener
+import android.view.ViewTreeObserver.OnWindowFocusChangeListener
+import com.appcues.AppcuesCoroutineScope
+import com.appcues.data.model.RenderContext
+import com.appcues.data.model.RenderContext.Modal
+import com.appcues.monitor.AppcuesActivityMonitor
+import com.appcues.statemachine.Action.Reset
+import com.appcues.statemachine.Action.Retry
+import com.appcues.statemachine.Error.StepError
+import com.appcues.statemachine.StateMachine
+import com.appcues.statemachine.states.RenderingStepState
+import com.appcues.ui.utils.getParentView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.Timer
+import java.util.TimerTask
+import kotlin.concurrent.schedule
+
+internal class ModalStateMachineOwner(
+    override val stateMachine: StateMachine,
+    private val coroutineScope: AppcuesCoroutineScope,
+) : StateMachineOwning {
+
+    companion object {
+        private const val SCROLL_DEBOUNCE_MILLISECONDS = 1_000L
+    }
+
+    override val renderContext: RenderContext = Modal
+
+    // used to attempt retry when items in view change
+    private var viewTreeUpdateHandler: ViewTreeUpdateHandler = ViewTreeUpdateHandler { attemptRetry() }
+    private var uiIdleDebounceTimer: TimerTask? = null
+    private var viewTreeObserver: ViewTreeObserver? = null
+
+    init {
+        // set up observer on the Modal state machine errors to initiate retry
+        coroutineScope.launch(Dispatchers.IO) {
+            stateMachine.errorFlow.collect { error ->
+                // if a recoverable step error is observed, begin attempting retry
+                if (error is StepError && error.recoverable) {
+                    startRetryHandling()
+                }
+            }
+        }
+    }
+
+    override suspend fun reset() {
+        stateMachine.stop(true)
+    }
+
+    override suspend fun onConfigurationChanged() {
+        if (stateMachine.state is RenderingStepState) {
+            stateMachine.handleAction(Reset)
+        }
+    }
+
+    fun stopRetryHandling() {
+        viewTreeUpdateHandler.detach()
+        viewTreeObserver = null
+    }
+
+    private fun startRetryHandling() {
+        if (viewTreeObserver == null) {
+            AppcuesActivityMonitor.activity?.getParentView()?.viewTreeObserver?.let {
+                viewTreeUpdateHandler.attach(it)
+                this.viewTreeObserver = it
+            }
+        }
+    }
+
+    private fun attemptRetry() {
+        onUiIdle {
+            // stop listening for updates, will re-attach if another error occurs
+            stopRetryHandling()
+
+            // cancel any current touch (drag) as our overlay is about to drop on top and we don't want things moving behind it
+            AppcuesActivityMonitor.activity?.getParentView()?.dispatchTouchEvent(
+                MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_CANCEL, 0f, 0f, 0)
+            )
+
+            // trigger the retry in the state machine
+            coroutineScope.launch {
+                stateMachine.handleAction(Retry)
+            }
+        }
+    }
+
+    private fun onUiIdle(block: () -> Unit) {
+        // cancel any previous
+        uiIdleDebounceTimer?.cancel()
+
+        uiIdleDebounceTimer = Timer().schedule(delay = SCROLL_DEBOUNCE_MILLISECONDS) {
+            // set to know to allow new Timer
+            uiIdleDebounceTimer = null
+            // run callback block
+            block()
+        }
+    }
+
+    private class ViewTreeUpdateHandler(private var action: () -> Unit) :
+        OnScrollChangedListener,
+        OnGlobalLayoutListener,
+        OnTouchModeChangeListener,
+        OnDrawListener,
+        OnGlobalFocusChangeListener,
+        OnWindowAttachListener,
+        OnWindowFocusChangeListener
+    {
+        private var viewTreeObserver: ViewTreeObserver? = null
+
+        fun attach(viewTreeObserver: ViewTreeObserver) {
+            this.viewTreeObserver = viewTreeObserver
+
+            viewTreeObserver.addOnScrollChangedListener(this)
+            viewTreeObserver.addOnGlobalLayoutListener(this)
+            viewTreeObserver.addOnTouchModeChangeListener(this)
+            viewTreeObserver.addOnDrawListener(this)
+            viewTreeObserver.addOnGlobalFocusChangeListener(this)
+            viewTreeObserver.addOnWindowAttachListener(this)
+            viewTreeObserver.addOnWindowFocusChangeListener(this)
+        }
+
+        fun detach() {
+            viewTreeObserver?.let {
+                it.removeOnScrollChangedListener(this)
+                it.removeOnGlobalLayoutListener(this)
+                it.removeOnTouchModeChangeListener(this)
+                it.removeOnDrawListener(this)
+                it.removeOnGlobalFocusChangeListener(this)
+                it.removeOnWindowAttachListener(this)
+                it.removeOnWindowFocusChangeListener(this)
+            }
+            viewTreeObserver = null
+        }
+
+        override fun onScrollChanged() {
+            action()
+        }
+
+        override fun onGlobalLayout() {
+            action()
+        }
+
+        override fun onTouchModeChanged(p0: Boolean) {
+
+        }
+
+        override fun onDraw() {
+            action()
+        }
+
+        override fun onGlobalFocusChanged(p0: View?, p1: View?) {
+
+        }
+
+        override fun onWindowAttached() {
+
+        }
+
+        override fun onWindowDetached() {
+
+        }
+
+        override fun onWindowFocusChanged(p0: Boolean) {
+
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -1,15 +1,10 @@
 package com.appcues.ui
 
 import android.view.MotionEvent
-import android.view.View
 import android.view.ViewTreeObserver
 import android.view.ViewTreeObserver.OnDrawListener
-import android.view.ViewTreeObserver.OnGlobalFocusChangeListener
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.view.ViewTreeObserver.OnScrollChangedListener
-import android.view.ViewTreeObserver.OnTouchModeChangeListener
-import android.view.ViewTreeObserver.OnWindowAttachListener
-import android.view.ViewTreeObserver.OnWindowFocusChangeListener
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.RenderContext.Modal
@@ -107,15 +102,10 @@ internal class ModalStateMachineOwner(
         }
     }
 
-    private class ViewTreeUpdateHandler(private var action: () -> Unit) :
-        OnScrollChangedListener,
-        OnGlobalLayoutListener,
-        OnTouchModeChangeListener,
-        OnDrawListener,
-        OnGlobalFocusChangeListener,
-        OnWindowAttachListener,
-        OnWindowFocusChangeListener
-    {
+    private class ViewTreeUpdateHandler(
+        private var action: () -> Unit
+    ) : OnScrollChangedListener, OnGlobalLayoutListener, OnDrawListener {
+
         private var viewTreeObserver: ViewTreeObserver? = null
 
         fun attach(viewTreeObserver: ViewTreeObserver) {
@@ -123,22 +113,14 @@ internal class ModalStateMachineOwner(
 
             viewTreeObserver.addOnScrollChangedListener(this)
             viewTreeObserver.addOnGlobalLayoutListener(this)
-            viewTreeObserver.addOnTouchModeChangeListener(this)
             viewTreeObserver.addOnDrawListener(this)
-            viewTreeObserver.addOnGlobalFocusChangeListener(this)
-            viewTreeObserver.addOnWindowAttachListener(this)
-            viewTreeObserver.addOnWindowFocusChangeListener(this)
         }
 
         fun detach() {
             viewTreeObserver?.let {
                 it.removeOnScrollChangedListener(this)
                 it.removeOnGlobalLayoutListener(this)
-                it.removeOnTouchModeChangeListener(this)
                 it.removeOnDrawListener(this)
-                it.removeOnGlobalFocusChangeListener(this)
-                it.removeOnWindowAttachListener(this)
-                it.removeOnWindowFocusChangeListener(this)
             }
             viewTreeObserver = null
         }
@@ -151,28 +133,8 @@ internal class ModalStateMachineOwner(
             action()
         }
 
-        override fun onTouchModeChanged(p0: Boolean) {
-
-        }
-
         override fun onDraw() {
             action()
-        }
-
-        override fun onGlobalFocusChanged(p0: View?, p1: View?) {
-
-        }
-
-        override fun onWindowAttached() {
-
-        }
-
-        override fun onWindowDetached() {
-
-        }
-
-        override fun onWindowFocusChanged(p0: Boolean) {
-
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
+++ b/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
@@ -3,10 +3,7 @@ package com.appcues.ui
 import com.appcues.AppcuesFrameView
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.RenderContext.Embed
-import com.appcues.data.model.RenderContext.Modal
-import com.appcues.statemachine.Action.Reset
 import com.appcues.statemachine.StateMachine
-import com.appcues.statemachine.states.RenderingStepState
 import org.jetbrains.annotations.VisibleForTesting
 import java.lang.ref.WeakReference
 
@@ -40,21 +37,6 @@ internal class AppcuesFrameStateMachineOwner(
         frame?.reset()
         // do not need to dismiss here, as the frame UI is already removed for embed
         stateMachine.stop(false)
-    }
-}
-
-internal class ModalStateMachineOwner(override val stateMachine: StateMachine) : StateMachineOwning {
-
-    override val renderContext: RenderContext = Modal
-
-    override suspend fun reset() {
-        stateMachine.stop(true)
-    }
-
-    override suspend fun onConfigurationChanged() {
-        if (stateMachine.state is RenderingStepState) {
-            stateMachine.handleAction(Reset)
-        }
     }
 }
 

--- a/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
+++ b/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
@@ -16,8 +16,6 @@ internal interface StateMachineOwning {
 
     suspend fun onConfigurationChanged() = Unit
 
-    fun onScreenChange() { }
-
     fun isInvalid(): Boolean = false
 }
 
@@ -52,7 +50,6 @@ internal class StateMachineDirectory {
     private var stateMachines = mutableMapOf<RenderContext, StateMachineOwning>()
 
     fun onScreenChange() {
-        stateMachines.values.forEach { it.onScreenChange() }
         stateMachines.values.removeAll { it.isInvalid() }
     }
 

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -165,7 +165,7 @@ internal class StateMachineTest : AppcuesScopeTest {
         val action = StartExperience(experience)
         val error = StepError(experience, 0, "test trait exception")
         val stateAtFailure = BeginningStepState(experience, 0, true)
-        val effect = PresentationEffect(experience, 0, 0, true)
+        val effect = PresentationEffect(experience, 0, 0, true, isRecovering = true)
         val targetState = FailingState(stateAtFailure, effect)
 
         // WHEN
@@ -730,7 +730,7 @@ internal class StateMachineTest : AppcuesScopeTest {
         // GIVEN
         val experience = mockExperience { throw AppcuesTraitException("test trait exception") }
         val stateAtFailure = BeginningStepState(experience, 0, true)
-        val retryEffect = PresentationEffect(experience, 0, 0, true)
+        val retryEffect = PresentationEffect(experience, 0, 0, true, isRecovering = true)
         val initialState = FailingState(stateAtFailure, retryEffect)
         val stateMachine = initMachine(initialState)
         val action = Retry

--- a/appcues/src/test/java/com/appcues/statemachine/effects/PresentationEffectTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/effects/PresentationEffectTest.kt
@@ -172,10 +172,10 @@ internal class PresentationEffectTest {
         coVerifySequence { presentingTrait.remove() }
         assertThat(result).isInstanceOf(ReportError::class.java)
         with(result as ReportError) {
-            assertThat(fatal).isTrue()
-            assertThat(error).isInstanceOf(Error.ExperienceError::class.java)
-            with(error as Error.ExperienceError) {
+            assertThat(error).isInstanceOf(Error.StepError::class.java)
+            with(error as Error.StepError) {
                 assertThat(experience).isEqualTo(this@PresentationEffectTest.experience)
+                assertThat(stepIndex).isEqualTo(flatStepIndex)
                 assertThat(message).isEqualTo("produceMetadata error")
             }
         }
@@ -210,10 +210,10 @@ internal class PresentationEffectTest {
         // after retrying returns ReportError
         assertThat(result).isInstanceOf(ReportError::class.java)
         with(result as ReportError) {
-            assertThat(fatal).isTrue()
-            assertThat(error).isInstanceOf(Error.ExperienceError::class.java)
-            with(error as Error.ExperienceError) {
+            assertThat(error).isInstanceOf(Error.StepError::class.java)
+            with(error as Error.StepError) {
                 assertThat(experience).isEqualTo(this@PresentationEffectTest.experience)
+                assertThat(stepIndex).isEqualTo(flatStepIndex)
                 assertThat(message).isEqualTo("produceMetadata error")
             }
         }

--- a/appcues/src/test/java/com/appcues/statemachine/states/BeginningExperienceStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/BeginningExperienceStateTest.kt
@@ -35,6 +35,7 @@ internal class BeginningExperienceStateTest {
                 MockActions.EndExperience,
                 MockActions.Reset,
                 MockActions.ReportError,
+                MockActions.Retry,
             )
         )
     }

--- a/appcues/src/test/java/com/appcues/statemachine/states/BeginningStepStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/BeginningStepStateTest.kt
@@ -35,6 +35,7 @@ internal class BeginningStepStateTest {
                 MockActions.EndExperience,
                 MockActions.Reset,
                 MockActions.ReportError,
+                MockActions.Retry,
             )
         )
     }

--- a/appcues/src/test/java/com/appcues/statemachine/states/EndingExperienceStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/EndingExperienceStateTest.kt
@@ -37,6 +37,7 @@ internal class EndingExperienceStateTest {
                 MockActions.RenderStep,
                 MockActions.EndExperience,
                 MockActions.ReportError,
+                MockActions.Retry,
             )
         )
     }

--- a/appcues/src/test/java/com/appcues/statemachine/states/EndingStepStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/EndingStepStateTest.kt
@@ -39,6 +39,7 @@ internal class EndingStepStateTest {
                 MockActions.RenderStep,
                 MockActions.Reset,
                 MockActions.ReportError,
+                MockActions.Retry,
             )
         )
     }

--- a/appcues/src/test/java/com/appcues/statemachine/states/FailingStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/FailingStateTest.kt
@@ -1,0 +1,76 @@
+package com.appcues.statemachine.states
+
+import com.appcues.mocks.mockExperience
+import com.appcues.statemachine.Action.Retry
+import com.appcues.statemachine.Action.StartExperience
+import com.appcues.statemachine.State
+import com.appcues.statemachine.effects.ContinuationEffect
+import com.appcues.statemachine.effects.PresentationEffect
+import com.appcues.statemachine.states.IdlingState.next
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class FailingStateTest {
+
+    @Test
+    fun `FailingState SHOULD be instance of STATE`() {
+        // GIVEN
+        val experience = mockExperience()
+        val stateAtFailure = BeginningStepState(experience, 3, false)
+        val retryEffect = PresentationEffect(experience, 3, 1, true)
+        val state = FailingState(stateAtFailure, retryEffect)
+        // THEN
+        assertThat(state).isInstanceOf(State::class.java)
+        assertThat(state.currentExperience).isEqualTo(experience)
+        assertThat(state.currentStepIndex).isEqualTo(3)
+    }
+
+    @Test
+    fun `take SHOULD ignore listed actions`() {
+        // GIVEN
+        val experience = mockExperience()
+        val stateAtFailure = BeginningStepState(experience, 3, false)
+        val retryEffect = PresentationEffect(experience, 3, 1, true)
+        val state = FailingState(stateAtFailure, retryEffect)
+        // THEN
+        state.assertIgnoredActions(
+            listOf(
+                MockActions.StartStep,
+                MockActions.MoveToStep,
+                MockActions.RenderStep,
+                MockActions.Reset,
+                MockActions.ReportError,
+            )
+        )
+    }
+
+    @Test
+    fun `take StartExperience SHOULD transition to Idling AND continue to StartExperience`() {
+        // GIVEN
+        val failingExperience = mockExperience()
+        val stateAtFailure = BeginningStepState(failingExperience, 3, false)
+        val retryEffect = PresentationEffect(failingExperience, 3, 1, true)
+        val state = FailingState(stateAtFailure, retryEffect)
+        val experience = mockExperience()
+        val action = StartExperience(experience)
+        // WHEN
+        val transition = state.take(action)
+        // THEN
+        transition.assertState(IdlingState)
+        transition.assertEffect(ContinuationEffect(action))
+    }
+
+    @Test
+    fun `take Retry SHOULD transition to stored value`() {
+        // GIVEN
+        val failingExperience = mockExperience()
+        val stateAtFailure = BeginningStepState(failingExperience, 3, false)
+        val retryEffect = PresentationEffect(failingExperience, 3, 1, true)
+        val state = FailingState(stateAtFailure, retryEffect)
+        val action = Retry
+        // WHEN
+        val transition = state.take(action)
+        // THEN
+        assertThat(transition).isEqualTo(state.next(stateAtFailure, retryEffect))
+    }
+}

--- a/appcues/src/test/java/com/appcues/statemachine/states/IdlingStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/IdlingStateTest.kt
@@ -35,6 +35,7 @@ internal class IdlingStateTest {
                 MockActions.EndExperience,
                 MockActions.Reset,
                 MockActions.ReportError,
+                MockActions.Retry,
             )
         )
     }

--- a/appcues/src/test/java/com/appcues/statemachine/states/RenderingStepStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/RenderingStepStateTest.kt
@@ -42,6 +42,7 @@ internal class RenderingStepStateTest {
                 MockActions.StartExperience,
                 MockActions.RenderStep,
                 MockActions.ReportError,
+                MockActions.Retry,
             )
         )
     }

--- a/appcues/src/test/java/com/appcues/statemachine/states/StatesTestingHelper.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/StatesTestingHelper.kt
@@ -54,4 +54,5 @@ internal object MockActions {
     val EndExperience = mockk<EndExperience>(relaxed = true)
     val Reset = mockk<Reset>(relaxed = true)
     val ReportError = mockk<ReportError>(relaxed = true)
+    val Retry = mockk<Action.Retry>(relaxed = true)
 }

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -1,6 +1,7 @@
 package com.appcues.ui
 
 import com.appcues.AppcuesConfig
+import com.appcues.AppcuesCoroutineScope
 import com.appcues.AppcuesFrameView
 import com.appcues.AppcuesInterceptor
 import com.appcues.analytics.AnalyticsEvent
@@ -20,6 +21,7 @@ import com.appcues.di.Bootstrap
 import com.appcues.di.scope.AppcuesScope
 import com.appcues.di.scope.AppcuesScopeDSL
 import com.appcues.di.scope.get
+import com.appcues.logging.Logcues
 import com.appcues.mocks.mockEmbedExperience
 import com.appcues.mocks.mockExperience
 import com.appcues.mocks.mockExperienceExperiment
@@ -514,6 +516,8 @@ internal class ExperienceRendererTest {
                     scoped { mockk<AnalyticsTracker>(relaxed = true) }
                     scoped { mockk<ExperienceLifecycleTracker>(relaxed = true) }
                     scoped { StateMachineDirectory() }
+                    scoped { AppcuesCoroutineScope(get()) }
+                    scoped { mockk<Logcues>(relaxed = true) }
                 }
             })
         )

--- a/appcues/src/test/java/com/appcues/ui/sm/owner/ModalStateMachineOwnerTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/sm/owner/ModalStateMachineOwnerTest.kt
@@ -1,5 +1,7 @@
 package com.appcues.ui.sm.owner
 
+import com.appcues.AppcuesCoroutineScope
+import com.appcues.logging.Logcues
 import com.appcues.statemachine.Action.Reset
 import com.appcues.statemachine.StateMachine
 import com.appcues.statemachine.states.IdlingState
@@ -7,7 +9,7 @@ import com.appcues.statemachine.states.RenderingStepState
 import com.appcues.ui.ModalStateMachineOwner
 import com.appcues.ui.StateMachineOwning
 import com.google.common.truth.Truth.assertThat
-import io.mockk.coVerifySequence
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -15,9 +17,10 @@ import org.junit.Test
 
 internal class ModalStateMachineOwnerTest {
 
+    private val coroutineScope = AppcuesCoroutineScope(Logcues())
     private val stateMachine = mockk<StateMachine>(relaxed = true)
 
-    private val owner = ModalStateMachineOwner(stateMachine)
+    private val owner = ModalStateMachineOwner(stateMachine, coroutineScope)
 
     @Test
     fun `owner SHOULD extend from StateMachineOwning`() {
@@ -29,7 +32,7 @@ internal class ModalStateMachineOwnerTest {
         // WHEN
         owner.reset()
         // THEN
-        coVerifySequence {
+        coVerify {
             stateMachine.stop(true)
         }
     }
@@ -41,9 +44,7 @@ internal class ModalStateMachineOwnerTest {
         // WHEN
         owner.onConfigurationChanged()
         // THEN
-        coVerifySequence {
-            stateMachine.state
-
+        coVerify {
             stateMachine.handleAction(Reset)
         }
     }
@@ -55,8 +56,8 @@ internal class ModalStateMachineOwnerTest {
         // WHEN
         owner.onConfigurationChanged()
         // THEN
-        coVerifySequence {
-            stateMachine.state
+        coVerify(exactly = 0) {
+            stateMachine.handleAction(any())
         }
     }
 }

--- a/appcues/src/test/java/com/appcues/ui/sm/owner/StateMachineDirectoryTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/sm/owner/StateMachineDirectoryTest.kt
@@ -96,7 +96,7 @@ internal class StateMachineDirectoryTest {
         // WHEN
         owner1.simulateGarbageCollector()
         owner2.simulateGarbageCollector()
-        ownerDirectory.cleanup()
+        ownerDirectory.onScreenChange()
         // THEN
         assertThat(ownerDirectory.getOwner(Embed("frame1"))).isNull()
         assertThat(ownerDirectory.getOwner(Embed("frame2"))).isNull()


### PR DESCRIPTION
This is some foundational work that will support future research on tooltip error/retry handling. I wanted to put up a preliminary PR checkpoint for feedback.

When an error occurs in the PresentationEffect now, it will use ReportError (as before) but also provide a retry SideEffect object as part of the ReportError Action. This SideEffect is whatever should be retried, if a recover attempt is to be made - in this case, the PresentationEffect again.

The StateMachine then has the ability to handle ReportError by transitioning to a FailingState, which captures the current state (to return to) and the SideEffect to retry, to try again later. FailingState can respond to 
* Retry - try the effect again
* StartExperience - which means something new has come into the machine and it should give up (transition back to Idling from the error), and continue on with the new StartExperience as normal.
* EndExperience - edge case if a new event triggered experience comes in and it needs to dismiss any active experience

The concept of "fatal error" is removed - as it was only used in once spot - the PresentationEffect, and this is now a StepError that supports retry. StepError now tracks the renderErrorId in the experience (like we had for embed errors) and the related capability to have a StepRecovered analytic event tracked if they later get retried and make it to StepSeen.

* The first commit here has the core of the new logic
* The second commit contains new tests for all the new logic around state machine transitions and related analytics