### PR TITLE
♻️  Processing deferred notification actions during identify call

### DIFF
--- a/appcues/src/main/java/com/appcues/MainModule.kt
+++ b/appcues/src/main/java/com/appcues/MainModule.kt
@@ -9,6 +9,8 @@ import com.appcues.di.AppcuesModule
 import com.appcues.di.scope.AppcuesScopeDSL
 import com.appcues.logging.LogcatDestination
 import com.appcues.logging.Logcues
+import com.appcues.push.PushDeeplinkHandler
+import com.appcues.push.PushOpenedProcessor
 import com.appcues.statemachine.StateMachine
 import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
@@ -30,6 +32,8 @@ internal object MainModule : AppcuesModule {
         scoped { LogcatDestination(get(), get<AppcuesConfig>().loggingLevel) }
         scoped { Storage(context = get(), config = get()) }
         scoped { DeepLinkHandler(scope = scope) }
+        scoped { PushDeeplinkHandler(scope) }
+        scoped { PushOpenedProcessor(scope) }
         scoped { AppcuesDebuggerManager(appcuesViewTreeOwner = get(), contextWrapper = get(), scope = scope) }
         scoped { StateMachineDirectory() }
         scoped { ExperienceRenderer(scope = scope) }

--- a/appcues/src/main/java/com/appcues/SessionMonitor.kt
+++ b/appcues/src/main/java/com/appcues/SessionMonitor.kt
@@ -27,7 +27,7 @@ internal class SessionMonitor(
     val sessionId: UUID?
         get() = _sessionId
 
-    val isExpired: Boolean
+    private val isExpired: Boolean
         get() = lastActivityAt?.let {
             TimeUnit.MILLISECONDS.toSeconds(Date().time - it.time) >= sessionTimeout
         } ?: false
@@ -42,7 +42,7 @@ internal class SessionMonitor(
     }
 
     fun hasSession(): Boolean {
-        val isValid = sessionId != null || isExpired.not()
+        val isValid = sessionId != null && isExpired.not()
 
         if (isValid) updateLastActivity()
 

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
@@ -52,7 +52,7 @@ internal class AnalyticsTrackerExtTest {
     fun `track internal event SHOULD update analyticsFlow with internal event`() {
         // given
         every { sessionMonitor.sessionId } returns UUID.randomUUID()
-        every { sessionMonitor.isExpired } returns false
+        every { sessionMonitor.hasSession() } returns true
         val activity: ActivityRequest = mockk(relaxed = true)
         every { activityBuilder.track(any(), any()) } returns activity
         // when
@@ -70,7 +70,7 @@ internal class AnalyticsTrackerExtTest {
         val sessionId = UUID.randomUUID()
         every { activityBuilder.track(sessionId, any(), any()) } returns activity
         every { sessionMonitor.sessionId } returns sessionId
-        every { sessionMonitor.isExpired } returns false
+        every { sessionMonitor.hasSession() } returns true
         val experiment = Experiment(
             id = UUID.fromString("06f9bf87-1921-4919-be55-429b278bf578"),
             group = "control",

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
@@ -63,13 +63,13 @@ internal class AnalyticsTrackerTest {
         // given
         val sessionId = UUID.randomUUID()
         every { sessionMonitor.sessionId } returns sessionId
-        every { sessionMonitor.startNewSession() } returns sessionId
+        every { sessionMonitor.hasSession() } returns true
         val activity: ActivityRequest = mockk(relaxed = true)
         every { activityBuilder.identify(any()) } returns activity
         // when
         analyticsTracker.identify()
         // then
-        verify { sessionMonitor.updateLastActivity() }
+        verify { sessionMonitor.hasSession() }
         assertThat(analyticsFlowUpdates).hasSize(1)
         verify { analyticsQueueProcessor.flushThenSend(activity, true) }
         assertThat(analyticsFlowUpdates.first().type).isEqualTo(AnalyticType.IDENTIFY)
@@ -93,13 +93,13 @@ internal class AnalyticsTrackerTest {
         // given
         val sessionId = UUID.randomUUID()
         every { sessionMonitor.sessionId } returns sessionId
-        every { sessionMonitor.isExpired } returns false
+        every { sessionMonitor.hasSession() } returns true
         val activity: ActivityRequest = mockk(relaxed = true)
         every { activityBuilder.track(sessionId, any()) } returns activity
         // when
         analyticsTracker.track("event1", interactive = true)
         // then
-        verify { sessionMonitor.updateLastActivity() }
+        verify { sessionMonitor.hasSession() }
         assertThat(analyticsFlowUpdates).hasSize(1)
         verify { analyticsQueueProcessor.queueThenFlush(activity) }
         assertThat(analyticsFlowUpdates.first().type).isEqualTo(AnalyticType.EVENT)
@@ -112,13 +112,13 @@ internal class AnalyticsTrackerTest {
         // given
         val sessionId = UUID.randomUUID()
         every { sessionMonitor.sessionId } returns sessionId
-        every { sessionMonitor.isExpired } returns false
+        every { sessionMonitor.hasSession() } returns true
         val activity: ActivityRequest = mockk(relaxed = true)
         every { activityBuilder.track(sessionId, any()) } returns activity
         // when
         analyticsTracker.track("event1", interactive = false)
         // then
-        verify { sessionMonitor.updateLastActivity() }
+        verify { sessionMonitor.hasSession() }
         assertThat(analyticsFlowUpdates).hasSize(1)
         verify { analyticsQueueProcessor.queue(activity) }
         assertThat(analyticsFlowUpdates.first().type).isEqualTo(AnalyticType.EVENT)
@@ -142,13 +142,13 @@ internal class AnalyticsTrackerTest {
         // given
         val sessionId = UUID.randomUUID()
         every { sessionMonitor.sessionId } returns sessionId
-        every { sessionMonitor.isExpired } returns false
+        every { sessionMonitor.hasSession() } returns true
         val activity: ActivityRequest = mockk(relaxed = true)
         every { activityBuilder.screen(sessionId, any()) } returns activity
         // when
         analyticsTracker.screen("title")
         // then
-        verify { sessionMonitor.updateLastActivity() }
+        verify { sessionMonitor.hasSession() }
         assertThat(analyticsFlowUpdates).hasSize(1)
         verify { analyticsQueueProcessor.queueThenFlush(activity) }
         assertThat(analyticsFlowUpdates.first().type).isEqualTo(AnalyticType.SCREEN)
@@ -172,13 +172,13 @@ internal class AnalyticsTrackerTest {
         // given
         val sessionId = UUID.randomUUID()
         every { sessionMonitor.sessionId } returns sessionId
-        every { sessionMonitor.isExpired } returns false
+        every { sessionMonitor.hasSession() } returns true
         val activity: ActivityRequest = mockk(relaxed = true)
         every { activityBuilder.group(sessionId) } returns activity
         // when
         analyticsTracker.group()
         // then
-        verify { sessionMonitor.updateLastActivity() }
+        verify { sessionMonitor.hasSession() }
         assertThat(analyticsFlowUpdates).hasSize(1)
         verify { analyticsQueueProcessor.flushThenSend(activity) }
         assertThat(analyticsFlowUpdates.first().type).isEqualTo(AnalyticType.GROUP)

--- a/appcues/src/test/java/com/appcues/rules/TestScopeRule.kt
+++ b/appcues/src/test/java/com/appcues/rules/TestScopeRule.kt
@@ -18,6 +18,8 @@ import com.appcues.di.scope.AppcuesScopeDSL
 import com.appcues.logging.LogcatDestination
 import com.appcues.logging.Logcues
 import com.appcues.mocks.storageMockk
+import com.appcues.push.PushDeeplinkHandler
+import com.appcues.push.PushOpenedProcessor
 import com.appcues.statemachine.StateMachine
 import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
@@ -47,6 +49,8 @@ internal class TestScopeRule : TestWatcher() {
                         scoped { mockk<TraitRegistry>(relaxed = true) }
                         scoped { mockk<ActionRegistry>(relaxed = true) }
                         scoped { mockk<DeepLinkHandler>(relaxed = true) }
+                        scoped { mockk<PushDeeplinkHandler>(relaxed = true) }
+                        scoped { mockk<PushOpenedProcessor>(relaxed = true) }
                         scoped { mockk<StateMachine>(relaxed = true) }
                         scoped { mockk<LinkOpener>(relaxed = true) }
                         scoped { storageMockk() }


### PR DESCRIPTION
Last piece for this task, consuming deferred action for given userId during the identify call, similarly to whats done on iOS [here](https://github.com/appcues/appcues-ios-sdk/blob/sdk4/Sources/AppcuesKit/Appcues.swift#L404)


* Minor changes to adjust unit tests.