### PR TITLE
Make Codecov more lenient about small drops in coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,9 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # https://docs.codecov.com/docs/commit-status#threshold
+        # Allow the coverage to drop by 0.5%, and keep a success status
+        threshold: 0.5%


### PR DESCRIPTION
targeting `main` (we can then rebase `sdk4`). Noticed a failure on a `-0.02%` drop recently.

same update made on iOS side a while back in https://github.com/appcues/appcues-ios-sdk/commit/b9a342e5dfc3235ac1f8fe0061bd14f3b67a6bcb