### PR TITLE
🐛 Properly handle link actions for invalid deep links

### DIFF
--- a/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
@@ -30,7 +30,7 @@ internal class ActionRegistry(override val scope: AppcuesScope) : AppcuesCompone
         register(ContinueAction.TYPE) { config, context -> ContinueAction(config, context, get()) }
         register(LaunchExperienceAction.TYPE) { config, context -> LaunchExperienceAction(config, context, get()) }
         register(SubmitFormAction.TYPE) { config, context -> SubmitFormAction(config, context, get(), get()) }
-        register(LinkAction.TYPE) { config, _ -> LinkAction(config, get(), get()) }
+        register(LinkAction.TYPE) { config, _ -> LinkAction(config, get(), get(), get()) }
         register(TrackEventAction.TYPE) { config, _ -> TrackEventAction(config, get()) }
         register(UpdateProfileAction.TYPE) { config, _ -> UpdateProfileAction(config, get(), get()) }
         register(RequestReviewAction.TYPE) { config, _ -> RequestReviewAction(config, get(), get()) }

--- a/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/experience/ExperienceMapper.kt
@@ -112,6 +112,7 @@ internal class ExperienceMapper(
                             redirectUrl = it,
                             linkOpener = get(),
                             appcues = get(),
+                            logcues = get(),
                         )
                     )
                 }


### PR DESCRIPTION
bug found during exploration test for the 3.1.5 release, its very low severity since its an edge case, but for future versions we can handle invalid deeplinks, we can also display a log error in the debugger so customers can figure out why they are not navigating properly

<img width="411" alt="image" src="https://github.com/appcues/appcues-android-sdk/assets/5244805/39df6c5a-829c-45d9-b181-bd120bf7891a">
