### PR TITLE
✨ Adding option for packageNames in AppcuesConfig

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -90,6 +90,12 @@ public data class AppcuesConfig internal constructor(
      */
     var additionalAutoProperties: Map<String, Any> = emptyMap()
 
+    /**
+     * Optional property that allows for setting custom package list for fonts, mostly used when your fonts are stored in
+     * a different package than your main app (multi-module apps)
+     */
+    var packageNames: List<String> = arrayListOf()
+
     // internally used for ui test on debug variant
     internal var imageLoader: ImageLoader? = null
     internal var configApiBasePath: String? = null

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerModule.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerModule.kt
@@ -27,7 +27,7 @@ internal object DebuggerModule : AppcuesModule {
         }
 
         scoped {
-            DebuggerFontManager(context = get(), logcues = get())
+            DebuggerFontManager(appcuesConfig = get(), context = get(), logcues = get())
         }
 
         scoped { DebuggerLogMessageManager(get()) }

--- a/appcues/src/main/java/com/appcues/debugger/ui/ds/BoxComponents.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/ds/BoxComponents.kt
@@ -1,0 +1,47 @@
+package com.appcues.debugger.ui.ds
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.appcues.debugger.ui.theme.LocalAppcuesTheme
+
+@Composable
+internal fun InfoBox(modifier: Modifier = Modifier, text: String) {
+    val theme = LocalAppcuesTheme.current
+    Row(
+        modifier = Modifier
+            .then(modifier)
+            .padding(16.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .border(3.dp, theme.info.copy(alpha = 0.5f))
+            .background(theme.info),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            modifier = Modifier.padding(start = 8.dp),
+            imageVector = Icons.Outlined.Info,
+            contentDescription = "Info Box icon",
+            tint = theme.background
+        )
+        Text(
+            modifier = Modifier.padding(8.dp),
+            text = text,
+            color = theme.background,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Normal
+        )
+    }
+}

--- a/appcues/src/main/java/com/appcues/debugger/ui/fonts/DebuggerFontList.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/fonts/DebuggerFontList.kt
@@ -33,12 +33,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.appcues.R
-import com.appcues.R.string
 import com.appcues.debugger.DebuggerViewModel
 import com.appcues.debugger.model.DebuggerFontItem
 import com.appcues.debugger.ui.AppcuesSearchView
 import com.appcues.debugger.ui.ds.DividerItem
 import com.appcues.debugger.ui.ds.FloatingBackButton
+import com.appcues.debugger.ui.ds.InfoBox
 import com.appcues.debugger.ui.ds.TextHeader
 import com.appcues.debugger.ui.lazyColumnScrollIndicator
 import com.appcues.debugger.ui.shared.copyToClipboardAndToast
@@ -95,6 +95,8 @@ internal fun DebuggerFontList(
             fonts(appSpecificFontsFiltered.value)
         }
 
+        info(R.string.appcues_debugger_fonts_informative)
+
         if (systemFontsFiltered.value.any()) {
             sectionTitle(R.string.appcues_debugger_font_details_system_title)
             fonts(systemFontsFiltered.value)
@@ -144,7 +146,7 @@ private fun FontDetailsOverlay(
                 .padding(start = 60.dp, top = 12.dp, end = 8.dp),
             height = 40.dp,
             elevation = elevation.value,
-            hint = LocalContext.current.getString(string.appcues_debugger_font_details_hint),
+            hint = LocalContext.current.getString(R.string.appcues_debugger_font_details_hint),
             inputDelay = 300,
         ) { filter.value = it.lowercase() }
     }
@@ -156,6 +158,12 @@ private fun LazyListScope.sectionTitle(resId: Int) {
             modifier = Modifier.padding(start = 20.dp, top = 20.dp, bottom = 16.dp),
             text = LocalContext.current.getString(resId)
         )
+    }
+}
+
+private fun LazyListScope.info(resId: Int) {
+    item {
+        InfoBox(text = LocalContext.current.getString(resId))
     }
 }
 

--- a/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogDetails.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogDetails.kt
@@ -35,6 +35,7 @@ import com.appcues.logging.LogMessage
 import com.appcues.logging.LogType.DEBUG
 import com.appcues.logging.LogType.ERROR
 import com.appcues.logging.LogType.INFO
+import com.appcues.logging.LogType.WARNING
 
 private val firstVisibleItemOffsetThreshold = 56.dp
 
@@ -43,15 +44,17 @@ internal fun DebuggerLogDetails(message: LogMessage, navController: NavHostContr
     val scrollState = rememberScrollState()
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
+    val theme = LocalAppcuesTheme.current
     val color = when (message.type) {
-        INFO, DEBUG -> LocalAppcuesTheme.current.primary
-        ERROR -> LocalAppcuesTheme.current.error
+        INFO, DEBUG -> theme.primary
+        ERROR -> theme.error
+        WARNING -> theme.warning
     }
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(LocalAppcuesTheme.current.background)
+            .background(theme.background)
             .verticalScroll(scrollState)
             .padding(16.dp)
     ) {
@@ -66,7 +69,7 @@ internal fun DebuggerLogDetails(message: LogMessage, navController: NavHostContr
         ) {
             Text(
                 text = text,
-                color = LocalAppcuesTheme.current.link
+                color = theme.link
             )
         }
 

--- a/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogList.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/logs/DebuggerLogList.kt
@@ -38,6 +38,7 @@ import com.appcues.logging.LogMessage
 import com.appcues.logging.LogType.DEBUG
 import com.appcues.logging.LogType.ERROR
 import com.appcues.logging.LogType.INFO
+import com.appcues.logging.LogType.WARNING
 
 private val firstVisibleItemOffsetThreshold = 56.dp
 
@@ -97,9 +98,11 @@ private fun LazyItemScope.ListItem(index: Int, logMessage: LogMessage, onItemCli
                 .padding(vertical = 8.dp, horizontal = 20.dp),
             verticalArrangement = Arrangement.Center
         ) {
+            val theme = LocalAppcuesTheme.current
             val color = when (logMessage.type) {
-                INFO, DEBUG -> LocalAppcuesTheme.current.primary
-                ERROR -> LocalAppcuesTheme.current.error
+                INFO, DEBUG -> theme.primary
+                ERROR -> theme.error
+                WARNING -> theme.warning
             }
 
             Text(

--- a/appcues/src/main/java/com/appcues/logging/LogType.kt
+++ b/appcues/src/main/java/com/appcues/logging/LogType.kt
@@ -1,5 +1,5 @@
 package com.appcues.logging
 
 internal enum class LogType(val displayName: String) {
-    INFO("Info"), DEBUG("Debug"), ERROR("Error")
+    INFO("Info"), WARNING("Warning"), DEBUG("Debug"), ERROR("Error")
 }

--- a/appcues/src/main/java/com/appcues/logging/LogcatDestination.kt
+++ b/appcues/src/main/java/com/appcues/logging/LogcatDestination.kt
@@ -6,6 +6,7 @@ import com.appcues.LoggingLevel.NONE
 import com.appcues.logging.LogType.DEBUG
 import com.appcues.logging.LogType.ERROR
 import com.appcues.logging.LogType.INFO
+import com.appcues.logging.LogType.WARNING
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,12 +34,13 @@ internal class LogcatDestination(
     }
 
     private fun LogMessage.log() {
-        if (type == INFO) {
-            Log.i(TAG, message)
-        } else if (type == ERROR) {
-            Log.e(TAG, message)
-        } else if (type == DEBUG && level == LoggingLevel.DEBUG) {
-            Log.d(TAG, message)
+        when (type) {
+            INFO -> Log.i(TAG, message)
+            WARNING -> Log.w(TAG, message)
+            ERROR -> Log.e(TAG, message)
+            DEBUG -> if (level == LoggingLevel.DEBUG) {
+                Log.d(TAG, message)
+            }
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/logging/Logcues.kt
+++ b/appcues/src/main/java/com/appcues/logging/Logcues.kt
@@ -3,6 +3,7 @@ package com.appcues.logging
 import com.appcues.logging.LogType.DEBUG
 import com.appcues.logging.LogType.ERROR
 import com.appcues.logging.LogType.INFO
+import com.appcues.logging.LogType.WARNING
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -22,6 +23,10 @@ internal class Logcues(private val dispatcher: CoroutineDispatcher = Dispatchers
 
     fun info(message: String) {
         launch { _messageFlow.emit(LogMessage(message, INFO, Date())) }
+    }
+
+    fun warning(message: String) {
+        launch { _messageFlow.emit(LogMessage(message, WARNING, Date())) }
     }
 
     fun debug(message: String) {

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -33,6 +33,7 @@ internal fun AppcuesComposition(
     imageLoader: ImageLoader,
     logcues: Logcues,
     chromeClient: WebChromeClient,
+    packageNames: List<String>
 ) {
     // ensure to change some colors to match appropriate design for custom primitive blocks
     AppcuesExperienceTheme {
@@ -42,6 +43,7 @@ internal fun AppcuesComposition(
             LocalViewModel provides viewModel,
             LocalLogcues provides logcues,
             LocalChromeClient provides chromeClient,
+            LocalPackageNames provides packageNames,
             LocalAppcuesActionDelegate provides DefaultAppcuesActionsDelegate(viewModel),
             LocalAppcuesPaginationDelegate provides AppcuesPagination { viewModel.onPageChanged(it) },
             LocalExperienceCompositionState provides ExperienceCompositionState()

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -60,6 +60,8 @@ internal val LocalStackScope = compositionLocalOf { StackScope.COLUMN }
 
 internal val LocalChromeClient = compositionLocalOf { WebChromeClient() }
 
+internal val LocalPackageNames = compositionLocalOf { listOf<String>() }
+
 internal enum class StackScope {
     ROW, COLUMN
 }

--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -76,13 +76,13 @@ internal fun ComponentStyle.getFontFamily(): FontFamily? {
     val logcues = LocalLogcues.current
     LaunchedEffect(Unit) {
         if (fontName != null && fontFamily == null) {
-            logcues.error(
+            logcues.warning(
                 "Font \"$fontName\" not found. Make sure to place it in your main app " +
                     "package or in one of the provided packageNames during SDK initialization"
             )
         }
     }
-    
+
     return fontFamily
 }
 

--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -82,8 +82,7 @@ internal fun ComponentStyle.getFontFamily(): FontFamily? {
             )
         }
     }
-
-
+    
     return fontFamily
 }
 

--- a/appcues/src/main/java/com/appcues/ui/extensions/TextStyleExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/TextStyleExt.kt
@@ -1,6 +1,7 @@
 package com.appcues.ui.extensions
 
-import android.content.Context
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -12,33 +13,36 @@ import androidx.compose.ui.unit.sp
 import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentStyle
 
-internal fun TextStyle.applyStyle(style: ComponentStyle, context: Context, packageNames: List<String>, isDark: Boolean): TextStyle {
+@Composable
+internal fun TextStyle.applyStyle(style: ComponentStyle): TextStyle {
     return copy(
-        color = style.foregroundColor.getColor(isDark) ?: color,
+        color = style.foregroundColor.getColor(isSystemInDarkTheme()) ?: color,
         fontSize = style.fontSize?.sp ?: fontSize,
         lineHeight = style.lineHeight?.sp ?: lineHeight,
         textAlign = style.getTextAlignment() ?: textAlign,
-        fontFamily = style.getFontFamily(context, packageNames) ?: fontFamily,
+        fontFamily = style.getFontFamily() ?: fontFamily,
         letterSpacing = style.letterSpacing?.sp ?: letterSpacing,
         fontWeight = style.getFontWeight() ?: fontWeight,
     )
 }
 
-internal fun List<TextSpanPrimitive>.toAnnotatedString(context: Context, packageNames: List<String>, isDark: Boolean): AnnotatedString {
+@Composable
+internal fun List<TextSpanPrimitive>.toAnnotatedString(): AnnotatedString {
     return buildAnnotatedString {
         forEach {
-            withStyle(style = it.style.toSpanStyle(context, packageNames, isDark)) {
+            withStyle(style = it.style.toSpanStyle()) {
                 append(it.text)
             }
         }
     }
 }
 
-private fun ComponentStyle.toSpanStyle(context: Context, packageNames: List<String>, isDark: Boolean): SpanStyle {
+@Composable
+private fun ComponentStyle.toSpanStyle(): SpanStyle {
     return SpanStyle(
-        color = foregroundColor.getColor(isDark) ?: Color.Unspecified,
+        color = foregroundColor.getColor(isSystemInDarkTheme()) ?: Color.Unspecified,
         fontSize = fontSize?.sp ?: TextUnit.Unspecified,
-        fontFamily = getFontFamily(context, packageNames),
+        fontFamily = getFontFamily(),
         letterSpacing = letterSpacing?.sp ?: TextUnit.Unspecified,
         fontWeight = getFontWeight(),
     )

--- a/appcues/src/main/java/com/appcues/ui/extensions/TextStyleExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/TextStyleExt.kt
@@ -12,33 +12,33 @@ import androidx.compose.ui.unit.sp
 import com.appcues.data.model.ExperiencePrimitive.TextSpanPrimitive
 import com.appcues.data.model.styling.ComponentStyle
 
-internal fun TextStyle.applyStyle(style: ComponentStyle, context: Context, isDark: Boolean): TextStyle {
+internal fun TextStyle.applyStyle(style: ComponentStyle, context: Context, packageNames: List<String>, isDark: Boolean): TextStyle {
     return copy(
         color = style.foregroundColor.getColor(isDark) ?: color,
         fontSize = style.fontSize?.sp ?: fontSize,
         lineHeight = style.lineHeight?.sp ?: lineHeight,
         textAlign = style.getTextAlignment() ?: textAlign,
-        fontFamily = style.getFontFamily(context) ?: fontFamily,
+        fontFamily = style.getFontFamily(context, packageNames) ?: fontFamily,
         letterSpacing = style.letterSpacing?.sp ?: letterSpacing,
         fontWeight = style.getFontWeight() ?: fontWeight,
     )
 }
 
-internal fun List<TextSpanPrimitive>.toAnnotatedString(context: Context, isDark: Boolean): AnnotatedString {
+internal fun List<TextSpanPrimitive>.toAnnotatedString(context: Context, packageNames: List<String>, isDark: Boolean): AnnotatedString {
     return buildAnnotatedString {
         forEach {
-            withStyle(style = it.style.toSpanStyle(context, isDark)) {
+            withStyle(style = it.style.toSpanStyle(context, packageNames, isDark)) {
                 append(it.text)
             }
         }
     }
 }
 
-private fun ComponentStyle.toSpanStyle(context: Context, isDark: Boolean): SpanStyle {
+private fun ComponentStyle.toSpanStyle(context: Context, packageNames: List<String>, isDark: Boolean): SpanStyle {
     return SpanStyle(
         color = foregroundColor.getColor(isDark) ?: Color.Unspecified,
         fontSize = fontSize?.sp ?: TextUnit.Unspecified,
-        fontFamily = getFontFamily(context),
+        fontFamily = getFontFamily(context, packageNames),
         letterSpacing = letterSpacing?.sp ?: TextUnit.Unspecified,
         fontWeight = getFontWeight(),
     )

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
+import com.appcues.AppcuesConfig
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.action.ActionProcessor
 import com.appcues.data.model.Experience
@@ -37,6 +38,7 @@ internal abstract class ViewPresenter(
     private val coroutineScope: AppcuesCoroutineScope by inject()
     private val actionProcessor: ActionProcessor by inject()
     private val appcuesViewTreeOwner: AppcuesViewTreeOwner by inject()
+    private val appcuesConfig: AppcuesConfig by inject()
 
     private var viewModel: AppcuesViewModel? = null
     private var gestureListener: ShakeGestureListener? = null
@@ -108,6 +110,7 @@ internal abstract class ViewPresenter(
                             logcues = get(),
                             imageLoader = get(),
                             chromeClient = EmbedChromeClient(this),
+                            packageNames = appcuesConfig.packageNames
                         )
                     }
                 }

--- a/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.appcues.data.model.ExperiencePrimitive.BoxPrimitive
+import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.extensions.getBoxAlignment
 import com.appcues.ui.extensions.getTextStyle
 
@@ -16,7 +17,7 @@ internal fun BoxPrimitive.Compose(modifier: Modifier) {
         modifier = modifier,
         contentAlignment = style.getBoxAlignment(),
     ) {
-        ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
+        ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalPackageNames.current, isSystemInDarkTheme())) {
             items.forEach { it.Compose() }
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/BoxPrimitive.kt
@@ -1,13 +1,10 @@
 package com.appcues.ui.primitive
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import com.appcues.data.model.ExperiencePrimitive.BoxPrimitive
-import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.extensions.getBoxAlignment
 import com.appcues.ui.extensions.getTextStyle
 
@@ -17,7 +14,7 @@ internal fun BoxPrimitive.Compose(modifier: Modifier) {
         modifier = modifier,
         contentAlignment = style.getBoxAlignment(),
     ) {
-        ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalPackageNames.current, isSystemInDarkTheme())) {
+        ProvideTextStyle(style.getTextStyle()) {
             items.forEach { it.Compose() }
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import com.appcues.data.model.ExperiencePrimitive.ButtonPrimitive
 import com.appcues.data.model.styling.ComponentStyle
+import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.extensions.getBoxAlignment
 import com.appcues.ui.extensions.getTextStyle
 
@@ -20,7 +21,7 @@ internal fun ButtonPrimitive.Compose(modifier: Modifier) {
         modifier = modifier,
         color = Color.Transparent,
     ) {
-        ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
+        ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalPackageNames.current, isSystemInDarkTheme())) {
             Box(
                 contentAlignment = content.style.getBoxAlignment(),
                 modifier = Modifier.styleButtonContentWidth(style),

--- a/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ButtonPrimitive.kt
@@ -1,6 +1,5 @@
 package com.appcues.ui.primitive
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.ProvideTextStyle
@@ -8,10 +7,8 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import com.appcues.data.model.ExperiencePrimitive.ButtonPrimitive
 import com.appcues.data.model.styling.ComponentStyle
-import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.extensions.getBoxAlignment
 import com.appcues.ui.extensions.getTextStyle
 
@@ -21,7 +18,7 @@ internal fun ButtonPrimitive.Compose(modifier: Modifier) {
         modifier = modifier,
         color = Color.Transparent,
     ) {
-        ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalPackageNames.current, isSystemInDarkTheme())) {
+        ProvideTextStyle(style.getTextStyle()) {
             Box(
                 contentAlignment = content.style.getBoxAlignment(),
                 modifier = Modifier.styleButtonContentWidth(style),

--- a/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
@@ -21,6 +21,7 @@ import com.appcues.data.model.ExperiencePrimitive.SpacerPrimitive
 import com.appcues.data.model.styling.ComponentDistribution
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment
+import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.composables.LocalStackScope
 import com.appcues.ui.composables.StackScope
 import com.appcues.ui.extensions.getTextStyle
@@ -38,7 +39,7 @@ internal fun HorizontalStackPrimitive.Compose(modifier: Modifier) {
         verticalAlignment = verticalAlignment
     ) {
         CompositionLocalProvider(LocalStackScope provides StackScope.ROW) {
-            ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
+            ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalPackageNames.current, isSystemInDarkTheme())) {
                 items.forEach {
                     ItemBox(distribution = distribution, primitive = it, parentVerticalAlignment = verticalAlignment) {
                         it.Compose()

--- a/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/HorizontalStackPrimitive.kt
@@ -1,6 +1,5 @@
 package com.appcues.ui.primitive
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -14,14 +13,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import com.appcues.data.model.ExperiencePrimitive
 import com.appcues.data.model.ExperiencePrimitive.HorizontalStackPrimitive
 import com.appcues.data.model.ExperiencePrimitive.SpacerPrimitive
 import com.appcues.data.model.styling.ComponentDistribution
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignment
-import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.composables.LocalStackScope
 import com.appcues.ui.composables.StackScope
 import com.appcues.ui.extensions.getTextStyle
@@ -31,7 +28,6 @@ import com.appcues.util.eq
 
 @Composable
 internal fun HorizontalStackPrimitive.Compose(modifier: Modifier) {
-
     val verticalAlignment = style.getVerticalAlignment(CenterVertically)
     Row(
         modifier = modifier.height(IntrinsicSize.Min),
@@ -39,7 +35,7 @@ internal fun HorizontalStackPrimitive.Compose(modifier: Modifier) {
         verticalAlignment = verticalAlignment
     ) {
         CompositionLocalProvider(LocalStackScope provides StackScope.ROW) {
-            ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalPackageNames.current, isSystemInDarkTheme())) {
+            ProvideTextStyle(style.getTextStyle()) {
                 items.forEach {
                     ItemBox(distribution = distribution, primitive = it, parentVerticalAlignment = verticalAlignment) {
                         it.Compose()

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -48,6 +48,7 @@ import com.appcues.data.model.styling.ComponentDataType.TEXT
 import com.appcues.data.model.styling.ComponentDataType.URL
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.composables.LocalExperienceStepFormStateDelegate
+import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.extensions.applyStyle
 import com.appcues.ui.extensions.checkErrorStyle
 import com.appcues.ui.extensions.getColor
@@ -87,6 +88,7 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
     val textStyle = LocalTextStyle.current.applyStyle(
         style = textFieldStyle,
         context = LocalContext.current,
+        packageNames = LocalPackageNames.current,
         isDark = isDark,
     )
 

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextInputPrimitive.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -48,7 +47,6 @@ import com.appcues.data.model.styling.ComponentDataType.TEXT
 import com.appcues.data.model.styling.ComponentDataType.URL
 import com.appcues.data.model.styling.ComponentStyle
 import com.appcues.ui.composables.LocalExperienceStepFormStateDelegate
-import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.extensions.applyStyle
 import com.appcues.ui.extensions.checkErrorStyle
 import com.appcues.ui.extensions.getColor
@@ -75,7 +73,6 @@ private const val LINE_HEIGHT_MULTIPLIER = 1.3f
 // default top and bottom padding for a TextField
 private const val TEXT_INPUT_PADDING = 16.0
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun TextInputPrimitive.Compose(modifier: Modifier) {
 
@@ -85,12 +82,7 @@ internal fun TextInputPrimitive.Compose(modifier: Modifier) {
     val showError = formState.shouldShowError(this)
     val errorTint = if (showError) errorLabel?.style?.foregroundColor else null
     val isDark = isSystemInDarkTheme()
-    val textStyle = LocalTextStyle.current.applyStyle(
-        style = textFieldStyle,
-        context = LocalContext.current,
-        packageNames = LocalPackageNames.current,
-        isDark = isDark,
-    )
+    val textStyle = LocalTextStyle.current.applyStyle(textFieldStyle)
 
     // this avoids recalculating the label style unless the showError state changes
     val updatedLabel = remember(showError) {

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
@@ -1,6 +1,5 @@
 package com.appcues.ui.primitive
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -12,10 +11,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
-import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.extensions.applyStyle
 import com.appcues.ui.extensions.toAnnotatedString
 
@@ -23,10 +20,7 @@ private const val TEXT_SCALE_REDUCTION_INTERVAL = 0.9f
 
 @Composable
 internal fun TextPrimitive.Compose(modifier: Modifier) {
-    val isDark = isSystemInDarkTheme()
-    val context = LocalContext.current
-    val packageNames = LocalPackageNames.current
-    val style = LocalTextStyle.current.applyStyle(style, context, packageNames, isDark)
+    val style = LocalTextStyle.current.applyStyle(style)
 
     var resizedStyle by remember(style) { mutableStateOf(style) }
     var resizedSpans by remember(style) { mutableStateOf(spans) }
@@ -38,7 +32,7 @@ internal fun TextPrimitive.Compose(modifier: Modifier) {
             modifier = modifier
                 .clipToBounds()
                 .drawWithContent { if (readyToDraw) drawContent() },
-            text = resizedSpans.toAnnotatedString(context, packageNames, isDark),
+            text = resizedSpans.toAnnotatedString(),
             style = resizedStyle,
             overflow = TextOverflow.Ellipsis,
             onTextLayout = { textLayoutResult ->

--- a/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/TextPrimitive.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import com.appcues.data.model.ExperiencePrimitive.TextPrimitive
+import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.extensions.applyStyle
 import com.appcues.ui.extensions.toAnnotatedString
 
@@ -24,7 +25,8 @@ private const val TEXT_SCALE_REDUCTION_INTERVAL = 0.9f
 internal fun TextPrimitive.Compose(modifier: Modifier) {
     val isDark = isSystemInDarkTheme()
     val context = LocalContext.current
-    val style = LocalTextStyle.current.applyStyle(style, context, isDark)
+    val packageNames = LocalPackageNames.current
+    val style = LocalTextStyle.current.applyStyle(style, context, packageNames, isDark)
 
     var resizedStyle by remember(style) { mutableStateOf(style) }
     var resizedSpans by remember(style) { mutableStateOf(spans) }
@@ -36,7 +38,7 @@ internal fun TextPrimitive.Compose(modifier: Modifier) {
             modifier = modifier
                 .clipToBounds()
                 .drawWithContent { if (readyToDraw) drawContent() },
-            text = resizedSpans.toAnnotatedString(context, isDark),
+            text = resizedSpans.toAnnotatedString(context, packageNames, isDark),
             style = resizedStyle,
             overflow = TextOverflow.Ellipsis,
             onTextLayout = { textLayoutResult ->

--- a/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
@@ -1,6 +1,5 @@
 package com.appcues.ui.primitive
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.ProvideTextStyle
@@ -8,10 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.ExperiencePrimitive.VerticalStackPrimitive
-import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.composables.LocalStackScope
 import com.appcues.ui.composables.StackScope
 import com.appcues.ui.extensions.getHorizontalAlignment
@@ -25,7 +22,7 @@ internal fun VerticalStackPrimitive.Compose(modifier: Modifier) {
         verticalArrangement = Arrangement.spacedBy(spacing.dp, Alignment.CenterVertically)
     ) {
         CompositionLocalProvider(LocalStackScope provides StackScope.COLUMN) {
-            ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalPackageNames.current, isSystemInDarkTheme())) {
+            ProvideTextStyle(style.getTextStyle()) {
                 items.forEach {
                     it.Compose()
                 }

--- a/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/VerticalStackPrimitive.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.appcues.data.model.ExperiencePrimitive.VerticalStackPrimitive
+import com.appcues.ui.composables.LocalPackageNames
 import com.appcues.ui.composables.LocalStackScope
 import com.appcues.ui.composables.StackScope
 import com.appcues.ui.extensions.getHorizontalAlignment
@@ -24,7 +25,7 @@ internal fun VerticalStackPrimitive.Compose(modifier: Modifier) {
         verticalArrangement = Arrangement.spacedBy(spacing.dp, Alignment.CenterVertically)
     ) {
         CompositionLocalProvider(LocalStackScope provides StackScope.COLUMN) {
-            ProvideTextStyle(style.getTextStyle(LocalContext.current, isSystemInDarkTheme())) {
+            ProvideTextStyle(style.getTextStyle(LocalContext.current, LocalPackageNames.current, isSystemInDarkTheme())) {
                 items.forEach {
                     it.Compose()
                 }

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="appcues_debugger_item_title">%1$s: %2$s</string>
 
     <string name="appcues_debugger_clipboard_copy_message">Copied to clipboard</string>
+    <string name="appcues_debugger_fonts_informative">Not finding your font? please check if your app needs additional package names provided at SDK initialization.</string>
 
     <!-- Screen Capture Dialog -->
     <string name="appcues_screen_capture_dismiss">dismiss</string>

--- a/appcues/src/test/java/com/appcues/logging/LogcuesTest.kt
+++ b/appcues/src/test/java/com/appcues/logging/LogcuesTest.kt
@@ -23,6 +23,18 @@ internal class LogcuesTest {
     }
 
     @Test
+    fun `warning SHOULD emit warning message`() = runBlocking {
+        // WHEN
+        logcues.warning("message")
+        // THEN
+        logcues.messageFlow.test {
+            val log = awaitItem()
+            assertThat(log.type).isEqualTo(LogType.WARNING)
+            assertThat(log.message).isEqualTo("message")
+        }
+    }
+
+    @Test
     fun `debug SHOULD emit debug message`() = runBlocking {
         // WHEN
         logcues.debug("message")

--- a/docs/Fonts.md
+++ b/docs/Fonts.md
@@ -1,0 +1,25 @@
+# Finding and using fonts
+
+Appcues allows for customers to use system and custom fonts when rending flows. 
+
+## Overview
+
+Available fonts can be found using the Appcues debugger in the `Available fonts`, 
+in some cases in order for Appcues to find those fonts customer may need to provide extra configuration property.
+
+## How it works
+
+Appcues will look for fonts in `assets/fonts` and `res/fonts`. but when placing fonts in `res/fonts` the Android compiler will create an ID linking that font.
+
+Both during the scan (Debugger) or during usage in any flow, Appcues relies on the font name provided in the builder and it will try to find the corresponding font available in the app.
+
+## Multi-module apps or custom App ids
+
+One of the main issues with our approach is that those paths sometimes are tied to the appId (package) where the font is located, the only path we can automatically know is the one provided from `context.packageName`
+And placing a font in a different package makes it hard for the SDK to find it, this is the reason why we provide with a config option `AppcuesConfig.packageNames` that allows customer to provide the locations we should scan for fonts.
+
+```kotlin
+appcues = Appcues(this, APPCUES_ACCOUNT_ID, APPCUES_APPLICATION_ID) {
+    packageNames = listOf("com.appcues.samples.kotlin.module")
+}
+```

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/ExampleApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/ExampleApplication.kt
@@ -42,7 +42,6 @@ class ExampleApplication : Application() {
 
         appcues = Appcues(this, BuildConfig.APPCUES_ACCOUNT_ID, BuildConfig.APPCUES_APPLICATION_ID) {
             loggingLevel = if (BuildConfig.DEBUG) LoggingLevel.DEBUG else LoggingLevel.INFO
-            packageNames = listOf("com.appcues.samples.kotlin.module")
             navigationHandler = object : NavigationHandler {
                 // This is an example where we're processing navigation requests coming from Appcues experiences,
                 // but simply forwarding them on to start an Activity from an Intent with the given Uri. If an application

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/ExampleApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/ExampleApplication.kt
@@ -42,6 +42,7 @@ class ExampleApplication : Application() {
 
         appcues = Appcues(this, BuildConfig.APPCUES_ACCOUNT_ID, BuildConfig.APPCUES_APPLICATION_ID) {
             loggingLevel = if (BuildConfig.DEBUG) LoggingLevel.DEBUG else LoggingLevel.INFO
+            packageNames = listOf("com.appcues.samples.kotlin.module")
             navigationHandler = object : NavigationHandler {
                 // This is an example where we're processing navigation requests coming from Appcues experiences,
                 // but simply forwarding them on to start an Activity from an Intent with the given Uri. If an application


### PR DESCRIPTION
Adding the property packageNames that allows customers to set different paths when we look for fonts in res/fonts

* Adding to the debugger scan was easy and straight forward
* Adding to the composition (Text and Syles) on the other hand required a lot of change 
    -> Created `LocalPackageNames` 


Improving logging when font coming from builder is not found:
![image](https://github.com/appcues/appcues-android-sdk/assets/5244805/b3b5ad76-061f-44c6-8fd4-bbf2f2315de5)


also Adding informative block about missing fonts
![image](https://github.com/appcues/appcues-android-sdk/assets/5244805/869d9e97-38ed-4530-a260-70ba47e40f91)
