### PR TITLE
Fix issue with screen capture not working in some scenarios

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -127,7 +128,7 @@ private fun CaptureContents(debuggerViewModel: DebuggerViewModel, capture: Captu
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         BoxWithConstraints(
-            modifier = Modifier.height(375.dp)
+            modifier = Modifier.heightIn(max = 375.dp)
         ) {
             // Captured screenshot
             Image(
@@ -140,7 +141,12 @@ private fun CaptureContents(debuggerViewModel: DebuggerViewModel, capture: Captu
             // Overlay to highlight targetable elements
             Canvas(modifier = Modifier.matchParentSize()) {
                 // figure out the scale value
-                val scale = maxHeight / capture.layout.height.dp
+                val landscape = capture.layout.width > capture.layout.height
+                val scale = if (landscape) {
+                    maxWidth / capture.layout.width.dp
+                } else {
+                    maxHeight / capture.layout.height.dp
+                }
 
                 drawTargetableElement(capture.layout, scale)
             }

--- a/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt
+++ b/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt
@@ -47,7 +47,7 @@ internal object AppcuesActivityMonitor : Application.ActivityLifecycleCallbacks 
     override fun onActivityResumed(activity: Activity) {
         _isPaused = false
 
-        if (this.activity == null) {
+        if (this.activity != activity) {
             this.activityWeakReference = WeakReference(activity)
             // notifies all subscribers that activity has changed
             activityMonitorListener.forEach { it.onActivityChanged(activity) }
@@ -65,10 +65,6 @@ internal object AppcuesActivityMonitor : Application.ActivityLifecycleCallbacks 
         // it means configuration has changed (same activity was re-created
         if (savedInstanceState != null) {
             notifyConfigurationChanged = true
-        } else {
-            if (this.activity != activity) {
-                this.activityWeakReference = null
-            }
         }
     }
 


### PR DESCRIPTION
It was observed that screen capture could fail sometimes, seemingly randomly, and the log message seen was
```
java.lang.IllegalArgumentException: Window doesn't have a backing surface!
```

The error was seen on a tablet device, using rotation to landscape as well during capture (important later). This message is coming from a call to PixelCopy, which was [introduced recently](https://github.com/appcues/appcues-android-sdk/pull/544) in the 3.1.7 version. 

However, further research seems to show that the root cause was actually a bad current `Activity` reference, from the `AppcuesActivityMonitor`, due to some other recent 3.1.7 changes in https://github.com/appcues/appcues-android-sdk/pull/543. Specifically, on a rotation change, the `onActivityCreated` handler would not set the current activity to `null`, thus when it went into `onActivityResumed`, it was not updating the current activity with the reference to the new (different) Activity being passed in. This would eventually lead to a bad activity reference in the screen capture code, after a rotation, and then the error message seen above.

Three small related fixes here:
1. Ensure we track the current `Activity` correctly at all times in the `AppcuesActivityMonitor` (root cause)
2. Add some more exception handling + fallback in the bitmap capture logic - now, if the PixelCopy attempt fails, we'll at least try to capture using the older style method (creating a Bitmap and having a View draw to it). This can also fail, so catching that exception now as well
3. Fix the selector preview display on landscape captures - just a UI bug noticed as well during this.

The selector displays now look correct in both orientations (ignore the missing dialog backdrop here, thats just an emulator rendering issue, known).

| portrait | landscape |
| --- | --- |
|  ![Screenshot 2023-12-08 at 2 57 24 PM](https://github.com/appcues/appcues-android-sdk/assets/19266448/2c233c8f-4c11-4623-8458-2a4ea0b982bf) | ![Screenshot 2023-12-08 at 2 55 02 PM](https://github.com/appcues/appcues-android-sdk/assets/19266448/21cceb20-820a-459a-ae9e-7299edae3d17) |
