### PR TITLE
🐛 LaunchExperience should launch different coroutine and unlock processing actions

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/effects/ExperienceActionEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/effects/ExperienceActionEffect.kt
@@ -8,7 +8,10 @@ import com.appcues.statemachine.SideEffect
 internal data class ExperienceActionEffect(private val actions: List<ExperienceAction>) : SideEffect {
 
     override suspend fun launch(processor: ActionProcessor): Action? {
-        processor.process(actions)
+        // invoking processPostFlowActions ensures the current transition will complete
+        // regardless of the actions being processed here.
+        // This is necessary to avoid a possible deadlock between the actions and the state machine.
+        processor.processPostFlowActions(actions)
 
         return null
     }

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -271,7 +271,7 @@ internal class StateMachineTest : AppcuesScopeTest {
         val experienceAction1 = mockk<ExperienceAction>(relaxed = true)
         val experienceAction2 = mockk<ExperienceAction>(relaxed = true)
         val presentingTrait = mockk<PresentingTrait>(relaxed = true)
-        val navigationActions = listOf(Action(NAVIGATE, experienceAction1), Action(NAVIGATE, experienceAction2),)
+        val navigationActions = listOf(Action(NAVIGATE, experienceAction1), Action(NAVIGATE, experienceAction2))
         val experience = mockExperienceNavigateActions(navigationActions, presentingTrait, Qualification("screen_view"))
         val initialState = IdlingState
         val stateMachine = initMachine(initialState)
@@ -664,7 +664,7 @@ internal class StateMachineTest : AppcuesScopeTest {
         // THEN
         assertThat(result.successValue()).isEqualTo(IdlingState)
         assertThat(stateMachine.state).isEqualTo(IdlingState)
-        coVerify { get<ActionProcessor>().process(experience.completionActions) }
+        coVerify { get<ActionProcessor>().processPostFlowActions(experience.completionActions) }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/statemachine/effects/ExperienceActionEffectTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/effects/ExperienceActionEffectTest.kt
@@ -20,6 +20,6 @@ internal class ExperienceActionEffectTest {
         val result = effect.launch(actionProcessor)
         // THEN
         assertThat(result).isNull()
-        coVerify { actionProcessor.process(actions) }
+        coVerify { actionProcessor.processPostFlowActions(actions) }
     }
 }


### PR DESCRIPTION
During regression testing I found an issue where a post complete action to LaunchExperience would lead to StateMachine getting into a deadlock situation, this happens because LaunchExperience is running on the same suspend function as the handleInternalAction and it gets to a point where both are waiting on each other to move on.

this can be tested by tapping on event2 and invoking [this](https://studio.appcues.com/mobile/flows/bf387041-bf99-43b7-b21f-da76bb56340c/settings) experience

now LaunchExperience launches a new coroutine which unlocks the ActionProcessor.process call, and unlocks the whole transition