### PR TITLE
♻️  Adding Query params for deeplink preview and show

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -219,7 +219,7 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
      * @return True if experience content was able to be shown, false if not.
      */
     public suspend fun show(experienceId: String): Boolean {
-        return experienceRenderer.show(experienceId, ExperienceTrigger.ShowCall)
+        return experienceRenderer.show(experienceId, ExperienceTrigger.ShowCall, mapOf())
     }
 
     /**

--- a/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
@@ -39,19 +39,32 @@ internal class DeepLinkHandler(
         return false // link not handled
     }
 
+    private fun Uri.getQueryMap(): Map<String, String> {
+        val queryMap = mutableMapOf<String, String>()
+        queryParameterNames.forEach { key ->
+            getQueryParameter(key)?.let { value ->
+                queryMap[key] = value
+            }
+        }
+
+        return queryMap
+    }
+
     // return true if handled
     private fun processLink(linkData: Uri, activity: Activity): Boolean {
         val segments = linkData.pathSegments
+        val query = linkData.getQueryMap()
+
         return when {
             segments.count() == 2 && segments[0] == "experience_preview" -> {
                 appcuesCoroutineScope.launch {
-                    previewExperience(segments[1], activity)
+                    previewExperience(segments[1], activity, query)
                 }
                 true
             }
             segments.count() == 2 && segments[0] == "experience_content" -> {
                 appcuesCoroutineScope.launch {
-                    experienceRenderer.show(segments[1], DeepLink)
+                    experienceRenderer.show(segments[1], DeepLink, query)
                 }
                 true
             }
@@ -73,8 +86,8 @@ internal class DeepLinkHandler(
         }
     }
 
-    private suspend fun previewExperience(experienceId: String, activity: Activity) {
-        experienceRenderer.preview(experienceId).run {
+    private suspend fun previewExperience(experienceId: String, activity: Activity, query: Map<String, String>) {
+        experienceRenderer.preview(experienceId, query).run {
             val resources = activity.resources
 
             when (this) {

--- a/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/LaunchExperienceAction.kt
@@ -45,7 +45,7 @@ internal class LaunchExperienceAction(
 
     override suspend fun execute() {
         if (experienceId != null) {
-            experienceRenderer.show(experienceId, getTrigger())
+            experienceRenderer.show(experienceId, getTrigger(), mapOf())
         }
     }
 

--- a/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
+++ b/appcues/src/main/java/com/appcues/data/AppcuesRepository.kt
@@ -47,29 +47,31 @@ internal class AppcuesRepository(
     private val processingActivity: HashSet<UUID> = hashSetOf()
     private val mutex = Mutex()
 
-    suspend fun getExperienceContent(experienceId: String, trigger: ExperienceTrigger): Experience? = withContext(Dispatchers.IO) {
-        appcuesRemoteSource.getExperienceContent(experienceId, storage.userSignature).let {
-            when (it) {
-                is Success -> experienceMapper.map(it.value, trigger)
-                is Failure -> {
-                    dataLogcues.error("Experience content request failed", it.reason.toString())
-                    null
+    suspend fun getExperienceContent(experienceId: String, trigger: ExperienceTrigger, query: Map<String, String>): Experience? =
+        withContext(Dispatchers.IO) {
+            appcuesRemoteSource.getExperienceContent(experienceId, storage.userSignature, query).let {
+                when (it) {
+                    is Success -> experienceMapper.map(it.value, trigger)
+                    is Failure -> {
+                        dataLogcues.error("Experience content request failed", it.reason.toString())
+                        null
+                    }
                 }
             }
         }
-    }
 
-    suspend fun getExperiencePreview(experienceId: String): ResultOf<Experience, RemoteError> = withContext(Dispatchers.IO) {
-        return@withContext appcuesRemoteSource.getExperiencePreview(experienceId, storage.userSignature).let {
-            when (it) {
-                is Success -> Success(experienceMapper.map(it.value, ExperienceTrigger.Preview))
-                is Failure -> {
-                    dataLogcues.error("Experience preview request failed", it.reason.toString())
-                    it
+    suspend fun getExperiencePreview(experienceId: String, query: Map<String, String>): ResultOf<Experience, RemoteError> =
+        withContext(Dispatchers.IO) {
+            return@withContext appcuesRemoteSource.getExperiencePreview(experienceId, storage.userSignature, query).let {
+                when (it) {
+                    is Success -> Success(experienceMapper.map(it.value, ExperienceTrigger.Preview))
+                    is Failure -> {
+                        dataLogcues.error("Experience preview request failed", it.reason.toString())
+                        it
+                    }
                 }
             }
         }
-    }
 
     suspend fun trackActivity(activity: ActivityRequest): QualificationResult? = withContext(Dispatchers.IO) {
 

--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -27,6 +27,7 @@ internal data class Experience(
     val requestId: UUID? = null,
     val error: String? = null,
     var renderErrorId: UUID? = null,
+    var previewQuery: Map<String, String> = mapOf(),
 ) {
 
     // a unique identifier for this instance of the Experience, for comparison purposes, in the

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/AppcuesRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/AppcuesRemoteSource.kt
@@ -30,25 +30,29 @@ internal class AppcuesRemoteSource(
     suspend fun getExperienceContent(
         experienceId: String,
         userSignature: String?,
-    ): ResultOf<ExperienceResponse, RemoteError> =
-        NetworkRequest.execute {
-            service.experienceContent(config.accountId, storage.userId, experienceId, userSignature?.let { "Bearer $it" })
+        query: Map<String, String>
+    ): ResultOf<ExperienceResponse, RemoteError> {
+        return NetworkRequest.execute {
+            service.experienceContent(config.accountId, storage.userId, experienceId, query, userSignature?.let { "Bearer $it" })
         }
+    }
 
     suspend fun getExperiencePreview(
         experienceId: String,
         userSignature: String?,
-    ): ResultOf<ExperienceResponse, RemoteError> =
+        query: Map<String, String>
+    ): ResultOf<ExperienceResponse, RemoteError> {
         // preview _can_ be personalized, so attempt to use the user info, if a valid userId exists
-        if (storage.userId.isNotEmpty()) {
+        return if (storage.userId.isNotEmpty()) {
             NetworkRequest.execute {
-                service.experiencePreview(config.accountId, storage.userId, experienceId, userSignature?.let { "Bearer $it" })
+                service.experiencePreview(config.accountId, storage.userId, experienceId, query, userSignature?.let { "Bearer $it" })
             }
         } else {
             NetworkRequest.execute {
-                service.experiencePreview(config.accountId, experienceId)
+                service.experiencePreview(config.accountId, experienceId, query)
             }
         }
+    }
 
     suspend fun postActivity(
         userId: String,

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/AppcuesService.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/AppcuesService.kt
@@ -10,9 +10,11 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.QueryMap
 import java.util.UUID
 
 internal interface AppcuesService {
+
     @POST("v1/accounts/{account}/users/{user}/activity")
     suspend fun activity(
         @Path("account") account: String,
@@ -35,6 +37,7 @@ internal interface AppcuesService {
         @Path("account") account: String,
         @Path("user") user: String,
         @Path("experienceId") experienceId: String,
+        @QueryMap(encoded = true) query: Map<String, String>,
         @Header("Authorization") authorization: String?,
     ): ExperienceResponse
 
@@ -43,6 +46,7 @@ internal interface AppcuesService {
         @Path("account") account: String,
         @Path("user") user: String,
         @Path("experienceId") experienceId: String,
+        @QueryMap(encoded = true) query: Map<String, String>,
         @Header("Authorization") authorization: String?,
     ): ExperienceResponse
 
@@ -50,6 +54,7 @@ internal interface AppcuesService {
     suspend fun experiencePreview(
         @Path("account") account: String,
         @Path("experienceId") experienceId: String,
+        @QueryMap(encoded = true) query: Map<String, String>,
     ): ExperienceResponse
 
     @GET("healthz")

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -192,10 +192,10 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
             ?: potentiallyRenderableExperiences[renderContext]?.let { attemptToShow(it) }
     }
 
-    suspend fun show(experienceId: String, trigger: ExperienceTrigger): Boolean {
+    suspend fun show(experienceId: String, trigger: ExperienceTrigger, query: Map<String, String>): Boolean {
         if (sessionMonitor.sessionId == null) return false
 
-        repository.getExperienceContent(experienceId, trigger)?.let {
+        repository.getExperienceContent(experienceId, trigger, query)?.let {
             if (it.renderContext != Modal) {
                 // No caching required for modals since they can't be lazy-loaded.
                 potentiallyRenderableExperiences[it.renderContext] = listOf(it)
@@ -226,10 +226,12 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
         data class StateMachineError(val experience: Experience, val error: Error) : PreviewResponse()
     }
 
-    suspend fun preview(experienceId: String): PreviewResponse {
-        repository.getExperiencePreview(experienceId).run {
+    suspend fun preview(experienceId: String, query: Map<String, String>): PreviewResponse {
+        repository.getExperiencePreview(experienceId, query).run {
             return when (this) {
                 is Success -> {
+                    // adding query to previewed experience to
+                    value.previewQuery = query
                     previewExperiences[value.renderContext] = value
 
                     return when (val result = show(value)) {

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -137,7 +137,7 @@ internal abstract class ViewPresenter(
     private fun refreshPreview() {
         currentExperience?.let {
             coroutineScope.launch {
-                experienceRenderer.preview(it.id.toString())
+                experienceRenderer.preview(it.id.toString(), it.previewQuery)
             }
         }
     }

--- a/appcues/src/test/java/com/appcues/AppcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/AppcuesTest.kt
@@ -269,7 +269,7 @@ internal class AppcuesTest : AppcuesScopeTest {
         appcues.show(experienceId)
 
         // THEN
-        coVerify { experienceRenderer.show(experienceId, ExperienceTrigger.ShowCall) }
+        coVerify { experienceRenderer.show(experienceId, ExperienceTrigger.ShowCall, mapOf()) }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/DeeplinkHandlerTest.kt
+++ b/appcues/src/test/java/com/appcues/DeeplinkHandlerTest.kt
@@ -295,7 +295,7 @@ internal class DeeplinkHandlerTest {
     }
 
     @Test
-    fun `handle SHOULD call show WITH experienceId`() {
+    fun `handle SHOULD call show WITH experienceId and query`() {
         // GIVEN
         val activity = mockk<Activity>(relaxed = true)
         val intent = mockk<Intent> {
@@ -304,6 +304,9 @@ internal class DeeplinkHandlerTest {
                 every { scheme } returns "appcues-democues"
                 every { host } returns "sdk"
                 every { pathSegments } returns listOf("experience_content", "experienceId-1234")
+                every { queryParameterNames } returns setOf("param1", "param2")
+                every { getQueryParameter("param1") } returns "value1"
+                every { getQueryParameter("param2") } returns "value2"
             }
         }
 
@@ -311,11 +314,11 @@ internal class DeeplinkHandlerTest {
         deepLinkHandler.handle(activity, intent)
 
         // THEN
-        coVerify { experienceRenderer.show("experienceId-1234", DeepLink) }
+        coVerify { experienceRenderer.show("experienceId-1234", DeepLink, mapOf("param1" to "value1", "param2" to "value2")) }
     }
 
     @Test
-    fun `handle SHOULD call preview WITH experienceId`() {
+    fun `handle SHOULD call preview WITH experienceId and query`() {
         // GIVEN
         val activity = mockk<Activity>(relaxed = true)
         val intent = mockk<Intent> {
@@ -324,6 +327,9 @@ internal class DeeplinkHandlerTest {
                 every { scheme } returns "appcues-democues"
                 every { host } returns "sdk"
                 every { pathSegments } returns listOf("experience_preview", "experienceId-1234")
+                every { queryParameterNames } returns setOf("param1", "param2")
+                every { getQueryParameter("param1") } returns "value1"
+                every { getQueryParameter("param2") } returns "value2"
             }
         }
 
@@ -331,7 +337,7 @@ internal class DeeplinkHandlerTest {
         deepLinkHandler.handle(activity, intent)
 
         // THEN
-        coVerify { experienceRenderer.preview("experienceId-1234") }
+        coVerify { experienceRenderer.preview("experienceId-1234", mapOf("param1" to "value1", "param2" to "value2")) }
     }
 
     @Test
@@ -346,7 +352,7 @@ internal class DeeplinkHandlerTest {
                 every { pathSegments } returns listOf("experience_preview", "experienceId-1234")
             }
         }
-        coEvery { experienceRenderer.preview("experienceId-1234") } returns Failed
+        coEvery { experienceRenderer.preview("experienceId-1234", mapOf()) } returns Failed
 
         // WHEN
         deepLinkHandler.handle(activity, intent)
@@ -367,7 +373,7 @@ internal class DeeplinkHandlerTest {
                 every { pathSegments } returns listOf("experience_preview", "experienceId-1234")
             }
         }
-        coEvery { experienceRenderer.preview("experienceId-1234") } returns PreviewDeferred(mockk(), null)
+        coEvery { experienceRenderer.preview("experienceId-1234", mapOf()) } returns PreviewDeferred(mockk(), null)
 
         // WHEN
         deepLinkHandler.handle(activity, intent)
@@ -391,7 +397,7 @@ internal class DeeplinkHandlerTest {
                 every { pathSegments } returns listOf("experience_preview", "experienceId-1234")
             }
         }
-        coEvery { experienceRenderer.preview("experienceId-1234") } returns PreviewDeferred(experience, "frame1234")
+        coEvery { experienceRenderer.preview("experienceId-1234", mapOf()) } returns PreviewDeferred(experience, "frame1234")
 
         // WHEN
         deepLinkHandler.handle(activity, intent)
@@ -415,7 +421,7 @@ internal class DeeplinkHandlerTest {
                 every { pathSegments } returns listOf("experience_preview", "experienceId-1234")
             }
         }
-        coEvery { experienceRenderer.preview("experienceId-1234") } returns StateMachineError(experience, ExperienceAlreadyActive)
+        coEvery { experienceRenderer.preview("experienceId-1234", mapOf()) } returns StateMachineError(experience, ExperienceAlreadyActive)
 
         // WHEN
         deepLinkHandler.handle(activity, intent)
@@ -436,7 +442,7 @@ internal class DeeplinkHandlerTest {
                 every { pathSegments } returns listOf("experience_preview", "experienceId-1234")
             }
         }
-        coEvery { experienceRenderer.preview("experienceId-1234") } returns ExperienceNotFound
+        coEvery { experienceRenderer.preview("experienceId-1234", mapOf()) } returns ExperienceNotFound
 
         // WHEN
         deepLinkHandler.handle(activity, intent)
@@ -457,7 +463,7 @@ internal class DeeplinkHandlerTest {
                 every { pathSegments } returns listOf("experience_preview", "experienceId-1234")
             }
         }
-        coEvery { experienceRenderer.preview("experienceId-1234") } returns Success
+        coEvery { experienceRenderer.preview("experienceId-1234", mapOf()) } returns Success
 
         // WHEN
         deepLinkHandler.handle(activity, intent)

--- a/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/LaunchExperienceActionTest.kt
@@ -90,7 +90,7 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
         action.execute()
 
         // THEN
-        coVerify { experienceRenderer.show(experienceIdString, ExperienceTrigger.LaunchExperienceAction(currentExperience.id)) }
+        coVerify { experienceRenderer.show(experienceIdString, ExperienceTrigger.LaunchExperienceAction(currentExperience.id), mapOf()) }
     }
 
     @Test
@@ -108,7 +108,7 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
         action.execute()
 
         // THEN
-        coVerify { experienceRenderer.show(experienceIdString, ExperienceTrigger.LaunchExperienceAction(null)) }
+        coVerify { experienceRenderer.show(experienceIdString, ExperienceTrigger.LaunchExperienceAction(null), mapOf()) }
     }
 
     @Test
@@ -132,7 +132,8 @@ internal class LaunchExperienceActionTest : AppcuesScopeTest {
         coVerify {
             experienceRenderer.show(
                 launchExperienceId.toString(),
-                ExperienceTrigger.ExperienceCompletionAction(completedExperienceId)
+                ExperienceTrigger.ExperienceCompletionAction(completedExperienceId),
+                mapOf()
             )
         }
     }

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -64,11 +64,11 @@ internal class AppcuesRepositoryTest {
     fun `getExperienceContent SHOULD get from appcuesRemoteSource AND map from experienceMapper`() = runTest {
         // GIVEN
         val experienceResponse = mockk<ExperienceResponse>()
-        coEvery { appcuesRemoteSource.getExperienceContent("1234", any()) } returns Success(experienceResponse)
+        coEvery { appcuesRemoteSource.getExperienceContent("1234", any(), any()) } returns Success(experienceResponse)
         val mappedExperience = mockk<Experience>()
         coEvery { experienceMapper.map(experienceResponse, ExperienceTrigger.ShowCall) } returns mappedExperience
         // WHEN
-        val result = repository.getExperienceContent("1234", ExperienceTrigger.ShowCall)
+        val result = repository.getExperienceContent("1234", ExperienceTrigger.ShowCall, mapOf())
         // THEN
         assertThat(result).isEqualTo(mappedExperience)
     }
@@ -76,9 +76,9 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `getExperienceContent SHOULD return null WHEN appcuesRemoteSource fails`() = runTest {
         // GIVEN
-        coEvery { appcuesRemoteSource.getExperienceContent("1234", any()) } returns Failure(HttpError())
+        coEvery { appcuesRemoteSource.getExperienceContent("1234", any(), any()) } returns Failure(HttpError())
         // WHEN
-        val result = repository.getExperienceContent("1234", ExperienceTrigger.ShowCall)
+        val result = repository.getExperienceContent("1234", ExperienceTrigger.ShowCall, mapOf())
         // THEN
         assertThat(result).isNull()
     }
@@ -87,11 +87,11 @@ internal class AppcuesRepositoryTest {
     fun `getExperiencePreview SHOULD get from appcuesRemoteSource AND map from experienceMapper`() = runTest {
         // GIVEN
         val experienceResponse = mockk<ExperienceResponse>()
-        coEvery { appcuesRemoteSource.getExperiencePreview("1234", any()) } returns Success(experienceResponse)
+        coEvery { appcuesRemoteSource.getExperiencePreview("1234", any(), any()) } returns Success(experienceResponse)
         val mappedExperience = mockk<Experience>()
         coEvery { experienceMapper.map(experienceResponse, ExperienceTrigger.Preview) } returns mappedExperience
         // WHEN
-        val result = repository.getExperiencePreview("1234")
+        val result = repository.getExperiencePreview("1234", mapOf())
         // THEN
         assertThat(result).isInstanceOf(Success::class.java)
     }
@@ -99,9 +99,9 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `getExperiencePreview SHOULD return PreviewError WHEN appcuesRemoteSource fails`() = runTest {
         // GIVEN
-        coEvery { appcuesRemoteSource.getExperiencePreview("1234", any()) } returns Failure(HttpError())
+        coEvery { appcuesRemoteSource.getExperiencePreview("1234", any(), any()) } returns Failure(HttpError())
         // WHEN
-        val result = repository.getExperiencePreview("1234")
+        val result = repository.getExperiencePreview("1234", mapOf())
         // THEN
         assertThat(result).isInstanceOf(Failure::class.java)
     }

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/AppcuesServiceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/AppcuesServiceTest.kt
@@ -37,7 +37,7 @@ internal class AppcuesServiceTest {
         mockWebServer.mockExperienceContent(accountId, userId, experienceId, mock)
 
         // When
-        val result = api.experienceContent(accountId, userId, experienceId, null)
+        val result = api.experienceContent(accountId, userId, experienceId, mapOf(), null)
 
         // Then
         with(result) {
@@ -165,7 +165,7 @@ internal class AppcuesServiceTest {
 
         // When
         try {
-            api.experienceContent(accountId, userId, experienceId, null)
+            api.experienceContent(accountId, userId, experienceId, mapOf(), null)
         } catch (exception: JsonDataException) {
             error = exception.message
         }
@@ -188,7 +188,7 @@ internal class AppcuesServiceTest {
 
         // When
         try {
-            api.experienceContent(accountId, userId, experienceId, null)
+            api.experienceContent(accountId, userId, experienceId, mapOf(), null)
         } catch (exception: JsonDataException) {
             error = exception.message
         }
@@ -211,7 +211,7 @@ internal class AppcuesServiceTest {
 
         // When
         try {
-            api.experienceContent(accountId, userId, experienceId, null)
+            api.experienceContent(accountId, userId, experienceId, mapOf(), null)
         } catch (exception: JsonDataException) {
             error = exception.message
         }

--- a/appcues/src/test/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSourceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/remote/retrofit/RetrofitAppcuesRemoteSourceTest.kt
@@ -41,19 +41,19 @@ internal class RetrofitAppcuesRemoteSourceTest {
     @Test
     fun `getExperienceContent SHOULD add Bearer token auth WHEN userSignature is not null`() = runTest {
         // When
-        retrofitAppcuesRemoteSource.getExperienceContent("test-experience", "abc")
+        retrofitAppcuesRemoteSource.getExperienceContent("test-experience", "abc", mapOf())
 
         // Then
-        coVerify { appcuesService.experienceContent("123", "test-user", "test-experience", "Bearer abc") }
+        coVerify { appcuesService.experienceContent("123", "test-user", "test-experience", mapOf(), "Bearer abc") }
     }
 
     @Test
     fun `getExperienceContent SHOULD NOT add Bearer token auth WHEN userSignature is null`() = runTest {
         // When
-        retrofitAppcuesRemoteSource.getExperienceContent("test-experience", null)
+        retrofitAppcuesRemoteSource.getExperienceContent("test-experience", null, mapOf())
 
         // Then
-        coVerify { appcuesService.experienceContent("123", "test-user", "test-experience", null) }
+        coVerify { appcuesService.experienceContent("123", "test-user", "test-experience", mapOf(), null) }
     }
 
     @Test
@@ -62,10 +62,10 @@ internal class RetrofitAppcuesRemoteSourceTest {
         // userId set in storage in setUp()
 
         // When
-        retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", "abc")
+        retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", "abc", mapOf())
 
         // Then
-        coVerify { appcuesService.experiencePreview("123", "test-user", "test-experience", "Bearer abc") }
+        coVerify { appcuesService.experiencePreview("123", "test-user", "test-experience", mapOf(), "Bearer abc") }
     }
 
     @Test
@@ -74,10 +74,10 @@ internal class RetrofitAppcuesRemoteSourceTest {
         // userId set in storage in setUp()
 
         // When
-        retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", null)
+        retrofitAppcuesRemoteSource.getExperiencePreview("test-experience", null, mapOf())
 
         // Then
-        coVerify { appcuesService.experiencePreview("123", "test-user", "test-experience", null) }
+        coVerify { appcuesService.experiencePreview("123", "test-user", "test-experience", mapOf(), null) }
     }
 
     @Test


### PR DESCRIPTION
matching iOS https://github.com/appcues/appcues-ios-sdk/pull/489.

Enabling query params from builder deeplinks (preview and show) to be used by de SDK when calling the end points for preview and show.

this use case is currently aiming to solve the localeId properly related to localization feature.