### PR TITLE
♻️  Adding properties to push data & improve naming

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesFirebaseMessagingService.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesFirebaseMessagingService.kt
@@ -53,7 +53,7 @@ public class AppcuesFirebaseMessagingService : FirebaseMessagingService() {
             if (ActivityCompat.checkSelfPermission(context, permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED)
                 return false
 
-            val isCheckPush = data.test && data.id.startsWith("test-push")
+            val isCheckPush = data.test && data.notificationId.startsWith("test-push")
 
             context.getNotificationBuilder()
                 .setupNotification(message)
@@ -78,10 +78,12 @@ public class AppcuesFirebaseMessagingService : FirebaseMessagingService() {
 
     @JsonClass(generateAdapter = true)
     internal data class AppcuesMessagingData(
-        @Json(name = "notification_id")
-        val id: String,
         val title: String,
         val body: String,
+        @Json(name = "notification_id")
+        val notificationId: String,
+        @Json(name = "notification_version")
+        val notificationVersion: Long? = null,
         @Json(name = "account_id")
         val accountId: String,
         @Json(name = "app_id")
@@ -92,6 +94,8 @@ public class AppcuesFirebaseMessagingService : FirebaseMessagingService() {
         val workflowId: String?,
         @Json(name = "workflow_task_id")
         val workflowTaskId: String?,
+        @Json(name = "workflow_version")
+        val workflowVersion: Long? = null,
         @Json(name = "deep_link_url")
         val deeplink: String?,
         @Json(name = "attachment_url")
@@ -101,9 +105,9 @@ public class AppcuesFirebaseMessagingService : FirebaseMessagingService() {
         @Json(name = "category")
         val category: String?,
         @Json(name = "android_notification_id")
-        val notificationId: String?,
+        val androidNotificationId: String?,
         @Json(name = "test")
-        val test: Boolean = false,
+        val test: Boolean = false
     )
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {

--- a/appcues/src/main/java/com/appcues/util/NotificationBuilderExt.kt
+++ b/appcues/src/main/java/com/appcues/util/NotificationBuilderExt.kt
@@ -72,7 +72,7 @@ internal fun NotificationCompat.Builder.setStyle(context: Context, data: Appcues
 internal fun NotificationCompat.Builder.setIntent(context: Context, data: AppcuesMessagingData, isCheckPush: Boolean) = apply {
     val intent = if (isCheckPush) {
         // during testing we just want to validate that push message came through
-        DeepLinkHandler.getDebuggerValidationIntent(data.appId, data.id)
+        DeepLinkHandler.getDebuggerValidationIntent(data.appId, data.notificationId)
     } else {
         DeepLinkHandler.getNotificationIntent(data)
     }


### PR DESCRIPTION
including properties: `notification_version` and `workflow_version` as part of notification data model.

also whenever they are present we want to include both in the push_opened track.

+ Renaming `id` to `notificationId` and  old `notificationId` to `androidNotificationId` for clarification

