### PR TITLE
Add request properties - root level source, and group property lastSeenAt

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ActivityRequestBuilder.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ActivityRequestBuilder.kt
@@ -30,13 +30,15 @@ internal class ActivityRequestBuilder(
         )
     )
 
-    fun group(sessionId: UUID, properties: Map<String, Any>? = null) = ActivityRequest(
-        userId = storage.userId,
-        accountId = config.accountId,
-        groupId = storage.groupId,
-        sessionId = sessionId,
-        groupUpdate = properties, // no auto-properties on group calls
-        userSignature = storage.userSignature,
+    fun group(sessionId: UUID, properties: Map<String, Any>? = null) = decorator.decorateGroup(
+        ActivityRequest(
+            userId = storage.userId,
+            accountId = config.accountId,
+            groupId = storage.groupId,
+            sessionId = sessionId,
+            groupUpdate = properties?.toMutableMap(),
+            userSignature = storage.userSignature,
+        )
     )
 
     fun track(sessionId: UUID, name: String, properties: Map<String, Any>? = null): ActivityRequest {

--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -104,4 +104,15 @@ internal class AutoPropertyDecorator(
             putAll(autoProperties)
         }
     )
+
+    fun decorateGroup(activity: ActivityRequest): ActivityRequest {
+        // only apply group auto props when the user is associated with a non-null group
+        if (activity.groupId == null) return activity
+
+        return activity.copy(
+            groupUpdate = (activity.groupUpdate ?: hashMapOf()).also {
+                it["_lastSeenAt"] = Date()
+            }
+        )
+    }
 }

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/request/ActivityRequest.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/request/ActivityRequest.kt
@@ -23,9 +23,12 @@ internal data class ActivityRequest(
     @SerializeNull
     val groupId: String? = null,
     @Json(name = "group_update")
-    val groupUpdate: Map<String, Any>? = null,
+    val groupUpdate: MutableMap<String, Any>? = null,
     @Json(ignore = true)
     val timestamp: Date = Date(),
     @Transient
     val userSignature: String? = null,
-)
+) {
+    // all requests from mobile should have `"source": "mobile"` in the request body root
+    var source: String = "mobile"
+}

--- a/appcues/src/test/java/com/appcues/analytics/ActivityRequestBuilderTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ActivityRequestBuilderTest.kt
@@ -31,6 +31,7 @@ internal class ActivityRequestBuilderTest {
         every { decorateIdentify(capture(activityRequestSlot)) } returns mockk()
         every { decorateTrack(capture(eventRequestSlot)) } returns mockk()
         every { autoProperties } returns hashMapOf("auto" to "properties")
+        every { decorateGroup(capture(activityRequestSlot)) } returns mockk()
     }
 
     private val activityRequestBuilder = ActivityRequestBuilder(
@@ -64,8 +65,9 @@ internal class ActivityRequestBuilderTest {
         val properties = hashMapOf("_test" to "test")
         val sessionId = UUID.randomUUID()
         // when
-        with(activityRequestBuilder.group(sessionId, properties)) {
-            // then
+        activityRequestBuilder.group(sessionId, properties)
+        // then
+        with(activityRequestSlot.captured) {
             assertThat(userId).isEqualTo("userId")
             assertThat(groupId).isEqualTo("groupId")
             assertThat(accountId).isEqualTo("accountId")

--- a/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
@@ -260,4 +260,56 @@ internal class AutoPropertyDecoratorTest {
             assertThat(get("_sdkName") as String).isNotEqualTo("test-sdk")
         }
     }
+
+    @Test
+    fun `decorateGroup SHOULD add autoProperties to groupUpdate map WHEN group is not null`() {
+        // given
+        val activityRequest = ActivityRequest(
+            userId = "test userId",
+            sessionId = UUID.randomUUID(),
+            accountId = "test accountId",
+            groupId = "group"
+        )
+        // when
+        with(autoPropertyDecorator.decorateGroup(activityRequest)) {
+            // then
+            assertThat(groupUpdate).hasSize(1)
+            assertThat(groupUpdate).containsKey("_lastSeenAt")
+        }
+    }
+
+    @Test
+    fun `decorateGroup SHOULD NOT add autoProperties to groupUpdate map WHEN group is null`() {
+        // given
+        val activityRequest = ActivityRequest(
+            userId = "test userId",
+            sessionId = UUID.randomUUID(),
+            accountId = "test accountId",
+            groupId = null
+        )
+        // when
+        with(autoPropertyDecorator.decorateGroup(activityRequest)) {
+            // then
+            assertThat(groupUpdate).isNull()
+        }
+    }
+
+    @Test
+    fun `decorateGroup SHOULD include custom properties into groupUpdate map`() {
+        // given
+        val activityRequest = ActivityRequest(
+            userId = "test userId",
+            accountId = "test accountId",
+            sessionId = UUID.randomUUID(),
+            groupId = "group",
+            groupUpdate = hashMapOf("prop" to 12)
+        )
+        // when
+        with(autoPropertyDecorator.decorateGroup(activityRequest)) {
+            // then
+            assertThat(groupUpdate).hasSize(2)
+            assertThat(groupUpdate!!["prop"]).isEqualTo(12)
+            assertThat(groupUpdate).containsKey("_lastSeenAt")
+        }
+    }
 }


### PR DESCRIPTION
[sc-58911] and [sc-58912]

A group update API request will now look like
```diff
{
	"request_id": "710a3f33-261b-4a56-ac06-aab4519c1f2b",
	"user_id": "default-0000",
	"account_id": "PLACEHOLDER_ACCOUNT_ID",
	"session_id": "4eb0d930-6125-48d0-af09-3e9838764416",
	"group_id": "group-name",
	"group_update": {
+		"_lastSeenAt": 1699300394324
	},
+	"source": "mobile"
}
```