### PR TITLE
🐛 Fix screenshot for API 26+ when target view that  doesn’t support hardware bitmaps.

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
@@ -94,7 +94,7 @@ internal fun DebuggerComposition(viewModel: DebuggerViewModel, onDismiss: () -> 
             if (isIdle && currentState.not() && targetState.not()) {
                 // when current state and target state are set to hide and animation is idle
                 // we will call back to onDismiss
-                viewModel.onDismissAnimationCompleted()
+                viewModel.onDismissAnimationCompleted(debuggerState)
             }
         }
     }
@@ -177,16 +177,13 @@ private fun LaunchedUIStateEffect(
                         is ScreenCapture -> {
                             // hide FAB
                             debuggerState.isVisible.targetState = false
-
-                            // capture screen
-                            viewModel.captureScreen(debuggerState)
                         }
                     }
                 }
                 is Dismissing -> {
                     animateFabToDismiss(
                         debuggerState = debuggerState,
-                        onComplete = { viewModel.onDismissAnimationCompleted() },
+                        onComplete = { viewModel.onDismissAnimationCompleted(debuggerState) },
                     )
 
                     debuggerState.isVisible.targetState = false


### PR DESCRIPTION
Customer was unable to take screenshot on a full compose app. I was able to reproduce by installing Appcues into [NowInAndroid](https://github.com/android/nowinandroid). the error message suggest that the method we were using for taking screenshots is probably not the most recommended, so for API 26+ I switched to an approach that uses PixelCopy.

+ When I changed to PixelCopy I noticed that the screenshot was being taken on the mainThread (probably) causing the visibility animation of the FAB to lag for some frames, so I changed our internal logic, we now wait for the fab to dismiss before taking the screen shot, this also means that we don't need to "prepare" and "restore" anymore as the FAB is no longer there.


Tested on API 22, 25, 26, 32