### PR TITLE
Fix screen capture bitmap handling with hardware accelerated views

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/screencapture/GetCaptureUseCase.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/GetCaptureUseCase.kt
@@ -62,9 +62,6 @@ internal class GetCaptureUseCase {
     private suspend fun View.screenshot(window: Window): Screenshot? {
         return if (this.width > 0 && this.height > 0) {
             awaitCaptureBitmap(this, window)?.let {
-                val canvas = Canvas(it)
-                this.draw(canvas)
-
                 val insets = ViewCompat.getRootWindowInsets(this)?.getInsets(WindowInsetsCompat.Type.systemBars()) ?: Insets.NONE
 
                 Screenshot(


### PR DESCRIPTION
I believe this will fix the issue seen recently with apps using HW accelerated views trying to take screen captures. The error observed was:
```
java.lang.Exception: java.lang.IllegalArgumentException: Software rendering doesn't support hardware bitmaps
```

This error was coming from the lines removed in this PR.

What I believe happened was
* A fix was made in https://github.com/appcues/appcues-android-sdk/pull/544 that corrected the behavior, and worked, in version 3.1.7
* Some refactoring was then done in https://github.com/appcues/appcues-android-sdk/pull/546 and when the `GetCaptureUseCase` was created, a couple of lines were accidentally copied over into this spot where they should not be. These lines are from the `captureLegacyBitmap` implementation - which should only be used on devices < API 26, or as a fallback when PixelCopy fails to try optimistically to capture a view with no hardware acceleration. This reverted the fix in version 3.1.8 (and 3.1.9 current)

This change should get it back to the expected structure for HW accelerated cases.