### PR TITLE
✨ Adding attributes to action @appcues/track

### DIFF
--- a/appcues/src/main/java/com/appcues/action/appcues/TrackEventAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/TrackEventAction.kt
@@ -3,6 +3,7 @@ package com.appcues.action.appcues
 import com.appcues.Appcues
 import com.appcues.action.ExperienceAction
 import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.getConfig
 import com.appcues.data.model.getConfigOrDefault
 
 internal class TrackEventAction(
@@ -17,9 +18,11 @@ internal class TrackEventAction(
 
     private val eventName = config.getConfigOrDefault<String?>("eventName", null)
 
+    private val attributes = config.getConfig<Map<String, Any>?>("attributes")
+
     override suspend fun execute() {
         if (!eventName.isNullOrEmpty()) {
-            appcues.track(eventName)
+            appcues.track(eventName, attributes)
         }
     }
 }

--- a/appcues/src/test/java/com/appcues/action/appcues/TrackEventActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/TrackEventActionTest.kt
@@ -36,6 +36,20 @@ internal class TrackEventActionTest : AppcuesScopeTest {
     }
 
     @Test
+    fun `track event SHOULD trigger Appcues track with event and attributes`() = runTest {
+        // GIVEN
+        val event = "track_event"
+        val appcues: Appcues = get()
+        val action = TrackEventAction(mapOf("eventName" to event, "attributes" to mapOf("_builderButtonClick" to true)), appcues)
+
+        // WHEN
+        action.execute()
+
+        // THEN
+        coVerify { appcues.track(event, mapOf("_builderButtonClick" to true)) }
+    }
+
+    @Test
     fun `track event SHOULD NOT trigger Appcues track WHEN no eventName is in config`() = runTest {
         // GIVEN
         val appcues: Appcues = get()


### PR DESCRIPTION
This is part of a larger initiative for integrations related to button clicks, on our end for now we need to add an attribute property that can receive generic information from builder, and pass it as properties when calling appcues.track internally.