### PR TITLE
♻️  Debugger adding view tree owners on demand

### DIFF
--- a/appcues/src/main/java/com/appcues/MainModule.kt
+++ b/appcues/src/main/java/com/appcues/MainModule.kt
@@ -13,12 +13,14 @@ import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
 import com.appcues.ui.StateMachineDirectory
 import com.appcues.ui.utils.ImageLoaderWrapper
+import com.appcues.util.AppcuesViewTreeOwner
 import com.appcues.util.LinkOpener
 
 internal object MainModule : AppcuesModule {
 
     override fun AppcuesScopeDSL.install() {
         scoped { Appcues(scope) }
+        scoped { AppcuesViewTreeOwner() }
         scoped { TraitRegistry(get(), get()) }
         scoped { ActionRegistry(get()) }
         scoped { ActionProcessor(get()) }
@@ -34,7 +36,7 @@ internal object MainModule : AppcuesModule {
                 debuggerManager = get(),
             )
         }
-        scoped { AppcuesDebuggerManager(contextWrapper = get(), scope = scope) }
+        scoped { AppcuesDebuggerManager(appcuesViewTreeOwner = get(), contextWrapper = get(), scope = scope) }
         scoped { StateMachineDirectory() }
         scoped { ExperienceRenderer(scope = scope) }
         scoped {

--- a/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/AppcuesDebuggerManager.kt
@@ -4,9 +4,11 @@ import android.app.ActionBar.LayoutParams
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.ViewGroup
-import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.findViewTreeOnBackPressedDispatcherOwner
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
@@ -14,12 +16,13 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.viewModelScope
 import com.appcues.R
 import com.appcues.debugger.DebuggerViewModel.UIState.Expanded
 import com.appcues.debugger.ui.DebuggerComposition
 import com.appcues.di.scope.AppcuesScope
+import com.appcues.ui.utils.getParentView
+import com.appcues.util.AppcuesViewTreeOwner
 import com.appcues.util.ContextWrapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +34,8 @@ import kotlin.coroutines.CoroutineContext
 
 @Suppress("TooManyFunctions")
 internal class AppcuesDebuggerManager(
-    contextWrapper: ContextWrapper,
+    private val appcuesViewTreeOwner: AppcuesViewTreeOwner,
+    private val contextWrapper: ContextWrapper,
     private val scope: AppcuesScope
 ) : Application.ActivityLifecycleCallbacks {
 
@@ -39,20 +43,12 @@ internal class AppcuesDebuggerManager(
         override val coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Main
     }
 
-    private val application = contextWrapper.getApplication()
-
     private var debuggerViewModel: DebuggerViewModel? = null
 
     private lateinit var currentActivity: Activity
 
-    private val onBackPressCallback = object : OnBackPressedCallback(false) {
-        override fun handleOnBackPressed() {
-            debuggerViewModel?.closeExpandedView()
-        }
-    }
-
     fun start(activity: Activity, mode: DebugMode, deeplink: String? = null) = activity.runOnUiThread {
-        this.currentActivity = activity
+        currentActivity = activity
         coroutineScope.coroutineContext.cancelChildren()
 
         // it is possible to re-enter start without a stop (deepLinks) - in which case we continue to
@@ -72,16 +68,15 @@ internal class AppcuesDebuggerManager(
         coroutineScope.launch {
             viewModel.uiState.collect { state -> onBackPressCallback.isEnabled = state is Expanded }
         }
-        addDebuggerView(activity, viewModel)
-        application.registerActivityLifecycleCallbacks(this)
-        setDebuggerBackPressCallback(activity)
+        addDebuggerView(viewModel)
+        contextWrapper.getApplication().registerActivityLifecycleCallbacks(this)
     }
 
     fun stop() {
         coroutineScope.coroutineContext.cancelChildren()
         removeDebuggerView()
         debuggerViewModel?.viewModelScope?.cancel() // stop the VM from listening to app activity
-        application.unregisterActivityLifecycleCallbacks(this)
+        contextWrapper.getApplication().unregisterActivityLifecycleCallbacks(this)
         onBackPressCallback.remove()
         debuggerViewModel = null // remove the reference to the current VM - new one will be made on next start()
     }
@@ -90,62 +85,60 @@ internal class AppcuesDebuggerManager(
         debuggerViewModel?.reset()
     }
 
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
     override fun onActivityResumed(activity: Activity) {
-        this.currentActivity = activity
-        debuggerViewModel?.let { addDebuggerView(activity, it) }
-    }
-
-    override fun onActivityPostResumed(activity: Activity) {
-        // not sure if this is necessary but I wanted to make sure we register our back press after everyone else
-        // in case customer is using fragments with the same approach then our callback must be the last one so we can better
-        // control native back press by enabling and disabling on our side
-        setDebuggerBackPressCallback(activity)
-        // also to make sure that if they change fragment, we will register again after the new fragment is attached
-        (activity as? FragmentActivity)?.supportFragmentManager?.addFragmentOnAttachListener { _, _ ->
-            setDebuggerBackPressCallback(activity)
+        currentActivity = activity
+        // setting this on postDelayed ensures we wait for
+        // any transition from one activity to the another before we actually try to add
+        // debugger view
+        debuggerViewModel?.let {
+            Handler(Looper.getMainLooper()).postDelayed({ addDebuggerView(it) }, 0)
         }
     }
 
     override fun onActivityPaused(activity: Activity) = Unit
-    override fun onActivityStarted(activity: Activity) = Unit
     override fun onActivityStopped(activity: Activity) = Unit
-    override fun onActivityCreated(activity: Activity, bundle: Bundle?) = Unit
-    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
     override fun onActivityDestroyed(activity: Activity) = Unit
 
-    private fun addDebuggerView(activity: Activity, debuggerViewModel: DebuggerViewModel) {
-        getParentView(activity).also {
-            // if view is not there
-            if (it.findViewById<ComposeView>(R.id.appcues_debugger_view) == null) {
-                // then we add
-                it.addView(
-                    ComposeView(activity).apply {
+    private fun addDebuggerView(debuggerViewModel: DebuggerViewModel) {
+        // does nothing if currentActivity is not initialized
+        if (this::currentActivity.isInitialized.not()) return
 
-                        id = R.id.appcues_debugger_view
+        val parentView = currentActivity.getParentView()
+        if (parentView.findViewById<ComposeView?>(R.id.appcues_debugger_view) == null) {
+            appcuesViewTreeOwner.init(parentView, currentActivity)
 
-                        layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT).apply {
-                            // adds margin top and bottom according to visible status and navigation bar
-                            ViewCompat.getRootWindowInsets(it)?.getInsets(WindowInsetsCompat.Type.systemBars())?.let { insets ->
-                                setMargins(insets.left, insets.top, insets.right, insets.bottom)
-                            }
+            setOnBackPressDispatcher(parentView)
+
+            parentView.addView(
+                ComposeView(currentActivity).apply {
+
+                    id = R.id.appcues_debugger_view
+
+                    layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT).apply {
+                        // adds margin top and bottom according to visible status and navigation bar
+                        ViewCompat.getRootWindowInsets(parentView)?.getInsets(WindowInsetsCompat.Type.systemBars())?.let { insets ->
+                            setMargins(insets.left, insets.top, insets.right, insets.bottom)
                         }
+                    }
 
-                        setContent {
-                            CompositionLocalProvider(
-                                // Debugger is in English and always LTR regardless of app settings
-                                LocalLayoutDirection provides LayoutDirection.Ltr
-                            ) {
-                                MaterialTheme {
-                                    DebuggerComposition(debuggerViewModel) {
-                                        stop()
-                                        it.removeView(this)
-                                    }
+                    setContent {
+                        CompositionLocalProvider(
+                            // Debugger is in English and always LTR regardless of app settings
+                            LocalLayoutDirection provides LayoutDirection.Ltr
+                        ) {
+                            MaterialTheme {
+                                DebuggerComposition(debuggerViewModel) {
+                                    stop()
+                                    parentView.removeView(this)
                                 }
                             }
                         }
                     }
-                )
-            }
+                }
+            )
         }
     }
 
@@ -153,25 +146,23 @@ internal class AppcuesDebuggerManager(
         // does nothing if currentActivity is not initialized
         if (this::currentActivity.isInitialized.not()) return
 
-        getParentView(currentActivity).also {
-            it.findViewById<ComposeView?>(R.id.appcues_debugger_view)?.run {
-                it.removeView(this)
-            }
+        val parentView = currentActivity.getParentView()
+        val debuggerView = parentView.findViewById<ComposeView?>(R.id.appcues_debugger_view)
+        if (debuggerView != null) {
+            parentView.removeView(debuggerView)
         }
     }
 
-    private fun getParentView(activity: Activity): ViewGroup {
-        // if there is any difference in API levels we can handle it here
-        return activity.window.decorView.rootView as ViewGroup
+    private fun setOnBackPressDispatcher(view: ViewGroup) {
+        view.findViewTreeOnBackPressedDispatcherOwner()?.run {
+            onBackPressCallback.remove()
+            onBackPressedDispatcher.addCallback(onBackPressCallback)
+        }
     }
 
-    private fun setDebuggerBackPressCallback(activity: Activity) {
-        // add onBackPressedDispatcher to handle internally native android back press when debugger is expanded
-        if (activity is ComponentActivity) {
-            onBackPressCallback.remove()
-
-            // attach to the new activity
-            activity.onBackPressedDispatcher.addCallback(onBackPressCallback)
+    private val onBackPressCallback = object : OnBackPressedCallback(false) {
+        override fun handleOnBackPressed() {
+            debuggerViewModel?.closeExpandedView()
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt
+++ b/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt
@@ -55,6 +55,7 @@ internal object AppcuesActivityMonitor : Application.ActivityLifecycleCallbacks 
     override fun onActivityPaused(activity: Activity) {
         _isPaused = true
     }
+
     override fun onActivityStopped(activity: Activity) = Unit
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
     override fun onActivityDestroyed(activity: Activity) = Unit

--- a/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt
@@ -4,37 +4,25 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.view.inspector.WindowInspector
-import androidx.lifecycle.findViewTreeLifecycleOwner
-import androidx.lifecycle.findViewTreeViewModelStoreOwner
-import androidx.lifecycle.setViewTreeLifecycleOwner
-import androidx.lifecycle.setViewTreeViewModelStoreOwner
-import androidx.savedstate.findViewTreeSavedStateRegistryOwner
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import java.lang.reflect.Method
 
 @Suppress("UNCHECKED_CAST")
 @SuppressLint("PrivateApi")
 internal fun Activity.getParentView(): ViewGroup {
-
     // try to find the most applicable decorView to inject Appcues content into. Typically there is just a single
     // decorView on the Activity window. However, if something like a dialog modal has been shown, this can add another
     // window with another decorView on top of the Activity. If we want to support showing content above that layer, we need
     // to find the top most decorView like below.
-
     val decorView = if (VERSION.SDK_INT >= VERSION_CODES.Q) {
-        try {
-            // this is the preferred method on API 29+ with the new WindowInspector function
-            // in case of multiple views, get the one that is hosting android.R.id.content
-            // we get the last one because sometimes stacking activities might be listed in this method,
-            // and we always want the one that is on top
-            WindowInspector.getGlobalWindowViews().last { it.findViewById<View?>(android.R.id.content) != null }
-        } catch (_: NoSuchElementException) {
-            // should never fail but just in case try to use standard decorView
-            window.decorView
-        }
+        // this is the preferred method on API 29+ with the new WindowInspector function
+        // in case of multiple views, get the one that is hosting android.R.id.content
+        // we get the last one because sometimes stacking activities might be listed in this method,
+        // and we always want the one that is on top
+        WindowInspector.getGlobalWindowViews().findTopMost() ?: window.decorView
     } else {
         @Suppress("SwallowedException", "TooGenericExceptionCaught")
         try {
@@ -45,31 +33,15 @@ internal fun Activity.getParentView(): ViewGroup {
             val getRootView: Method = windowManagerClass.getMethod("getRootView", String::class.java)
             val rootViewNames = getViewRootNames.invoke(windowManager) as Array<Any?>
             val rootViews = rootViewNames.map { getRootView(windowManager, it) as View }
-            rootViews.last()
-        } catch (_: Exception) {
+            rootViews.findTopMost() ?: window.decorView
+        } catch (ex: Exception) {
+            Log.e("Appcues", "error getting decorView, ${ex.message}")
             // if all else fails, use the decorView on the window, which is typically the only one
             window.decorView
         }
     }
 
-    // This is the case of some other decorView showing on top - like a modal
-    // dialog. In this case, we need to apply the fix-ups below to ensure that our
-    // content can render correctly inside of this other view. In each case, we use
-    // the applicable value from the Activity default window.
-    if (decorView.findViewTreeLifecycleOwner() == null) {
-        val lifecycleOwner = window.decorView.findViewTreeLifecycleOwner()
-        decorView.setViewTreeLifecycleOwner(lifecycleOwner)
-    }
-
-    if (decorView.findViewTreeViewModelStoreOwner() == null) {
-        val viewModelStoreOwner = window.decorView.findViewTreeViewModelStoreOwner()
-        decorView.setViewTreeViewModelStoreOwner(viewModelStoreOwner)
-    }
-
-    if (decorView.findViewTreeSavedStateRegistryOwner() == null) {
-        val savedStateRegistryOwner = window.decorView.findViewTreeSavedStateRegistryOwner()
-        decorView.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
-    }
-
     return decorView.rootView as ViewGroup
 }
+
+private fun List<View>.findTopMost() = lastOrNull { it.findViewById<View?>(android.R.id.content) != null }

--- a/appcues/src/main/java/com/appcues/util/AppcuesViewTreeOwner.kt
+++ b/appcues/src/main/java/com/appcues/util/AppcuesViewTreeOwner.kt
@@ -1,0 +1,75 @@
+package com.appcues.util
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.ViewGroup
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.OnBackPressedDispatcherOwner
+import androidx.activity.findViewTreeOnBackPressedDispatcherOwner
+import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+
+internal class AppcuesViewTreeOwner : LifecycleOwner, ViewModelStoreOwner, SavedStateRegistryOwner, OnBackPressedDispatcherOwner {
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+    override val lifecycle: Lifecycle
+        get() = lifecycleRegistry
+
+    override val onBackPressedDispatcher: OnBackPressedDispatcher = OnBackPressedDispatcher { }
+
+    private val savedState = Bundle()
+
+    private val savedStateRegistryController: SavedStateRegistryController =
+        SavedStateRegistryController.create(this)
+    override val savedStateRegistry: SavedStateRegistry
+        get() = savedStateRegistryController.savedStateRegistry
+
+    override val viewModelStore: ViewModelStore = ViewModelStore()
+
+    fun init(view: ViewGroup, activity: Activity) {
+        initRegistry()
+        // this is the "official" decorView, that may contain registered Owners
+        val decorView = activity.window.decorView
+
+        if (view.findViewTreeLifecycleOwner() == null) {
+            val viewOwner = decorView.findViewTreeLifecycleOwner()
+            view.setViewTreeLifecycleOwner(viewOwner ?: this)
+        }
+
+        if (view.findViewTreeViewModelStoreOwner() == null) {
+            val viewOwner = decorView.findViewTreeViewModelStoreOwner()
+            view.setViewTreeViewModelStoreOwner(viewOwner ?: this)
+        }
+
+        if (view.findViewTreeSavedStateRegistryOwner() == null) {
+            val viewOwner = decorView.findViewTreeSavedStateRegistryOwner()
+            view.setViewTreeSavedStateRegistryOwner(viewOwner ?: this)
+        }
+
+        if (view.findViewTreeOnBackPressedDispatcherOwner() == null) {
+            val viewOwner = decorView.findViewTreeOnBackPressedDispatcherOwner()
+            view.setViewTreeOnBackPressedDispatcherOwner(viewOwner ?: this)
+        }
+    }
+
+    private fun initRegistry() {
+        if (savedStateRegistry.isRestored.not()) {
+            savedStateRegistryController.performRestore(savedState)
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+        }
+    }
+}

--- a/appcues/src/test/java/com/appcues/ModulesTests.kt
+++ b/appcues/src/test/java/com/appcues/ModulesTests.kt
@@ -48,6 +48,7 @@ import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
 import com.appcues.ui.StateMachineDirectory
 import com.appcues.ui.utils.ImageLoaderWrapper
+import com.appcues.util.AppcuesViewTreeOwner
 import com.appcues.util.ContextWrapper
 import com.appcues.util.LinkOpener
 import com.google.common.truth.Truth.assertThat
@@ -106,6 +107,7 @@ internal class ModulesTests {
     @Test
     fun `check MainModule instances`() = withScope {
         get<Appcues>()
+        get<AppcuesViewTreeOwner>()
         get<TraitRegistry>()
         get<ActionRegistry>()
         get<ActionProcessor>()

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/signin/SignInActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/signin/SignInActivity.kt
@@ -14,6 +14,7 @@ import com.appcues.samples.kotlin.databinding.ActivitySigninBinding
 import com.appcues.samples.kotlin.main.MainActivity
 
 class SignInActivity : AppCompatActivity() {
+
     private val binding by lazy { ActivitySigninBinding.inflate(layoutInflater) }
     private val appcues = ExampleApplication.appcues
 


### PR DESCRIPTION
Initially this was focusing more on the debugger behavior, but I guess we can now more generally handle views that are not "ViewTreeOwners" for both the debugger and PresenterViews, its basically an extra safety that can enable the debugger and experiences to show for customers on old Activity apis.