### PR TITLE
Update identity verification note to point to central help doc

### DIFF
--- a/docs/Identifying.md
+++ b/docs/Identifying.md
@@ -14,14 +14,7 @@ It is recommended that the application identify a user at moments such as sign i
 
 The inverse of identifying is resetting. For example, if a user logs out of your app. Calling `reset()` will disable tracking of screens and events until a user is identified again.
 
-### Identity Verification
-If your Appcues account is configured for identity verification, pass the user signature in the properties included on the `identify(userId, properties)` call. Use the key "appcues:user_id_signature" and the string value of the signature.
-
-```kotlin
-appcues.identify(userId, mapOf("appcues:user_id_signature" to signature))
-```
-
-This signature will be used in an Authorization header on network requests from the SDK. The Appcues API will use this signature to verify that the requests from the client are authorized using an SDK key configured in Appcues Studio.
+If you have special security needs and your account has been configured to use the Appcues identity verification feature, follow the steps outlined in the [Appcues identity verification documentation](https://docs.appcues.com/dev-installing-appcues/identity-verification), when calling `appcues.identify`.
 
 ## Identifying Anonymous Users
 


### PR DESCRIPTION
Per recent customer feedback and [discussion](https://appcues.slack.com/archives/C031RLGS4F8/p1704495749255789) - moving to an approach where we do not provide a code snippet including `"appcues:user_id_signature"` that could mistakenly be copy/pasted, and rather a less explicit pointer to the main help doc for identity verification - for the less common use case where those details are needed.