### PR TITLE
Fix proguard rules for Moshi response models

### DIFF
--- a/appcues/consumer-rules.pro
+++ b/appcues/consumer-rules.pro
@@ -1,5 +1,6 @@
 # generated Moshi adapaters
--keep class com.appcues.**.*JsonAdapter { *; }
+-keep class com.appcues.data.remote.**.response.** { *; }
+-keep class com.appcues.ViewElement { *; }
 
 # required for element targeting with Jetpack Compose
 -keep class androidx.compose.ui.platform.AndroidComposeView { *; }


### PR DESCRIPTION
The update I made in #532 was incorrect for the Moshi response model classes, this should fix that back up - restoring the old rule and adding a new one for ViewElement, which seems like it was working already, but just in case.