### PR TITLE
♻️  Storing deferred actions when processing notification deeplink in no-session run

### DIFF
--- a/appcues/src/main/java/com/appcues/SessionMonitor.kt
+++ b/appcues/src/main/java/com/appcues/SessionMonitor.kt
@@ -41,6 +41,14 @@ internal class SessionMonitor(
         }
     }
 
+    fun hasSession(): Boolean {
+        val isValid = sessionId != null || isExpired.not()
+
+        if (isValid) updateLastActivity()
+
+        return isValid
+    }
+
     fun startNewSession(): UUID? {
         if (storage.userId.isEmpty()) return null
 
@@ -56,7 +64,7 @@ internal class SessionMonitor(
         }
     }
 
-    fun updateLastActivity() {
+    private fun updateLastActivity() {
         lastActivityAt = Date()
     }
 

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
@@ -80,7 +80,7 @@ internal class AnalyticsTracker(
 
     // returns valid session id (existing or creating new) or null if unable to start one.
     private fun getSession(): UUID? {
-        if (sessionMonitor.sessionId == null || sessionMonitor.isExpired) {
+        if (!sessionMonitor.hasSession()) {
             // if no existing session, or expired, start a new one
             val sessionId = sessionMonitor.startNewSession() ?: return null
             // immediately track the session_started analytic, before any
@@ -90,9 +90,6 @@ internal class AnalyticsTracker(
             // use true for waitForBatch, as a session_started event created due to a new user identify() should
             // merge and send together in a single activity payload
             analyticsQueueProcessor.flushThenSend(activityRequest, true)
-        } else {
-            // we have a valid session, update its last activity timestamp to push out the timeout
-            sessionMonitor.updateLastActivity()
         }
 
         return sessionMonitor.sessionId

--- a/appcues/src/main/java/com/appcues/push/PushDeeplinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/push/PushDeeplinkHandler.kt
@@ -1,0 +1,102 @@
+package com.appcues.push
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import com.appcues.AppcuesCoroutineScope
+import com.appcues.AppcuesFirebaseMessagingService.AppcuesMessagingData
+import com.appcues.SessionMonitor
+import com.appcues.Storage
+import com.appcues.data.PushRepository
+import com.appcues.di.component.AppcuesComponent
+import com.appcues.di.component.inject
+import com.appcues.di.scope.AppcuesScope
+import com.appcues.di.scope.inject
+import kotlinx.coroutines.launch
+
+internal class PushDeeplinkHandler(
+    override val scope: AppcuesScope,
+) : AppcuesComponent {
+
+    companion object {
+
+        private const val NOTIFICATION_ID_EXTRA = "ID"
+        private const val NOTIFICATION_VERSION_EXTRA = "VERSION"
+        private const val NOTIFICATION_SHOW_CONTENT_EXTRA = "SHOW_CONTENT"
+        private const val NOTIFICATION_TEST_EXTRA = "TEST"
+        private const val NOTIFICATION_WORKFLOW_ID_EXTRA = "WORKFLOW_ID"
+        private const val NOTIFICATION_WORKFLOW_TASK_ID_EXTRA = "WORKFLOW_TASK_ID"
+        private const val NOTIFICATION_WORKFLOW_VERSION_EXTRA = "WORKFLOW_VERSION"
+        private const val NOTIFICATION_FORWARD_DEEPLINK_EXTRA = "FORWARD_DEEPLINK"
+
+        fun getNotificationIntent(appcuesData: AppcuesMessagingData) = Intent(Intent.ACTION_VIEW).apply {
+            data = Uri.parse("appcues-${appcuesData.appId}://sdk/notification")
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+
+            putExtra(NOTIFICATION_ID_EXTRA, appcuesData.notificationId)
+            putExtra(NOTIFICATION_VERSION_EXTRA, appcuesData.notificationVersion)
+            putExtra(NOTIFICATION_WORKFLOW_ID_EXTRA, appcuesData.workflowId)
+            putExtra(NOTIFICATION_WORKFLOW_TASK_ID_EXTRA, appcuesData.workflowTaskId)
+            putExtra(NOTIFICATION_WORKFLOW_VERSION_EXTRA, appcuesData.workflowVersion)
+            putExtra(NOTIFICATION_FORWARD_DEEPLINK_EXTRA, appcuesData.deeplink)
+            putExtra(NOTIFICATION_SHOW_CONTENT_EXTRA, appcuesData.experienceId)
+            putExtra(NOTIFICATION_TEST_EXTRA, appcuesData.test)
+        }
+    }
+
+    private val sessionMonitor by inject<SessionMonitor>()
+    private val pushOpenedProcessor by inject<PushOpenedProcessor>()
+    private val coroutineScope by scope.inject<AppcuesCoroutineScope>()
+    private val storage by inject<Storage>()
+    private val pushRepository by scope.inject<PushRepository>()
+
+    fun processLink(segments: List<String>, extras: Bundle?, query: Map<String, String>): Boolean {
+        return when {
+            segments.any() && segments[0] == "notification" && extras != null -> {
+                processNotification(extras)
+                true
+            }
+            segments.count() == 2 && segments[0] == "push_preview" -> {
+                processPreviewPush(segments[1], query)
+                true
+            }
+            segments.count() == 2 && segments[0] == "push_content" -> {
+                processShowPush(segments[1])
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun processNotification(extras: Bundle) {
+        if (extras.getBoolean(NOTIFICATION_TEST_EXTRA, false)) return
+
+        val properties = mapOf<String, Any?>(
+            "notification_id" to extras.getString(NOTIFICATION_ID_EXTRA, null),
+            "push_notification_version" to extras.getLong(NOTIFICATION_VERSION_EXTRA, -1L).let { if (it == -1L) null else it },
+            "workflow_id" to extras.getString(NOTIFICATION_WORKFLOW_ID_EXTRA, null),
+            "workflow_task_id" to extras.getString(NOTIFICATION_WORKFLOW_TASK_ID_EXTRA, null),
+            "workflow_version" to extras.getLong(NOTIFICATION_WORKFLOW_VERSION_EXTRA, -1L).let { if (it == -1L) null else it },
+            "device_id" to storage.deviceId
+        ).filterValues { it != null }.mapValues { it.value as Any }
+
+        val deeplink = extras.getString(NOTIFICATION_FORWARD_DEEPLINK_EXTRA, null)
+        val experienceId = extras.getString(NOTIFICATION_SHOW_CONTENT_EXTRA, null)
+
+        val action = PushOpenedAction(storage.userId, properties, deeplink, experienceId)
+
+        if (sessionMonitor.hasSession()) {
+            coroutineScope.launch { pushOpenedProcessor.process(action) }
+        } else {
+            pushOpenedProcessor.defer(action)
+        }
+    }
+
+    private fun processPreviewPush(id: String, query: Map<String, String>) {
+        coroutineScope.launch { pushRepository.preview(id, query) }
+    }
+
+    private fun processShowPush(id: String) {
+        coroutineScope.launch { pushRepository.send(id) }
+    }
+}

--- a/appcues/src/main/java/com/appcues/push/PushOpenedAction.kt
+++ b/appcues/src/main/java/com/appcues/push/PushOpenedAction.kt
@@ -1,0 +1,13 @@
+package com.appcues.push
+
+import com.appcues.analytics.AnalyticsEvent.PushOpened
+
+internal data class PushOpenedAction(
+    val userId: String,
+    val eventProperties: Map<String, Any>?,
+    val deeplink: String?,
+    val experienceId: String?,
+) {
+
+    val eventName = PushOpened.eventName
+}

--- a/appcues/src/main/java/com/appcues/push/PushOpenedProcessor.kt
+++ b/appcues/src/main/java/com/appcues/push/PushOpenedProcessor.kt
@@ -1,0 +1,58 @@
+package com.appcues.push
+
+import android.content.ActivityNotFoundException
+import android.net.Uri
+import com.appcues.Appcues
+import com.appcues.analytics.AnalyticsTracker
+import com.appcues.data.model.ExperienceTrigger.DeepLink
+import com.appcues.di.component.AppcuesComponent
+import com.appcues.di.component.inject
+import com.appcues.di.scope.AppcuesScope
+import com.appcues.di.scope.inject
+import com.appcues.logging.Logcues
+import com.appcues.ui.ExperienceRenderer
+import com.appcues.util.LinkOpener
+
+internal class PushOpenedProcessor(
+    override val scope: AppcuesScope,
+) : AppcuesComponent {
+
+    private val analyticsTracker by inject<AnalyticsTracker>()
+    private val experienceRenderer by scope.inject<ExperienceRenderer>()
+    private val linkOpener by scope.inject<LinkOpener>()
+    private val appcues by scope.inject<Appcues>()
+    private val logcues by scope.inject<Logcues>()
+
+    private var deferredAction: PushOpenedAction? = null
+
+    fun defer(action: PushOpenedAction) {
+        deferredAction = action
+    }
+
+    suspend fun processDeferred(userId: String) {
+        deferredAction?.let {
+            if (it.userId == userId) process(it)
+        }
+
+        deferredAction = null
+    }
+
+    suspend fun process(pushAction: PushOpenedAction) {
+        analyticsTracker.track(pushAction.eventName, pushAction.eventProperties, interactive = false, isInternal = true)
+
+        pushAction.deeplink?.let {
+            val uri = Uri.parse(it)
+            try {
+                // this will handle any in-app deep link scheme URLs OR any web urls that were
+                // requested to open into the external browser application
+                appcues.navigationHandler?.navigateTo(uri) ?: linkOpener.startNewIntent(uri)
+            } catch (exception: ActivityNotFoundException) {
+                logcues.error("Unable to process deep link $it\n\n Reason: ${exception.message}")
+            }
+        }
+
+        pushAction.experienceId?.let {
+            experienceRenderer.show(it, DeepLink, mapOf())
+        }
+    }
+}

--- a/appcues/src/main/java/com/appcues/util/NotificationBuilderExt.kt
+++ b/appcues/src/main/java/com/appcues/util/NotificationBuilderExt.kt
@@ -16,6 +16,7 @@ import com.appcues.AppcuesFirebaseMessagingService
 import com.appcues.AppcuesFirebaseMessagingService.AppcuesMessagingData
 import com.appcues.DeepLinkHandler
 import com.appcues.R
+import com.appcues.push.PushDeeplinkHandler
 import com.google.firebase.messaging.RemoteMessage
 import java.io.InputStream
 import java.net.HttpURLConnection
@@ -74,7 +75,7 @@ internal fun NotificationCompat.Builder.setIntent(context: Context, data: Appcue
         // during testing we just want to validate that push message came through
         DeepLinkHandler.getDebuggerValidationIntent(data.appId, data.notificationId)
     } else {
-        DeepLinkHandler.getNotificationIntent(data)
+        PushDeeplinkHandler.getNotificationIntent(data)
     }
 
     setContentIntent(PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE))


### PR DESCRIPTION
First pass of this task. here we are storing in Room table the deferred actions (currently Track, Deeplink and ShowContent) when we see that sessionMonitor has no active session, else we run those normally.


+ Separated some piece of DeeplinkHandler for clarity and to solve some detekt warnings (Complex methods)

This is the big chunk, want to make sure this makes sense before moving forward, the idea here is that we will be storing deferred actions based on appId and userId (to account for different sessions and multi-instances of appcues),

and then later we are going to implement the other piece which after the identify we will see if there is any elements in that list and run those, also clear those elements from the list afterwards.