### PR TITLE
Batch group updates with user identification when called right after identify

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsModule.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsModule.kt
@@ -23,13 +23,14 @@ internal object AnalyticsModule : AppcuesModule {
         scoped { ActivityRequestBuilder(config = get(), storage = get(), decorator = get()) }
         factory { ExperienceLifecycleTracker(scope = scope) }
         scoped { ActivityScreenTracking(context = get(), analyticsTracker = get(), logcues = get()) }
-        scoped<QueueScheduler> { AnalyticsQueueScheduler() }
+        factory<QueueScheduler> { AnalyticsQueueScheduler() }
         scoped {
             AnalyticsQueueProcessor(
                 appcuesCoroutineScope = get(),
                 experienceRenderer = get(),
                 repository = get(),
-                analyticsQueueScheduler = get()
+                analyticsQueueScheduler = get(),
+                priorityQueueScheduler = get(),
             )
         }
         scoped {

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsModule.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsModule.kt
@@ -29,7 +29,7 @@ internal object AnalyticsModule : AppcuesModule {
                 appcuesCoroutineScope = get(),
                 experienceRenderer = get(),
                 repository = get(),
-                analyticsQueueScheduler = get(),
+                backgroundQueueScheduler = get(),
                 priorityQueueScheduler = get(),
             )
         }

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsQueueProcessor.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsQueueProcessor.kt
@@ -16,22 +16,29 @@ internal class AnalyticsQueueProcessor(
     private val appcuesCoroutineScope: AppcuesCoroutineScope,
     private val repository: AppcuesRepository,
     private val experienceRenderer: ExperienceRenderer,
+    // this is the background analytics processing queue - 10 sec batch
     private val analyticsQueueScheduler: QueueScheduler,
+    // this is the immediate processing queue - 50ms batch to group identify with immediate subsequent updates
+    private val priorityQueueScheduler: QueueScheduler,
 ) {
 
     interface QueueScheduler {
-
-        fun schedule(block: () -> Unit)
+        fun schedule(delay: Long = 10000L, block: () -> Unit)
         fun cancel()
     }
 
+    // holds background analytics (flow events) to batch and send in 10 sec intervals
     private val pendingActivity = mutableListOf<ActivityRequest>()
+
+    // holds items to be immediately processed, but allowed to group with very near additional updates (50ms)
+    private val priorityQueue = mutableListOf<ActivityRequest>()
 
     @VisibleForTesting
     fun queueForTesting(activity: ActivityRequest) {
         pendingActivity.add(activity)
     }
 
+    // used by non-interactive tracking - flow events - allowing for 10 sec batching
     fun queue(activity: ActivityRequest) {
         synchronized(this) {
             // add activity to pending activities
@@ -45,6 +52,9 @@ internal class AnalyticsQueueProcessor(
         }
     }
 
+    // used by normal interactive screen/track calls
+    // add this item to any waiting in the background queue, and flush immediately,
+    // preempting any 10 sec wait for other items
     fun queueThenFlush(activity: ActivityRequest) {
         synchronized(this) {
             analyticsQueueScheduler.cancel()
@@ -54,30 +64,93 @@ internal class AnalyticsQueueProcessor(
         }
     }
 
-    fun flushThenSend(activity: ActivityRequest) {
+    // used by identify, group, and session_started event
+    // flush any items in the background queue, then send this item immediately*
+    // existing background items are flushed first, as they may pertain to a previous user/session
+    //
+    // *the `waitForBatch` param determines whether a 50ms timer will start to allow
+    // a slight delay before sending this item to allow any immediately subsequent items
+    // to batch with it before sending - common case may be grouping an identify(id) with a group(id)
+    // that immediately follows
+    fun flushThenSend(activity: ActivityRequest, waitForBatch: Boolean = false) {
         synchronized(this) {
             analyticsQueueScheduler.cancel()
             // send all pending activities as a merged activity request
             flushPendingActivity()
             // then send another one for our newer activity
-            send(activity, activity.timestamp)
+            sendPriority(activity, waitForBatch, activity.timestamp)
         }
     }
 
+    // used on session reset or app backgrounding to immediately empty anything still in the queue first
     fun flushAsync() {
         // to be called when any pending activity should immediately be flushed to cache, and network if possible
         // i.e. app going to background / being killed
         synchronized(this) {
+            flushPriorityActivity()
             flushPendingActivity()
         }
     }
 
+    // this function handles the optional creation of a 50ms buffer to allow for priority items
+    // to be batched together, when calls are very near in succession.
+    // 1. only start the queue if requested with `startQueue` - only identify or session_start will start a queue
+    // 2. if no queue exists, and not starting a queue - send immediately with no delay
+    // 3. if a queue exists and it contains items from a different user - flush immediately and then process this item
+    // 4. otherwise, add this item to the queue and start it (if not already)
+    private fun sendPriority(activity: ActivityRequest, startQueue: Boolean, time: Date?) {
+        // if there is no queue in flight, just send it immediate - hopefully common case
+        if (!startQueue && priorityQueue.isEmpty()) {
+            send(activity, time)
+            return
+        }
+        // if the queue items are for a different user
+        if (priorityQueue.any { it.userId != activity.userId }) {
+            // flush immediately...
+            priorityQueueScheduler.cancel()
+            flushPriorityActivity()
+            // note: we know that background items were already flushed before getting here
+            // with a new user identified, in flushThenSend.
+            //
+            // then try again..
+            sendPriority(activity, startQueue, time)
+            return
+        }
+        // add activity to priority queue
+        priorityQueue.add(activity)
+        // and schedule the flush task (if not already scheduled)
+        priorityQueueScheduler.schedule(delay = 50L) {
+            synchronized(this) {
+                flushPriorityActivity()
+            }
+        }
+    }
+
+    // send anything in the background analytics queue, merging into a priority queue, if exists
     private fun flushPendingActivity(time: Date? = null) {
         pendingActivity.merge()
             .let {
-                if (it != null) send(it, time)
+                if (it != null) {
+                    // sending through the priority queue here - if there
+                    // is anything batching at 50ms delay (i.e. a new identify)
+                    // then these items will get merged in. Typically, this
+                    // is not the case, and they will be sent immediately.
+                    // `startQueue` is false, as this call will never start a new
+                    // 50ms delay, only merge with an existing one, if exists.
+                    sendPriority(it, false, time)
+                }
             }.also {
                 pendingActivity.clear()
+            }
+    }
+
+    // send the priority queue
+    private fun flushPriorityActivity() {
+        priorityQueue.merge()
+            .let {
+                if (it != null) send(it, it.timestamp)
+            }.also {
+                priorityQueue.clear()
             }
     }
 
@@ -86,6 +159,8 @@ internal class AnalyticsQueueProcessor(
         val activity = first()
         val events = mutableListOf<EventRequest>()
         val profileUpdate = hashMapOf<String, Any>()
+        val groupUpdate = hashMapOf<String, Any>()
+        var groupId: String? = null
         forEach { item ->
             // merge events
             item.events?.let {
@@ -95,10 +170,22 @@ internal class AnalyticsQueueProcessor(
             if (item.profileUpdate != null) {
                 profileUpdate.putAll(item.profileUpdate)
             }
+            // since a group update might get merged in with a new user identify,
+            // we need to take the latest groupId and merge group props as well
+            groupId = item.groupId
+            if (item.groupUpdate != null) {
+                groupUpdate.putAll(item.groupUpdate)
+            }
         }
-        return activity.copy(events = events, profileUpdate = profileUpdate)
+        return activity.copy(
+            groupId = groupId,
+            events = events.ifEmpty { null },
+            profileUpdate = profileUpdate.ifEmpty { null },
+            groupUpdate = groupUpdate.ifEmpty { null },
+        )
     }
 
+    // make the network call to send the activity, and process the result
     private fun send(activity: ActivityRequest, time: Date?) {
         SdkMetrics.tracked(activity.requestId, time)
         appcuesCoroutineScope.launch {
@@ -122,10 +209,10 @@ internal class AnalyticsQueueProcessor(
 
         private var debounceTimer: TimerTask? = null
 
-        override fun schedule(block: () -> Unit) {
+        override fun schedule(delay: Long, block: () -> Unit) {
             // if null, then schedule
             if (debounceTimer == null) {
-                debounceTimer = Timer().schedule(delay = 10000L) {
+                debounceTimer = Timer().schedule(delay = delay) {
                     // set to know to allow new Timer
                     debounceTimer = null
                     // run callback block

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
@@ -49,7 +49,7 @@ internal class AnalyticsQueueProcessorTest {
             appcuesCoroutineScope = coroutineScope,
             experienceRenderer = experienceRenderer,
             repository = repository,
-            analyticsQueueScheduler = queueScheduler,
+            backgroundQueueScheduler = queueScheduler,
             priorityQueueScheduler = priorityQueueScheduler,
         )
     }

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
@@ -39,6 +39,7 @@ internal class AnalyticsQueueProcessorTest {
     }
 
     private val queueScheduler = StubQueueScheduler()
+    private val priorityQueueScheduler = StubQueueScheduler()
 
     private lateinit var analyticsQueueProcessor: AnalyticsQueueProcessor
 
@@ -49,6 +50,7 @@ internal class AnalyticsQueueProcessorTest {
             experienceRenderer = experienceRenderer,
             repository = repository,
             analyticsQueueScheduler = queueScheduler,
+            priorityQueueScheduler = priorityQueueScheduler,
         )
     }
 
@@ -59,7 +61,7 @@ internal class AnalyticsQueueProcessorTest {
         // when
         analyticsQueueProcessor.queue(mockkActivity)
         // then
-        verify { queueScheduler.mockkScheduler.schedule(any()) }
+        verify { queueScheduler.mockkScheduler.schedule(any(), any()) }
         coVerify { repository.trackActivity(capture(activitySlot)) }
         coVerify { experienceRenderer.show(mockkQualificationResult) }
         assertThat(activitySlot.captured.events).hasSize(1)

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
@@ -71,7 +71,7 @@ internal class AnalyticsTrackerTest {
         // then
         verify { sessionMonitor.updateLastActivity() }
         assertThat(analyticsFlowUpdates).hasSize(1)
-        verify { analyticsQueueProcessor.flushThenSend(activity) }
+        verify { analyticsQueueProcessor.flushThenSend(activity, true) }
         assertThat(analyticsFlowUpdates.first().type).isEqualTo(AnalyticType.IDENTIFY)
         assertThat(analyticsFlowUpdates.first().isInternal).isFalse()
         assertThat(analyticsFlowUpdates.first().request).isEqualTo(activity)

--- a/appcues/src/test/java/com/appcues/analytics/StubQueueScheduler.kt
+++ b/appcues/src/test/java/com/appcues/analytics/StubQueueScheduler.kt
@@ -7,9 +7,29 @@ internal class StubQueueScheduler : QueueScheduler {
 
     val mockkScheduler: QueueScheduler = mockk(relaxed = true)
 
+    // used to guard against setting up queue handling more than once for deferred
+    // execution tests
+    private var pendingBlock: (() -> Unit)? = null
+
+    // can be set true by tests to have fine control over when the queue completion
+    // block is processed. By default, queue items are processed immediately
+    var deferCompletion = false
+
     override fun schedule(delay: Long, block: () -> Unit) {
         mockkScheduler.schedule(delay, block)
-        block()
+
+        if (deferCompletion) {
+            pendingBlock = block
+        } else {
+            block()
+        }
+    }
+
+    // used to allow tests to control exactly when the queue should process - simulating
+    // the timer expiry
+    fun processQueue() {
+        pendingBlock?.invoke()
+        pendingBlock = null
     }
 
     override fun cancel() {

--- a/appcues/src/test/java/com/appcues/analytics/StubQueueScheduler.kt
+++ b/appcues/src/test/java/com/appcues/analytics/StubQueueScheduler.kt
@@ -7,8 +7,8 @@ internal class StubQueueScheduler : QueueScheduler {
 
     val mockkScheduler: QueueScheduler = mockk(relaxed = true)
 
-    override fun schedule(block: () -> Unit) {
-        mockkScheduler.schedule(block)
+    override fun schedule(delay: Long, block: () -> Unit) {
+        mockkScheduler.schedule(delay, block)
         block()
     }
 


### PR DESCRIPTION
This is a similar update to what was recently done in the web sdk in https://github.com/appcues/javascript-sdk/pull/613

* on `identify(id, props)` or the `appcues:session_started` event - a 50ms timer is started to allow analytics that occur immediately after, to be batched together into the same activity payload to the API.
* the expected use case would be a `group(id, props)` called immediately after `identify(id, props)` resulting in a combined payload with the new user and the current group - this prevents any chance of state group information being used during the resulting qualification on the server for the new user update or session start qualification
* all other analytics are unaffected, unless they also happen within that 50ms window (in which case they would go in this immediate batch as well)

This is an example of what this result would look like, for a new user landing on a login page, signing in, and then triggering the resulting user profile update, the session_started event, and an immediate group update to identify that user's current group and props.
![Screenshot 2023-11-08 at 3 27 28 PM](https://github.com/appcues/appcues-android-sdk/assets/19266448/d68b191f-61ce-4b5b-8597-b36c315801f7)

This is implemented by adding a new priority queue to our `AnalyticsQueueProcessor` - the 50ms queue. We still have the 10 sec background batching queue for flow events as well. If a new priority update comes in (identify or session_start) it will flush anything in the queue existing, and start this new 50ms queue to gather up all immediately subsequent updates.

Couple of edge cases:
* There is already a 50ms queue going for another user - could happen if you made multiple `identify(id)` calls for different user ids, in rapid succession. This will result in the existing priority queue being immediately flushed, stopping any existing timer, before processing the new one.
* There is a 50ms queue running while an otherwise immediate event is triggered (a screen or track event) - this will result in the normally immediate event having some delay of < 50ms, as it is merged into this queue (hopefully rare).
