### PR TITLE
Add retry handling on tooltip render when ui layout updates are detected

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
@@ -115,7 +115,7 @@ private fun View.asCaptureView(screenBounds: Rect): ViewElement? {
         getGlobalVisibleRect(globalVisibleRect).not() ||
         // if the view is not currently in the screenshot image (scrolled away), ignore
         // (this is possibly a redundant check to item above, but keeping for now)
-        screenBounds.contains(globalVisibleRect).not()
+        Rect.intersects(globalVisibleRect, screenBounds).not()
     ) {
         // if any of these conditions failed, this view is not captured
         return null

--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -16,5 +16,10 @@ internal sealed class Error(open val message: String) {
     object ExperienceAlreadyActive : Error("Experience already active")
 
     data class ExperienceError(val experience: Experience, override val message: String) : Error(message)
-    data class StepError(val experience: Experience, val stepIndex: Int, override val message: String) : Error(message)
+    data class StepError(
+        val experience: Experience,
+        val stepIndex: Int,
+        override val message: String,
+        var recoverable: Boolean = false,
+    ) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/statemachine/Error.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Error.kt
@@ -20,6 +20,6 @@ internal sealed class Error(open val message: String) {
         val experience: Experience,
         val stepIndex: Int,
         override val message: String,
-        var recoverable: Boolean = false,
+        val recoverable: Boolean = false,
     ) : Error(message)
 }

--- a/appcues/src/main/java/com/appcues/trait/AppcuesTraitException.kt
+++ b/appcues/src/main/java/com/appcues/trait/AppcuesTraitException.kt
@@ -11,4 +11,11 @@ internal class AppcuesTraitException(
      *  of traits can be attempted, to try to auto-recover from this error.
      */
     val retryMilliseconds: Int? = null,
+
+    /**
+     * When true, this means that the issue may be recoverable at a later time, for instance
+     * if a target element is not found, but future layout updates to scroll other content
+     * into view could resolve the target.
+     */
+    val recoverable: Boolean = false
 ) : Exception(message)

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetElementTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetElementTrait.kt
@@ -78,6 +78,7 @@ internal class TargetElementTrait(
             throw AppcuesTraitException(
                 message = "no view matching selector ${selector.toMap()}",
                 retryMilliseconds = retryMilliseconds,
+                recoverable = true,
             )
         }
 
@@ -114,6 +115,7 @@ internal class TargetElementTrait(
         throw AppcuesTraitException(
             message = "multiple non-distinct views (${weightedViews.count()}) matched selector ${selector.toMap()}",
             retryMilliseconds = retryMilliseconds,
+            recoverable = true,
         )
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -55,6 +55,8 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
     private val potentiallyRenderableExperiences = hashMapOf<RenderContext, List<Experience>>()
     private val previewExperiences = hashMapOf<RenderContext, Experience>()
 
+    private val modalStateMachineOwner = ModalStateMachineOwner(get(::onExperienceEnded), get())
+
     private fun onExperienceEnded(experience: Experience) {
         // when an experience completes, remove this render context from the cache, until a new set of
         // qualified experiences is processed
@@ -64,7 +66,7 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
     init {
         // sets up the single state machine used for modal experiences (mobile flows, not embeds)
         // that lives indefinitely and handles one experience at a time
-        stateMachines.setOwner(ModalStateMachineOwner(get(::onExperienceEnded)))
+        stateMachines.setOwner(modalStateMachineOwner)
     }
 
     fun getStateFlow(renderContext: RenderContext): Flow<State>? {
@@ -135,6 +137,9 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
             // clear list in case this was a screen_view qualification
             potentiallyRenderableExperiences.clear()
             stateMachines.cleanup()
+
+            // and stop any Modal retry processing ongoing when screen changes
+            modalStateMachineOwner.stopRetryHandling()
         }
 
         // Add new experiences, replacing any existing ones

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -60,6 +60,8 @@ internal class ModalStateMachineOwner(
     private fun stopRetryHandling() {
         viewTreeUpdateHandler.detach()
         viewTreeObserver = null
+        uiIdleDebounceTimer?.cancel()
+        uiIdleDebounceTimer = null
     }
 
     private fun startRetryHandling() {

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -1,0 +1,170 @@
+package com.appcues.ui
+
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.ViewTreeObserver.OnDrawListener
+import android.view.ViewTreeObserver.OnGlobalFocusChangeListener
+import android.view.ViewTreeObserver.OnGlobalLayoutListener
+import android.view.ViewTreeObserver.OnScrollChangedListener
+import android.view.ViewTreeObserver.OnTouchModeChangeListener
+import android.view.ViewTreeObserver.OnWindowAttachListener
+import android.view.ViewTreeObserver.OnWindowFocusChangeListener
+import com.appcues.AppcuesCoroutineScope
+import com.appcues.data.model.RenderContext
+import com.appcues.data.model.RenderContext.Modal
+import com.appcues.monitor.AppcuesActivityMonitor
+import com.appcues.statemachine.Action.Retry
+import com.appcues.statemachine.Error.StepError
+import com.appcues.statemachine.StateMachine
+import com.appcues.ui.utils.getParentView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.Timer
+import java.util.TimerTask
+import kotlin.concurrent.schedule
+
+internal class ModalStateMachineOwner(
+    override val stateMachine: StateMachine,
+    private val coroutineScope: AppcuesCoroutineScope,
+) : StateMachineOwning {
+
+    companion object {
+        private const val SCROLL_DEBOUNCE_MILLISECONDS = 1_000L
+    }
+
+    override val renderContext: RenderContext = Modal
+
+    // used to attempt retry when items in view change
+    private var viewTreeUpdateHandler: ViewTreeUpdateHandler = ViewTreeUpdateHandler { attemptRetry() }
+    private var uiIdleDebounceTimer: TimerTask? = null
+    private var viewTreeObserver: ViewTreeObserver? = null
+
+    init {
+        // set up observer on the Modal state machine errors to initiate retry
+        coroutineScope.launch(Dispatchers.IO) {
+            stateMachine.errorFlow.collect { error ->
+                // if a recoverable step error is observed, begin attempting retry
+                if (error is StepError && error.recoverable) {
+                    startRetryHandling()
+                }
+            }
+        }
+    }
+
+    override suspend fun reset() {
+        stateMachine.stop(true)
+    }
+
+    fun stopRetryHandling() {
+        viewTreeUpdateHandler.detach()
+        viewTreeObserver = null
+    }
+
+    private fun startRetryHandling() {
+        if (viewTreeObserver == null) {
+            AppcuesActivityMonitor.activity?.getParentView()?.viewTreeObserver?.let {
+                viewTreeUpdateHandler.attach(it)
+                this.viewTreeObserver = it
+            }
+        }
+    }
+
+    private fun attemptRetry() {
+        onUiIdle {
+            // stop listening for updates, will re-attach if another error occurs
+            stopRetryHandling()
+
+            // cancel any current touch (drag) as our overlay is about to drop on top and we don't want things moving behind it
+            AppcuesActivityMonitor.activity?.getParentView()?.dispatchTouchEvent(
+                MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_CANCEL, 0f, 0f, 0)
+            )
+
+            // trigger the retry in the state machine
+            coroutineScope.launch {
+                stateMachine.handleAction(Retry)
+            }
+        }
+    }
+
+    private fun onUiIdle(block: () -> Unit) {
+        // cancel any previous
+        uiIdleDebounceTimer?.cancel()
+
+        uiIdleDebounceTimer = Timer().schedule(delay = SCROLL_DEBOUNCE_MILLISECONDS) {
+            // set to know to allow new Timer
+            uiIdleDebounceTimer = null
+            // run callback block
+            block()
+        }
+    }
+
+    private class ViewTreeUpdateHandler(private var action: () -> Unit) :
+        OnScrollChangedListener,
+        OnGlobalLayoutListener,
+        OnTouchModeChangeListener,
+        OnDrawListener,
+        OnGlobalFocusChangeListener,
+        OnWindowAttachListener,
+        OnWindowFocusChangeListener
+    {
+        private var viewTreeObserver: ViewTreeObserver? = null
+
+        fun attach(viewTreeObserver: ViewTreeObserver) {
+            this.viewTreeObserver = viewTreeObserver
+
+            viewTreeObserver.addOnScrollChangedListener(this)
+            viewTreeObserver.addOnGlobalLayoutListener(this)
+            viewTreeObserver.addOnTouchModeChangeListener(this)
+            viewTreeObserver.addOnDrawListener(this)
+            viewTreeObserver.addOnGlobalFocusChangeListener(this)
+            viewTreeObserver.addOnWindowAttachListener(this)
+            viewTreeObserver.addOnWindowFocusChangeListener(this)
+        }
+
+        fun detach() {
+            viewTreeObserver?.let {
+                it.removeOnScrollChangedListener(this)
+                it.removeOnGlobalLayoutListener(this)
+                it.removeOnTouchModeChangeListener(this)
+                it.removeOnDrawListener(this)
+                it.removeOnGlobalFocusChangeListener(this)
+                it.removeOnWindowAttachListener(this)
+                it.removeOnWindowFocusChangeListener(this)
+            }
+            viewTreeObserver = null
+        }
+
+        override fun onScrollChanged() {
+            action()
+        }
+
+        override fun onGlobalLayout() {
+            action()
+        }
+
+        override fun onTouchModeChanged(p0: Boolean) {
+
+        }
+
+        override fun onDraw() {
+            action()
+        }
+
+        override fun onGlobalFocusChanged(p0: View?, p1: View?) {
+
+        }
+
+        override fun onWindowAttached() {
+
+        }
+
+        override fun onWindowDetached() {
+
+        }
+
+        override fun onWindowFocusChanged(p0: Boolean) {
+
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -51,7 +51,13 @@ internal class ModalStateMachineOwner(
         stateMachine.stop(true)
     }
 
-    fun stopRetryHandling() {
+    // gets called by the StateMachineDirectory onScreenChange, which occurs when a new screen view
+    // is processed in ExperienceRenderer - stop any active retry in that case
+    override fun onScreenChange() {
+        stopRetryHandling()
+    }
+
+    private fun stopRetryHandling() {
         viewTreeUpdateHandler.detach()
         viewTreeObserver = null
     }

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -1,15 +1,10 @@
 package com.appcues.ui
 
 import android.view.MotionEvent
-import android.view.View
 import android.view.ViewTreeObserver
 import android.view.ViewTreeObserver.OnDrawListener
-import android.view.ViewTreeObserver.OnGlobalFocusChangeListener
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.view.ViewTreeObserver.OnScrollChangedListener
-import android.view.ViewTreeObserver.OnTouchModeChangeListener
-import android.view.ViewTreeObserver.OnWindowAttachListener
-import android.view.ViewTreeObserver.OnWindowFocusChangeListener
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.RenderContext.Modal
@@ -99,15 +94,10 @@ internal class ModalStateMachineOwner(
         }
     }
 
-    private class ViewTreeUpdateHandler(private var action: () -> Unit) :
-        OnScrollChangedListener,
-        OnGlobalLayoutListener,
-        OnTouchModeChangeListener,
-        OnDrawListener,
-        OnGlobalFocusChangeListener,
-        OnWindowAttachListener,
-        OnWindowFocusChangeListener
-    {
+    private class ViewTreeUpdateHandler(
+        private var action: () -> Unit
+    ) : OnScrollChangedListener, OnGlobalLayoutListener, OnDrawListener {
+
         private var viewTreeObserver: ViewTreeObserver? = null
 
         fun attach(viewTreeObserver: ViewTreeObserver) {
@@ -115,22 +105,14 @@ internal class ModalStateMachineOwner(
 
             viewTreeObserver.addOnScrollChangedListener(this)
             viewTreeObserver.addOnGlobalLayoutListener(this)
-            viewTreeObserver.addOnTouchModeChangeListener(this)
             viewTreeObserver.addOnDrawListener(this)
-            viewTreeObserver.addOnGlobalFocusChangeListener(this)
-            viewTreeObserver.addOnWindowAttachListener(this)
-            viewTreeObserver.addOnWindowFocusChangeListener(this)
         }
 
         fun detach() {
             viewTreeObserver?.let {
                 it.removeOnScrollChangedListener(this)
                 it.removeOnGlobalLayoutListener(this)
-                it.removeOnTouchModeChangeListener(this)
                 it.removeOnDrawListener(this)
-                it.removeOnGlobalFocusChangeListener(this)
-                it.removeOnWindowAttachListener(this)
-                it.removeOnWindowFocusChangeListener(this)
             }
             viewTreeObserver = null
         }
@@ -143,28 +125,8 @@ internal class ModalStateMachineOwner(
             action()
         }
 
-        override fun onTouchModeChanged(p0: Boolean) {
-
-        }
-
         override fun onDraw() {
             action()
-        }
-
-        override fun onGlobalFocusChanged(p0: View?, p1: View?) {
-
-        }
-
-        override fun onWindowAttached() {
-
-        }
-
-        override fun onWindowDetached() {
-
-        }
-
-        override fun onWindowFocusChanged(p0: Boolean) {
-
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
+++ b/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
@@ -2,7 +2,6 @@ package com.appcues.ui
 
 import com.appcues.AppcuesFrameView
 import com.appcues.data.model.RenderContext
-import com.appcues.data.model.RenderContext.Modal
 import com.appcues.statemachine.StateMachine
 import java.lang.ref.WeakReference
 
@@ -23,15 +22,6 @@ internal class AppcuesFrameStateMachineOwner(
         frame.get()?.reset()
         // do not need to dismiss here, as the frame UI is already removed for embed
         stateMachine.stop(false)
-    }
-}
-
-internal class ModalStateMachineOwner(override val stateMachine: StateMachine) : StateMachineOwning {
-
-    override val renderContext: RenderContext = Modal
-
-    override suspend fun reset() {
-        stateMachine.stop(true)
     }
 }
 

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -165,7 +165,7 @@ internal class StateMachineTest : AppcuesScopeTest {
         val action = StartExperience(experience)
         val error = StepError(experience, 0, "test trait exception")
         val stateAtFailure = BeginningStepState(experience, 0, true)
-        val effect = PresentationEffect(experience, 0, 0, true)
+        val effect = PresentationEffect(experience, 0, 0, true, isRecovering = true)
         val targetState = FailingState(stateAtFailure, effect)
 
         // WHEN
@@ -730,7 +730,7 @@ internal class StateMachineTest : AppcuesScopeTest {
         // GIVEN
         val experience = mockExperience { throw AppcuesTraitException("test trait exception") }
         val stateAtFailure = BeginningStepState(experience, 0, true)
-        val retryEffect = PresentationEffect(experience, 0, 0, true)
+        val retryEffect = PresentationEffect(experience, 0, 0, true, isRecovering = true)
         val initialState = FailingState(stateAtFailure, retryEffect)
         val stateMachine = initMachine(initialState)
         val action = Retry

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -1,6 +1,7 @@
 package com.appcues.ui
 
 import com.appcues.AppcuesConfig
+import com.appcues.AppcuesCoroutineScope
 import com.appcues.AppcuesFrameView
 import com.appcues.AppcuesInterceptor
 import com.appcues.analytics.AnalyticsEvent
@@ -18,6 +19,7 @@ import com.appcues.di.Bootstrap
 import com.appcues.di.scope.AppcuesScope
 import com.appcues.di.scope.AppcuesScopeDSL
 import com.appcues.di.scope.get
+import com.appcues.logging.Logcues
 import com.appcues.mocks.mockEmbedExperience
 import com.appcues.mocks.mockExperience
 import com.appcues.mocks.mockExperienceExperiment
@@ -478,6 +480,8 @@ internal class ExperienceRendererTest {
                     scoped { mockk<AnalyticsTracker>(relaxed = true) }
                     scoped { mockk<ExperienceLifecycleTracker>(relaxed = true) }
                     scoped { StateMachineDirectory() }
+                    scoped { AppcuesCoroutineScope(get()) }
+                    scoped { mockk<Logcues>(relaxed = true) }
                 }
             })
         )


### PR DESCRIPTION
Stacks on error/retry handling in #528 

Creating a draft here for feedback on approach.

The bulk of the work is being done in the `ModalStateMachineOwner` now - split out from the main ExperienceRenderer, as this is Modal render context specific logic. There are a variety of options available to observe changes in the view tree, using a ViewTreeObserver. This starts out by watching scroll, global layout changes, and draw updates - detecting when the UI is idling by waiting for a 1 sec period after all updates have concluded, before attempting a retry.

The retry is controlled by listening for StepErrors that are marked recoverable. Only selected errors are such type, like "no target element found" and "multiple matching targets" - things that _could_ be resolved by UI updates. Each time a retry is triggered, all the listeners stop, and if another error occurs, then they re-attach and keep trying. If a screen view is processed - retry handling also stops (permanently for that failed experience).

This would support a tooltip step failing when it was the first step in a group - new container presentation, as well as a subsequent step in the group - where the container would be removed, then re-presented on the desired step, if it recovers.