### PR TITLE
⬆️  Update compose from 1.5 to 1.6

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -11,7 +11,7 @@ apply from: 'copy-dependencies.gradle'
 apply from: 'dokka.gradle'
 
 ext.room_version = '2.5.2'
-ext.compose_version = '1.6.0'
+ext.compose_version = '1.6.2'
 ext.compose_compiler_version = '1.4.8'
 ext.coil_version = '2.4.0'
 ext.moshi_version = '1.15.0'

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -11,7 +11,7 @@ apply from: 'copy-dependencies.gradle'
 apply from: 'dokka.gradle'
 
 ext.room_version = '2.5.2'
-ext.compose_version = '1.5.2'
+ext.compose_version = '1.6.0'
 ext.compose_compiler_version = '1.4.8'
 ext.coil_version = '2.4.0'
 ext.moshi_version = '1.15.0'
@@ -88,7 +88,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
-    implementation "com.google.android.material:material:1.9.0"
+    implementation "com.google.android.material:material:1.11.0"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"

--- a/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
+++ b/appcues/src/main/java/com/appcues/debugger/screencapture/AndroidTargetingStrategy.kt
@@ -208,9 +208,6 @@ private fun View.extractResourceName(): String? {
 }
 
 private fun SemanticsNode.asCaptureView(context: Context, screenBounds: Rect): ViewElement? {
-    val displayMetrics = context.resources.displayMetrics
-    val density = displayMetrics.density
-
     val bounds = unclippedGlobalBounds()
 
     // if the view is not currently in the screenshot image (scrolled away), ignore

--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -235,7 +235,7 @@ internal fun ComponentStyle.getTextStyle(context: Context, isDark: Boolean): Tex
         color = foregroundColor.getColor(isDark) ?: Color.Unspecified,
         fontSize = fontSize?.sp ?: TextUnit.Unspecified,
         lineHeight = lineHeight?.sp ?: TextUnit.Unspecified,
-        textAlign = getTextAlignment(),
+        textAlign = getTextAlignment() ?: TextAlign.Unspecified,
         fontFamily = getFontFamily(context),
         letterSpacing = letterSpacing?.sp ?: TextUnit.Unspecified,
         fontWeight = getFontWeight(),

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.trait.AppcuesContentAnimatedVisibility
@@ -75,6 +76,7 @@ internal fun BottomSheetModal(
                         .fillMaxHeight(height.value)
                         // default modal style modifiers
                         .modalStyle(style, isDark) { Modifier.sheetModifier(appcuesWindowInfo, isDark, it) },
+                    color = Color.Transparent,
                     content = {
                         content(
                             Modifier.fillMaxSize(),

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
@@ -111,7 +112,8 @@ internal fun DialogModal(
                     // default modal style modifiers
                     .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) }
                     // apply width AFTER any margin in modalStyle in line above
-                    .styleWidth(style)
+                    .styleWidth(style),
+                color = Color.Transparent,
             ) {
                 content(
                     Modifier,

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.trait.AppcuesContentAnimatedVisibility
 import com.appcues.ui.extensions.getPaddings
@@ -71,6 +72,7 @@ internal fun ExpandedBottomSheetModal(
                         .fillMaxHeight(height.value)
                         // default modal style modifiers
                         .modalStyle(style, isDark) { Modifier.sheetModifier(windowInfo, isDark, it) },
+                    color = Color.Transparent,
                     content = {
                         content(
                             Modifier.fillMaxSize(),

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -53,6 +53,7 @@ import com.appcues.ui.extensions.checkErrorStyle
 import com.appcues.ui.extensions.getColor
 import com.appcues.ui.extensions.getHorizontalAlignment
 import com.appcues.ui.extensions.styleBorder
+import com.appcues.ui.theme.LocalAppcuesColors
 
 @Composable
 internal fun OptionSelectPrimitive.Compose(modifier: Modifier) {
@@ -220,6 +221,7 @@ private fun ComponentSelectMode.Compose(
     errorTint: Color?,
     selectionToggled: () -> Unit,
 ) {
+    val colors = LocalAppcuesColors.current
     val selectedColor = optionSelectPrimitive.selectedColor.getColor(isSystemInDarkTheme())
     val unselectedColor = optionSelectPrimitive.unselectedColor.getColor(isSystemInDarkTheme())
     val accentColor = optionSelectPrimitive.accentColor.getColor(isSystemInDarkTheme())
@@ -231,8 +233,8 @@ private fun ComponentSelectMode.Compose(
                 onClick = selectionToggled,
                 colors = RadioButtonDefaults.colors(
                     // the builder should always send these values, but default to the theme like the standard default behavior
-                    selectedColor = selectedColor ?: MaterialTheme.colors.secondary,
-                    unselectedColor = errorTint ?: unselectedColor ?: MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                    selectedColor = selectedColor ?: colors.primary,
+                    unselectedColor = errorTint ?: unselectedColor ?: colors.onBackground,
                 )
             )
         }
@@ -242,9 +244,9 @@ private fun ComponentSelectMode.Compose(
                 onCheckedChange = { selectionToggled() },
                 colors = CheckboxDefaults.colors(
                     // the builder should always send these values, but default to the theme like the standard default behavior
-                    checkedColor = selectedColor ?: MaterialTheme.colors.secondary,
-                    uncheckedColor = errorTint ?: unselectedColor ?: MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
-                    checkmarkColor = accentColor ?: MaterialTheme.colors.surface,
+                    checkedColor = selectedColor ?: colors.primary,
+                    uncheckedColor = errorTint ?: unselectedColor ?: colors.onBackground.copy(alpha = 0.6f),
+                    checkmarkColor = accentColor ?: colors.primary,
                 )
             )
         }
@@ -283,7 +285,7 @@ private fun List<OptionSelectPrimitive.OptionItem>.ComposePicker(
                     .size(size = 20.dp),
                 contentDescription = null,
                 imageVector = ImageVector.vectorResource(id = R.drawable.appcues_ic_drop_down),
-                tint = accentColor ?: MaterialTheme.colors.secondary,
+                tint = accentColor ?: LocalAppcuesColors.current.secondary,
             )
         }
         // 2. the dropdown menu for selection that shows on expanded state

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.runtime.Composable

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -60,6 +60,7 @@ import com.appcues.ui.extensions.styleBackground
 import com.appcues.ui.extensions.styleBorder
 import com.appcues.ui.extensions.styleCorner
 import com.appcues.ui.extensions.styleShadow
+import com.appcues.ui.theme.LocalAppcuesColors
 import com.appcues.ui.utils.margin
 import kotlin.math.max
 
@@ -149,7 +150,7 @@ private fun TextInputPrimitive.getColors(isDark: Boolean) =
     TextFieldDefaults.textFieldColors(
         backgroundColor = Color.Transparent,
         // the builder should always send this value, but default to the theme like the standard default behavior
-        cursorColor = cursorColor?.getColor(isDark) ?: MaterialTheme.colors.primary,
+        cursorColor = cursorColor?.getColor(isDark) ?: LocalAppcuesColors.current.primary,
         focusedIndicatorColor = Color.Transparent,
         unfocusedIndicatorColor = Color.Transparent,
     )

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable

--- a/appcues/src/main/java/com/appcues/ui/theme/AppcuesExperienceTheme.kt
+++ b/appcues/src/main/java/com/appcues/ui/theme/AppcuesExperienceTheme.kt
@@ -2,10 +2,9 @@ package com.appcues.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.Colors
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
 /**
@@ -15,26 +14,45 @@ import androidx.compose.ui.graphics.Color
 internal fun AppcuesExperienceTheme(
     content: @Composable () -> Unit
 ) {
-    MaterialTheme(
-        colors = getColors(isSystemInDarkTheme()),
-        typography = MaterialTheme.typography,
-        shapes = MaterialTheme.shapes,
-        content = content,
-    )
+    val colors = if (isSystemInDarkTheme()) darkAppcuesColors() else lightAppcuesColors()
+    CompositionLocalProvider(value = LocalAppcuesColors provides colors) {
+        content()
+    }
 }
 
-private fun getColors(isDark: Boolean): Colors {
+/**
+ * CompositionLocal used to pass [Colors] down the tree.
+ *
+ */
+internal val LocalAppcuesColors = staticCompositionLocalOf { lightAppcuesColors() }
 
-    return if (isDark)
-        darkColors().copy(
-            background = Color.Transparent,
-            onBackground = Color.Transparent,
-            surface = Color.Transparent
-        )
-    else
-        lightColors().copy(
-            background = Color.Transparent,
-            onBackground = Color.Transparent,
-            surface = Color.Transparent
-        )
-}
+internal data class AppcuesColors(
+    val background: Color,
+    val onBackground: Color,
+    val primary: Color,
+    val secondary: Color,
+)
+
+private fun lightAppcuesColors(
+    background: Color = Color.White,
+    text: Color = Color.Black,
+    primary: Color = Color(0xFF5C5CFF),
+    secondary: Color = Color(0xFF2CB4FF),
+): AppcuesColors = AppcuesColors(
+    background = background,
+    onBackground = text,
+    primary = primary,
+    secondary = secondary,
+)
+
+private fun darkAppcuesColors(
+    background: Color = Color.Black,
+    text: Color = Color.White,
+    primary: Color = Color(0xFF5C5CFF),
+    secondary: Color = Color(0xFF2CB4FF),
+): AppcuesColors = AppcuesColors(
+    background = background,
+    onBackground = text,
+    primary = primary,
+    secondary = secondary,
+)

--- a/appcues/src/main/java/com/appcues/ui/theme/AppcuesExperienceTheme.kt
+++ b/appcues/src/main/java/com/appcues/ui/theme/AppcuesExperienceTheme.kt
@@ -2,10 +2,13 @@ package com.appcues.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.Colors
+import androidx.compose.material.LocalTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 
 /**
  * Official AppcuesTheme for all compositions
@@ -15,7 +18,10 @@ internal fun AppcuesExperienceTheme(
     content: @Composable () -> Unit
 ) {
     val colors = if (isSystemInDarkTheme()) darkAppcuesColors() else lightAppcuesColors()
-    CompositionLocalProvider(value = LocalAppcuesColors provides colors) {
+    CompositionLocalProvider(
+        LocalAppcuesColors provides colors,
+        LocalTextStyle provides getAppcuesTextStyle()
+    ) {
         content()
     }
 }
@@ -36,8 +42,8 @@ internal data class AppcuesColors(
 private fun lightAppcuesColors(
     background: Color = Color.White,
     text: Color = Color.Black,
-    primary: Color = Color(0xFF5C5CFF),
-    secondary: Color = Color(0xFF2CB4FF),
+    primary: Color = Color(color = 0xFF5C5CFF),
+    secondary: Color = Color(color = 0xFF2CB4FF),
 ): AppcuesColors = AppcuesColors(
     background = background,
     onBackground = text,
@@ -48,11 +54,18 @@ private fun lightAppcuesColors(
 private fun darkAppcuesColors(
     background: Color = Color.Black,
     text: Color = Color.White,
-    primary: Color = Color(0xFF5C5CFF),
-    secondary: Color = Color(0xFF2CB4FF),
+    primary: Color = Color(color = 0xFF5C5CFF),
+    secondary: Color = Color(color = 0xFF2CB4FF),
 ): AppcuesColors = AppcuesColors(
     background = background,
     onBackground = text,
     primary = primary,
     secondary = secondary,
+)
+
+@Composable
+private fun getAppcuesTextStyle() = LocalTextStyle.current.copy(
+    fontWeight = FontWeight.Normal,
+    fontSize = 16.sp,
+    letterSpacing = 0.5.sp
 )


### PR DESCRIPTION
Migrating from compose 1.5 to 1.6

it was necessary to remove the MaterialTheme since they constraint the line height to a proper font style, since we dynamically decide on the font size and possibly custom font height, using MaterialTheme as our overall theme is no longer an option.

* Pending to figure out if there is a way to minimize the differences in text display from the material theme and the standard theme.