### PR TITLE
Fix issue with duplicate state updates in shared flow

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -35,7 +35,7 @@ import com.appcues.ui.ExperienceRenderer.RenderingResult.StateMachineError
 import com.appcues.ui.ExperienceRenderer.RenderingResult.WontDisplay
 import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.Flow
 
 internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesComponent {
 
@@ -67,7 +67,7 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
         stateMachines.setOwner(ModalStateMachineOwner(get(::onExperienceEnded)))
     }
 
-    fun getStateFlow(renderContext: RenderContext): SharedFlow<State>? {
+    fun getStateFlow(renderContext: RenderContext): Flow<State>? {
         return stateMachines.getOwner(renderContext)?.stateMachine?.stateFlow
     }
 


### PR DESCRIPTION
Item found while testing updates in #528 

[distinctUntilChanged](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/distinct-until-changed.html) is enabled by default on StateFlow, but not on the SharedFlow used here - but we want that behavior here as well, since the state could be emitted multiple times with the same value, during error transitions (i.e. ExperienceAlreadyActive)