### PR TITLE
🐛 Invalidate current step and re-present onConfigurationChanged

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -37,6 +37,7 @@ import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
 import kotlinx.coroutines.flow.Flow
 
+@Suppress("TooManyFunctions")
 internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesComponent {
 
     companion object {
@@ -211,6 +212,10 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
 
     suspend fun show(renderContext: RenderContext, stepReference: StepReference) {
         stateMachines.getOwner(renderContext)?.stateMachine?.handleAction(MoveToStep(stepReference))
+    }
+
+    suspend fun onViewConfigurationChanged(renderContext: RenderContext) {
+        stateMachines.getOwner(renderContext)?.onConfigurationChanged()
     }
 
     sealed class PreviewResponse {

--- a/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
@@ -134,4 +134,10 @@ internal class AppcuesViewModel(
             }
         }
     }
+
+    fun onConfigurationChanged() {
+        coroutineScope.launch {
+            experienceRenderer.onViewConfigurationChanged(renderContext)
+        }
+    }
 }

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -47,6 +47,10 @@ internal abstract class ViewPresenter(
         override fun onActivityChanged(activity: Activity) {
             viewModel?.onActivityChanged()
         }
+
+        override fun onConfigurationChanged(activity: Activity) {
+            viewModel?.onConfigurationChanged()
+        }
     }
 
     private val lifecycleObserver = object : DefaultLifecycleObserver {

--- a/appcues/src/test/java/com/appcues/monitor/AppcuesActivityMonitorTest.kt
+++ b/appcues/src/test/java/com/appcues/monitor/AppcuesActivityMonitorTest.kt
@@ -60,6 +60,7 @@ internal class AppcuesActivityMonitorTest {
         val monitor = AppcuesActivityMonitor
         // WHEN
         monitor.subscribe(listener)
+        monitor.onActivityCreated(activity, null)
         monitor.onActivityResumed(activity)
         // THEN
         verify { listener.onActivityChanged(activity) }
@@ -92,6 +93,7 @@ internal class AppcuesActivityMonitorTest {
         excludeRecords { listener.hashCode() }
         // WHEN
         monitor.onActivityResumed(activity1)
+        monitor.onActivityCreated(activity2, null)
         monitor.onActivityResumed(activity2)
         // THEN
         verifySequence {

--- a/appcues/src/test/java/com/appcues/statemachine/states/RenderingStepStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/RenderingStepStateTest.kt
@@ -39,7 +39,6 @@ internal class RenderingStepStateTest {
                 MockActions.StartStep,
                 MockActions.StartExperience,
                 MockActions.RenderStep,
-                MockActions.Reset,
                 MockActions.ReportError,
             )
         )


### PR DESCRIPTION
https://app.shortcut.com/appcues/story/59914/anchored-tooltip-positioning-issue-on-rotation-to-landscape

During investigation it was discovered that sometimes we are also dismissing the current Experience, if for some reason when configuration changes we hit the onActivityChanged callback from ActivityMonitor (1), and then when the experience is able to persist through the configuration changing the current state of the state machine was the same was before (2) this is why we see this anchored tooltip issue in the first place.

So:

1 - ActivityMonitor now better differentiate between activity changes and configuration changes (new callback method too)
2 - Introduced new action `RestartStep` (open to name suggestions) that we can send to RenderingStepState to move to BeginningStepState and force the re-presentation through PresentationEffect (which will produce a new set of metadata)