### PR TITLE
✨ Adding shortcut for settings when Push notification permission is not granted

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/model/DebuggerStatusItem.kt
+++ b/appcues/src/main/java/com/appcues/debugger/model/DebuggerStatusItem.kt
@@ -16,5 +16,6 @@ internal enum class StatusType {
 internal enum class TapActionType {
     HEALTH_CHECK,
     DEEPLINK_CHECK,
-    PUSH_CHECK
+    PUSH_CHECK,
+    OPEN_SETTINGS
 }


### PR DESCRIPTION
When verifying the push setup, if permission is not granted customer can tap on the same line and open settings page to give permission manually (this is done this one to avoid having to deal with different scenarios like permission denied forever, api level differences, etc)