### PR TITLE
🐛 Back press not being handled on Experiences

### DIFF
--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -5,6 +5,7 @@ import com.appcues.data.model.Action.Trigger.NAVIGATE
 import com.appcues.trait.AppcuesTraitException
 import com.appcues.trait.MetadataSettingTrait
 import com.appcues.trait.PresentingTrait
+import com.appcues.trait.appcues.SkippableTrait
 import java.util.UUID
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
@@ -81,6 +82,10 @@ internal data class Experience(
 
     fun getMetadataSettingTraits(flatStepIndex: Int): List<MetadataSettingTrait> {
         return getStepOrThrow(flatStepIndex).metadataSettingTraits
+    }
+
+    fun isSkippable(flatStepIndex: Int): Boolean {
+        return getStepOrThrow(flatStepIndex).backdropDecoratingTraits.any { it is SkippableTrait }
     }
 
     private fun getStepOrThrow(flatStepIndex: Int): Step {

--- a/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
@@ -125,4 +125,13 @@ internal class AppcuesViewModel(
         onDismiss()
         awaitDismissEffect.dismissed()
     }
+
+    fun onBackPressed() {
+        val state = uiState.value
+        if (state is Rendering && state.experience.isSkippable(state.flatStepIndex)) {
+            coroutineScope.launch {
+                experienceRenderer.dismiss(renderContext, markComplete = false, destroyed = false)
+            }
+        }
+    }
 }

--- a/appcues/src/main/java/com/appcues/ui/presentation/EmbedViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/EmbedViewPresenter.kt
@@ -16,6 +16,8 @@ internal class EmbedViewPresenter(
     private val stateMachines: StateMachineDirectory,
 ) : ViewPresenter(scope, renderContext) {
 
+    override val shouldHandleBack = false
+
     override fun ViewGroup.setupView(activity: Activity): ComposeView? {
         return stateMachines.getFrame(renderContext)?.let {
             it.isVisible = true

--- a/appcues/src/main/java/com/appcues/ui/presentation/OverlayViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/OverlayViewPresenter.kt
@@ -16,6 +16,8 @@ import com.appcues.di.scope.AppcuesScope
 
 internal class OverlayViewPresenter(scope: AppcuesScope, renderContext: RenderContext) : ViewPresenter(scope, renderContext) {
 
+    override val shouldHandleBack = true
+
     override fun ViewGroup.setupView(activity: Activity): ComposeView {
         // remove customers view on accessibility stack
         setAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)

--- a/appcues/src/test/java/com/appcues/data/model/ExperienceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/model/ExperienceTest.kt
@@ -5,8 +5,11 @@ import com.appcues.data.model.Action.Trigger.NAVIGATE
 import com.appcues.data.model.Action.Trigger.TAP
 import com.appcues.data.model.ExperiencePriority.NORMAL
 import com.appcues.trait.AppcuesTraitException
+import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.MetadataSettingTrait
 import com.appcues.trait.PresentingTrait
+import com.appcues.trait.appcues.BackdropTrait
+import com.appcues.trait.appcues.SkippableTrait
 import com.google.common.truth.Truth.assertThat
 import io.mockk.mockk
 import org.junit.Test
@@ -196,6 +199,30 @@ internal class ExperienceTest {
     }
 
     @Test
+    fun `isSkippable SHOULD return true WHEN step contains skippableTrait`() {
+        // GIVEN
+        val skippableTrait = mockk<SkippableTrait>()
+        val stepContainer = getStepContainer(steps = listOf(getStep(backdropDecoratingTrait = listOf(skippableTrait))))
+        val experience = getExperience(listOf(stepContainer))
+        // WHEN
+        val result = experience.isSkippable(0)
+        // THEN
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isSkippable SHOULD return false WHEN step contains no skippableTrait`() {
+        // GIVEN
+        val skippableTrait = mockk<BackdropTrait>()
+        val stepContainer = getStepContainer(steps = listOf(getStep(backdropDecoratingTrait = listOf(skippableTrait))))
+        val experience = getExperience(listOf(stepContainer))
+        // WHEN
+        val result = experience.isSkippable(0)
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
     fun `getMetadataSettingTraits SHOULD return traits from step`() {
         // GIVEN
         val trait1 = mockk<MetadataSettingTrait>()
@@ -268,13 +295,17 @@ internal class ExperienceTest {
         )
     }
 
-    private fun getStep(presentingTrait: PresentingTrait = mockk(), metadataSettingTrait: List<MetadataSettingTrait> = listOf()): Step {
+    private fun getStep(
+        presentingTrait: PresentingTrait = mockk(),
+        metadataSettingTrait: List<MetadataSettingTrait> = listOf(),
+        backdropDecoratingTrait: List<BackdropDecoratingTrait> = listOf()
+    ): Step {
         return Step(
             id = UUID.randomUUID(),
             content = mockk(),
             presentingTrait = presentingTrait,
             stepDecoratingTraits = mockk(),
-            backdropDecoratingTraits = mockk(),
+            backdropDecoratingTraits = backdropDecoratingTrait,
             containerDecoratingTraits = mockk(),
             metadataSettingTraits = metadataSettingTrait,
             actions = mockk(),

--- a/appcues/src/test/java/com/appcues/ui/presentation/EmbedViewPresenterTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/presentation/EmbedViewPresenterTest.kt
@@ -1,0 +1,15 @@
+package com.appcues.ui.presentation
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import org.junit.Test
+
+internal class EmbedViewPresenterTest {
+
+    val presenter = EmbedViewPresenter(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+
+    @Test
+    fun `presenter SHOULD not handle back press`() {
+        assertThat(presenter.shouldHandleBack).isFalse()
+    }
+}

--- a/appcues/src/test/java/com/appcues/ui/presentation/OverlayViewPresenterTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/presentation/OverlayViewPresenterTest.kt
@@ -1,0 +1,15 @@
+package com.appcues.ui.presentation
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import org.junit.Test
+
+internal class OverlayViewPresenterTest {
+
+    val presenter = OverlayViewPresenter(mockk(relaxed = true), mockk(relaxed = true))
+
+    @Test
+    fun `presenter SHOULD handle back press`() {
+        assertThat(presenter.shouldHandleBack).isTrue()
+    }
+}


### PR DESCRIPTION
related to https://app.shortcut.com/appcues/story/42518/non-skippable-experience-can-be-skipped-by-device-back-button-or-gesture noticed that since we moved away from the Activity approach, experiences are not handling the back press properly, this change takes into consideration a possible feature "Block" users from dismissing experience by not including skippable traits into the step, but also includes a fix to make so experiences showing can properly handle the native back press