### PR TITLE
✨ Adding _lastSeenAt autoProp to identify and event analytics

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -22,7 +22,7 @@ internal class AutoPropertyDecorator(
     companion object {
 
         const val IDENTITY_PROPERTY = "_identity"
-        const val UPDATED_AT_PROPERTY = "_updatedAt"
+        const val LAST_SEEN_AT = "_lastSeenAt"
     }
 
     private var currentScreen: String? = null
@@ -55,7 +55,9 @@ internal class AutoPropertyDecorator(
             "userId" to storage.userId,
             "_isAnonymous" to storage.isAnonymous,
             "_localId" to storage.deviceId,
-            UPDATED_AT_PROPERTY to Date(),
+            "_updatedAt" to Date(),
+            // Last Seen At will deprecate _updatedAt which can't be entirely removed today since it's used for targeting
+            LAST_SEEN_AT to Date(),
             "_sessionId" to sessionMonitor.sessionId?.toString(),
             "_lastContentShownAt" to storage.lastContentShownAt,
             "_lastBrowserLanguage" to contextWrapper.getLanguage(),
@@ -111,7 +113,7 @@ internal class AutoPropertyDecorator(
 
         return activity.copy(
             groupUpdate = (activity.groupUpdate ?: hashMapOf()).also {
-                it["_lastSeenAt"] = Date()
+                it[LAST_SEEN_AT] = Date()
             }
         )
     }

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerRecentEventsManager.kt
@@ -95,9 +95,9 @@ internal class DebuggerRecentEventsManager(
             DebuggerEventItem(
                 id = lastEventId,
                 type = EventType.USER_PROFILE,
-                // it should always contain updated at property, this is just a safeguard
+                // it should always contain timestamp property, this is just a safeguard
                 // in case something changes in the future to avoid unwanted exceptions
-                timestamp = ((request.profileUpdate?.get(AutoPropertyDecorator.UPDATED_AT_PROPERTY) as Date?) ?: Date()).time,
+                timestamp = ((request.profileUpdate?.get(AutoPropertyDecorator.LAST_SEEN_AT) as Date?) ?: Date()).time,
                 name = request.userId,
                 propertySections = listOf(
                     DebuggerEventItemPropertySection(

--- a/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
@@ -50,12 +50,37 @@ internal class AutoPropertyDecoratorTest {
     }
 
     @Test
-    fun `autoProperties SHOULD contain 20 amount of elements`() {
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(20)
+    fun `autoProperties SHOULD contain 21 amount of elements`() {
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(21)
+        with(autoPropertyDecorator.autoProperties) {
+            // App
+            assertThat(containsKey("_appId")).isTrue()
+            assertThat(containsKey("_operatingSystem")).isTrue()
+            assertThat(containsKey("_bundlePackageId")).isTrue()
+            assertThat(containsKey("_appName")).isTrue()
+            assertThat(containsKey("_appVersion")).isTrue()
+            assertThat(containsKey("_appBuild")).isTrue()
+            assertThat(containsKey("_sdkVersion")).isTrue()
+            assertThat(containsKey("_sdkName")).isTrue()
+            assertThat(containsKey("_osVersion")).isTrue()
+            assertThat(containsKey("_deviceType")).isTrue()
+            assertThat(containsKey("_deviceModel")).isTrue()
+            // session
+            assertThat(containsKey("userId")).isTrue()
+            assertThat(containsKey("_isAnonymous")).isTrue()
+            assertThat(containsKey("_localId")).isTrue()
+            assertThat(containsKey("_updatedAt")).isTrue()
+            assertThat(containsKey("_lastSeenAt")).isTrue()
+            assertThat(containsKey("_sessionId")).isTrue()
+            assertThat(containsKey("_lastContentShownAt")).isTrue()
+            assertThat(containsKey("_lastBrowserLanguage")).isTrue()
+            assertThat(containsKey("_sessionPageviews")).isTrue()
+            assertThat(containsKey("_sessionRandomizer")).isTrue()
+        }
     }
 
     @Test
-    fun `autoProperties SHOULD contain 21 amount of elements WHEN one ScreenView is decorated`() {
+    fun `autoProperties SHOULD contain 22 amount of elements WHEN one ScreenView is decorated`() {
         // given
         autoPropertyDecorator.decorateTrack(
             EventRequest(
@@ -66,11 +91,11 @@ internal class AutoPropertyDecoratorTest {
             )
         )
         // then
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(21)
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(22)
     }
 
     @Test
-    fun `autoProperties SHOULD contain 22 amount of elements WHEN two or more ScreenView are decorated`() {
+    fun `autoProperties SHOULD contain 23 amount of elements WHEN two or more ScreenView are decorated`() {
         // given
         autoPropertyDecorator.decorateTrack(
             EventRequest(
@@ -89,7 +114,7 @@ internal class AutoPropertyDecoratorTest {
             )
         )
         // then
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(22)
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(23)
     }
 
     @Test
@@ -192,7 +217,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(20)
+            assertThat(profileUpdate).hasSize(21)
         }
     }
 
@@ -208,7 +233,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(21)
+            assertThat(profileUpdate).hasSize(22)
         }
         // then when
         with(autoPropertyDecorator.decorateTrack(EventRequest(name = SessionStarted.eventName))) {
@@ -228,7 +253,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(21)
+            assertThat(profileUpdate).hasSize(22)
             assertThat(profileUpdate!!["_test"]).isEqualTo("Test")
         }
     }


### PR DESCRIPTION
Keeping in sync with Web Frontend change to include _lastSeenAt as _updatedAt is deprecated but is still used for targeting.

included:
* changes to autoPropertyDecorator.
* change to Debugger for recent events to use new property
* changes to unit tests