### PR TITLE
✨ Adding app_id to ActivityRequest

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/ActivityRequestBuilder.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ActivityRequestBuilder.kt
@@ -23,6 +23,7 @@ internal class ActivityRequestBuilder(
         ActivityRequest(
             userId = storage.userId,
             accountId = config.accountId,
+            appId = config.applicationId,
             groupId = storage.groupId,
             sessionId = sessionId,
             profileUpdate = properties?.toMutableMap(),
@@ -34,6 +35,7 @@ internal class ActivityRequestBuilder(
         ActivityRequest(
             userId = storage.userId,
             accountId = config.accountId,
+            appId = config.applicationId,
             groupId = storage.groupId,
             sessionId = sessionId,
             groupUpdate = properties?.toMutableMap(),
@@ -52,6 +54,7 @@ internal class ActivityRequestBuilder(
             userId = storage.userId,
             profileUpdate = decorator.autoProperties.toMutableMap(),
             accountId = config.accountId,
+            appId = config.applicationId,
             groupId = storage.groupId,
             sessionId = sessionId,
             events = listOf(trackEvent),
@@ -75,6 +78,7 @@ internal class ActivityRequestBuilder(
             userId = storage.userId,
             profileUpdate = decorator.autoProperties.toMutableMap(),
             accountId = config.accountId,
+            appId = config.applicationId,
             groupId = storage.groupId,
             sessionId = sessionId,
             events = listOf(screenEvent),

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/request/ActivityRequest.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/request/ActivityRequest.kt
@@ -17,6 +17,8 @@ internal data class ActivityRequest(
     val userId: String,
     @Json(name = "account_id")
     val accountId: String,
+    @Json(name = "app_id")
+    val appId: String,
     @Json(name = "session_id")
     val sessionId: UUID,
     @Json(name = "group_id")

--- a/appcues/src/test/java/com/appcues/AnalyticsPublisherTest.kt
+++ b/appcues/src/test/java/com/appcues/AnalyticsPublisherTest.kt
@@ -64,6 +64,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         )
         val activity = ActivityRequest(
             accountId = "123",
+            appId = "appId",
             userId = "userId",
             sessionId = UUID.randomUUID(),
             events = listOf(EventRequest("event1", attributes = attributes))
@@ -90,6 +91,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val attributes = hashMapOf<String, Any>("prop" to 42)
         val activity = ActivityRequest(
             accountId = "123",
+            appId = "appId",
             userId = "userId",
             sessionId = UUID.randomUUID(),
             events = listOf(EventRequest("event1", attributes = attributes))
@@ -110,6 +112,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val attributes = hashMapOf<String, Any>(ActivityRequestBuilder.SCREEN_TITLE_ATTRIBUTE to "screen1")
         val activity = ActivityRequest(
             accountId = "123",
+            appId = "appId",
             userId = "userId",
             sessionId = UUID.randomUUID(),
             events = listOf(EventRequest(ScreenView.eventName, attributes = attributes))
@@ -132,6 +135,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val attributes = hashMapOf<String, Any>("prop" to 42)
         val activity = ActivityRequest(
             accountId = "123",
+            appId = "appId",
             sessionId = UUID.randomUUID(),
             userId = storage.userId,
             profileUpdate = attributes
@@ -154,6 +158,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val attributes = hashMapOf<String, Any>("prop" to 42)
         val activity = ActivityRequest(
             accountId = "123",
+            appId = "appId",
             userId = "userId",
             sessionId = UUID.randomUUID(),
             groupId = storage.groupId,
@@ -175,6 +180,7 @@ internal class AnalyticsPublisherTest : AppcuesScopeTest {
         val attributes = hashMapOf<String, Any>("prop" to 42)
         val activity = ActivityRequest(
             accountId = "123",
+            appId = "appId",
             userId = "userId",
             sessionId = UUID.randomUUID(),
             events = listOf(EventRequest("event1", attributes = attributes))

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsQueueProcessorTest.kt
@@ -29,7 +29,7 @@ internal class AnalyticsQueueProcessorTest {
 
     private val mockkEvent: EventRequest = mockk()
     private val mockkActivity: ActivityRequest =
-        ActivityRequest(userId = "222", accountId = "111", sessionId = UUID.randomUUID(), events = listOf(mockkEvent))
+        ActivityRequest(userId = "222", accountId = "111", appId = "appId", sessionId = UUID.randomUUID(), events = listOf(mockkEvent))
     private val mockkQualificationResult: QualificationResult =
         QualificationResult(Qualification("screen_view"), arrayListOf(mockk()))
 
@@ -93,7 +93,13 @@ internal class AnalyticsQueueProcessorTest {
         // given
         val queuedActivitySlot = slot<ActivityRequest>()
         val queuedEvent: EventRequest = mockk()
-        val queuedActivity = ActivityRequest(userId = "222", accountId = "111", sessionId = UUID.randomUUID(), events = listOf(queuedEvent))
+        val queuedActivity = ActivityRequest(
+            userId = "222",
+            appId = "appId",
+            accountId = "111",
+            sessionId = UUID.randomUUID(),
+            events = listOf(queuedEvent)
+        )
         val activitySlot = slot<ActivityRequest>()
         analyticsQueueProcessor.queueForTesting(queuedActivity)
         // when
@@ -119,7 +125,8 @@ internal class AnalyticsQueueProcessorTest {
         // given
         val queuedActivitySlot = slot<ActivityRequest>()
         val queuedEvent: EventRequest = mockk()
-        val queuedActivity = ActivityRequest(userId = "222", accountId = "111", sessionId = UUID.randomUUID(), events = listOf(queuedEvent))
+        val queuedActivity =
+            ActivityRequest(userId = "222", accountId = "111", appId = "appId", sessionId = UUID.randomUUID(), events = listOf(queuedEvent))
         analyticsQueueProcessor.queueForTesting(queuedActivity)
         // when
         analyticsQueueProcessor.flushAsync()
@@ -135,12 +142,14 @@ internal class AnalyticsQueueProcessorTest {
         // given
         val identifyActivity = ActivityRequest(
             userId = "user-1",
+            appId = "appId",
             accountId = "00000",
             sessionId = UUID.randomUUID(),
             profileUpdate = mutableMapOf("userProp" to 1)
         )
         val groupActivity = ActivityRequest(
             userId = "user-1",
+            appId = "appId",
             accountId = "00000",
             sessionId = UUID.randomUUID(),
             groupId = "group-id",
@@ -170,12 +179,14 @@ internal class AnalyticsQueueProcessorTest {
         // given
         val identifyActivity1 = ActivityRequest(
             userId = "user-1",
+            appId = "appId",
             accountId = "00000",
             sessionId = UUID.randomUUID(),
             profileUpdate = mutableMapOf("userProp" to 1)
         )
         val identifyActivity2 = ActivityRequest(
             userId = "user-2",
+            appId = "appId",
             accountId = "00000",
             sessionId = UUID.randomUUID(),
             profileUpdate = mutableMapOf("groupProp" to 2)
@@ -211,12 +222,14 @@ internal class AnalyticsQueueProcessorTest {
         // given
         val identifyActivity = ActivityRequest(
             userId = "user-1",
+            appId = "appId",
             accountId = "00000",
             sessionId = UUID.randomUUID(),
             profileUpdate = mutableMapOf("userProp" to 1)
         )
         val eventActivity = ActivityRequest(
             userId = "user-1",
+            appId = "appId",
             accountId = "00000",
             sessionId = UUID.randomUUID(),
             events = listOf(mockkEvent)
@@ -244,12 +257,14 @@ internal class AnalyticsQueueProcessorTest {
         // given
         val identifyActivity = ActivityRequest(
             userId = "user-1",
+            appId = "appId",
             accountId = "00000",
             sessionId = UUID.randomUUID(),
             profileUpdate = mutableMapOf("userProp" to 1)
         )
         val eventActivity = ActivityRequest(
             userId = "user-1",
+            appId = "appId",
             accountId = "00000",
             sessionId = UUID.randomUUID(),
             events = listOf(mockkEvent)

--- a/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
@@ -213,7 +213,12 @@ internal class AutoPropertyDecoratorTest {
     @Test
     fun `decorateIdentity SHOULD add autoProperties to profileUpdate map`() {
         // given
-        val activityRequest = ActivityRequest(userId = "test userId", sessionId = UUID.randomUUID(), accountId = "test accountId")
+        val activityRequest = ActivityRequest(
+            userId = "test userId",
+            appId = "appId",
+            sessionId = UUID.randomUUID(),
+            accountId = "test accountId"
+        )
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
@@ -226,6 +231,7 @@ internal class AutoPropertyDecoratorTest {
         // given
         val activityRequest = ActivityRequest(
             userId = "test userId",
+            appId = "appId",
             accountId = "test accountId",
             sessionId = UUID.randomUUID(),
             profileUpdate = hashMapOf("test_property" to "test_value")
@@ -246,6 +252,7 @@ internal class AutoPropertyDecoratorTest {
         // given
         val activityRequest = ActivityRequest(
             userId = "test userId",
+            appId = "appId",
             accountId = "test accountId",
             sessionId = UUID.randomUUID(),
             profileUpdate = hashMapOf("_test" to "Test")
@@ -291,6 +298,7 @@ internal class AutoPropertyDecoratorTest {
         // given
         val activityRequest = ActivityRequest(
             userId = "test userId",
+            appId = "appId",
             sessionId = UUID.randomUUID(),
             accountId = "test accountId",
             groupId = "group"
@@ -308,6 +316,7 @@ internal class AutoPropertyDecoratorTest {
         // given
         val activityRequest = ActivityRequest(
             userId = "test userId",
+            appId = "appId",
             sessionId = UUID.randomUUID(),
             accountId = "test accountId",
             groupId = null
@@ -324,6 +333,7 @@ internal class AutoPropertyDecoratorTest {
         // given
         val activityRequest = ActivityRequest(
             userId = "test userId",
+            appId = "appId",
             accountId = "test accountId",
             sessionId = UUID.randomUUID(),
             groupId = "group",

--- a/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
+++ b/appcues/src/test/java/com/appcues/data/AppcuesRepositoryTest.kt
@@ -109,7 +109,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD save to local storage AND send qualify request`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
+        val request = ActivityRequest(accountId = "123", appId = "appId", sessionId = UUID.randomUUID(), userId = "userId")
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk<ExperienceResponse>(), mockk<ExperienceResponse>()),
             performedQualification = true,
@@ -136,7 +136,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD call postActivity on cache item WHEN the next request is sent`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
+        val request = ActivityRequest(accountId = "123", appId = "appId", sessionId = UUID.randomUUID(), userId = "userId")
         val activityStorage = ActivityStorage(UUID.randomUUID(), "123", "userId", "data", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
 
@@ -154,7 +154,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD retain cache item WHEN the qualify request fails with a NetworkError`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
+        val request = ActivityRequest(accountId = "123", appId = "appId", sessionId = UUID.randomUUID(), userId = "userId")
         coEvery { appcuesRemoteSource.qualify(any(), any(), request.requestId, any()) } returns Failure(NetworkError())
 
         // WHEN
@@ -168,7 +168,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD NOT retain cache item WHEN the qualify request fails with an HTTPError`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
+        val request = ActivityRequest(accountId = "123", appId = "appId", sessionId = UUID.randomUUID(), userId = "userId")
         coEvery { appcuesRemoteSource.qualify(any(), any(), request.requestId, any()) } returns Failure(HttpError())
 
         // WHEN
@@ -182,7 +182,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD retain a cache item WHEN the retry fails with a NetworkError`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
+        val request = ActivityRequest(accountId = "123", appId = "appId", sessionId = UUID.randomUUID(), userId = "userId")
         val activityStorage = ActivityStorage(UUID.randomUUID(), "123", "userId", "data", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
         coEvery { appcuesRemoteSource.postActivity("userId", null, "data") } returns Failure(NetworkError())
@@ -200,7 +200,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD NOT retain a cache item WHEN the retry fails with an HTTPError`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
+        val request = ActivityRequest(accountId = "123", appId = "appId", sessionId = UUID.randomUUID(), userId = "userId")
         val activityStorage = ActivityStorage(UUID.randomUUID(), "123", "userId", "data", null)
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(activityStorage)
         coEvery { appcuesRemoteSource.postActivity("userId", null, "data") } returns Failure(HttpError())
@@ -267,7 +267,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD mark the experience LOW priority WHEN the qualification reason is screen_view`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
+        val request = ActivityRequest(accountId = "123", appId = "appId", sessionId = UUID.randomUUID(), userId = "userId")
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk<ExperienceResponse>(), mockk<ExperienceResponse>()),
             performedQualification = true,
@@ -290,7 +290,7 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD mark the experience NORMAL priority WHEN the qualification reason is not screen_view`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", sessionId = UUID.randomUUID(), userId = "userId")
+        val request = ActivityRequest(accountId = "123", appId = "appId", sessionId = UUID.randomUUID(), userId = "userId")
         val qualifyResponse = QualifyResponse(
             experiences = listOf(mockk<ExperienceResponse>(), mockk<ExperienceResponse>()),
             performedQualification = true,
@@ -313,7 +313,13 @@ internal class AppcuesRepositoryTest {
     @Test
     fun `trackActivity SHOULD include user signature in ActivityStorage WHEN the ActivityRequest has a user signature`() = runTest {
         // GIVEN
-        val request = ActivityRequest(accountId = "123", userId = "userId", sessionId = UUID.randomUUID(), userSignature = "user-signature")
+        val request = ActivityRequest(
+            accountId = "123",
+            appId = "appId",
+            userId = "userId",
+            sessionId = UUID.randomUUID(),
+            userSignature = "user-signature"
+        )
         val cacheItem = ActivityStorage(UUID.randomUUID(), "123", "userId", "data1", "user-signature-cache")
         coEvery { appcuesLocalSource.getAllActivity() } returns listOf(cacheItem)
 


### PR DESCRIPTION
adding app_id as a root property of the ActivityRequest, this is how the new request looks like:

```json
{
  "request_id": "a6e00d46-2343-4bf3-a131-396da3560fd4",
  "events": [ ... ],
  "profile_update": { ... },
  "user_id": "default-0000",
  "account_id": "103523",
  "app_id": "4b6b796f-1313-440a-b356-ee4b7abe931c",
  "session_id": "8f368e26-d3da-4b30-83c6-08df9d66d48a",
  "group_id": null,
  "source": "mobile"
}
```