### PR TITLE
✨ Adding request-push action

### DIFF
--- a/appcues/src/main/AndroidManifest.xml
+++ b/appcues/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application>
@@ -11,12 +10,16 @@
             android:name=".ui.InAppReviewActivity"
             android:exported="false"
             android:theme="@style/Appcues.AppcuesActivityTheme" />
+        <activity
+            android:name=".ui.RequestPermissionActivity"
+            android:exported="false"
+            android:theme="@style/Appcues.AppcuesActivityTheme" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
             tools:node="merge">
-
             <meta-data
                 android:name="com.appcues.monitor.AppcuesInitializer"
                 android:value="androidx.startup" />

--- a/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
@@ -4,6 +4,7 @@ import com.appcues.action.appcues.CloseAction
 import com.appcues.action.appcues.ContinueAction
 import com.appcues.action.appcues.LaunchExperienceAction
 import com.appcues.action.appcues.LinkAction
+import com.appcues.action.appcues.RequestPushAction
 import com.appcues.action.appcues.RequestReviewAction
 import com.appcues.action.appcues.SubmitFormAction
 import com.appcues.action.appcues.TrackEventAction
@@ -34,6 +35,7 @@ internal class ActionRegistry(override val scope: AppcuesScope) : AppcuesCompone
         register(TrackEventAction.TYPE) { config, _ -> TrackEventAction(config, get()) }
         register(UpdateProfileAction.TYPE) { config, _ -> UpdateProfileAction(config, get(), get()) }
         register(RequestReviewAction.TYPE) { config, _ -> RequestReviewAction(config, get(), get()) }
+        register(RequestPushAction.TYPE) { config, _ -> RequestPushAction(config, get(), get()) }
     }
 
     operator fun get(key: String): ActionFactoryBlock? {

--- a/appcues/src/main/java/com/appcues/action/appcues/RequestPushAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/RequestPushAction.kt
@@ -1,0 +1,34 @@
+package com.appcues.action.appcues
+
+import android.content.Context
+import com.appcues.action.ExperienceAction
+import com.appcues.analytics.AnalyticsEvent
+import com.appcues.analytics.AnalyticsTracker
+import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.ui.RequestPermissionActivity
+import kotlinx.coroutines.CompletableDeferred
+
+internal class RequestPushAction(
+    override val config: AppcuesConfigMap,
+    private val context: Context,
+    private val analyticsTracker: AnalyticsTracker,
+) : ExperienceAction {
+
+    companion object {
+
+        const val TYPE = "@appcues/request-push"
+    }
+
+    override suspend fun execute() {
+        val completion = CompletableDeferred<Boolean>()
+        RequestPermissionActivity.completion = completion
+
+        // so passing in the actual string (matching the manifest value) ensures that this string exist in all versions of android
+        // since this key was limited by @RequiresApi(VERSION_CODES.TIRAMISU), in case its a invalid string nothing happens
+        context.startActivity(RequestPermissionActivity.getIntent(context, "android.permission.POST_NOTIFICATIONS"))
+
+        completion.await()
+
+        analyticsTracker.track(AnalyticsEvent.DeviceUpdated.eventName, properties = null, interactive = false, isInternal = true)
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/RequestPermissionActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/RequestPermissionActivity.kt
@@ -1,0 +1,96 @@
+package com.appcues.ui
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CompletableDeferred
+
+internal class RequestPermissionActivity : AppCompatActivity() {
+
+    companion object {
+
+        private const val EXTRA_PERMISSION_KEY = "EXTRA_PERMISSION"
+
+        // since there can only be one review activity running at a time, this companion level
+        // deferred can be used to await completion
+        var completion: CompletableDeferred<Boolean>? = null
+
+        fun getIntent(context: Context, permission: String): Intent = Intent(context, RequestPermissionActivity::class.java)
+            .apply {
+                putExtra(EXTRA_PERMISSION_KEY, permission)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+    }
+
+    private val permissionKey by lazy { intent.getStringExtra(EXTRA_PERMISSION_KEY)!! }
+
+    private val permissionLauncher = registerForActivityResult(RequestPermission()) {
+        completion?.complete(it)
+        finish()
+    }
+
+    private var settingsLauncher = registerForActivityResult(StartActivityForResult()) {
+        // check permission again and return the completion
+        val hasPermission = ContextCompat.checkSelfPermission(this, permissionKey) == PackageManager.PERMISSION_GRANTED
+        completion?.complete(hasPermission)
+        finish()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        // remove enter animation from this activity
+        if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
+        } else {
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+        }
+        super.onCreate(savedInstanceState)
+
+        val hasPermission = ContextCompat.checkSelfPermission(this, permissionKey)
+
+        when {
+            // first we check if the permission is already granted
+            hasPermission == PackageManager.PERMISSION_GRANTED -> {
+                completion?.complete(true)
+                finish()
+            }
+            // POST_NOTIFICATION did not exist before API 33, so instead we direct user to open the settings page
+            VERSION.SDK_INT < VERSION_CODES.TIRAMISU &&
+                permissionKey == Manifest.permission.POST_NOTIFICATIONS &&
+                !NotificationManagerCompat.from(this).areNotificationsEnabled() -> {
+                val intent = Intent().apply {
+                    action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                    data = Uri.fromParts("package", packageName, null)
+                }
+                settingsLauncher.launch(intent)
+            }
+            // Permission is denied, we try to launch the permission launcher,
+            // if user has already declined too many times it will instantly return false
+            hasPermission == PackageManager.PERMISSION_DENIED -> {
+                permissionLauncher.launch(permissionKey)
+            }
+        }
+    }
+
+    override fun finish() {
+        super.finish()
+        // remove exit animation from this activity
+        if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
+        } else {
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/ui/RequestPermissionActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/RequestPermissionActivity.kt
@@ -15,6 +15,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 internal class RequestPermissionActivity : AppCompatActivity() {
 
@@ -46,6 +51,8 @@ internal class RequestPermissionActivity : AppCompatActivity() {
         completion?.complete(hasPermission)
         finish()
     }
+
+    private var delayedJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // remove enter animation from this activity
@@ -81,6 +88,22 @@ internal class RequestPermissionActivity : AppCompatActivity() {
                 permissionLauncher.launch(permissionKey)
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        delayedJob = CoroutineScope(Dispatchers.Main).launch {
+            // if we get stuck in this activity for any reason we should exit
+            delay(timeMillis = 300)
+
+            completion?.complete(false)
+            finish()
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        delayedJob?.cancel()
     }
 
     override fun finish() {


### PR DESCRIPTION
Adding appcues/request-push action 

Creates a new transparent activity just so we can call permission request and listen to the return of the REQUEST_CODE, which is internally implemented by this new API `ActivityResultLauncher `