### PR TITLE
♻️  Adding new push verification check for the manifest.xml

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -44,7 +44,7 @@ internal class AutoPropertyDecorator(
     private var applicationProperties = hashMapOf<String, Any>(
         "_appId" to config.applicationId,
         "_operatingSystem" to "Android",
-        "_bundlePackageId" to contextWrapper.getPackageName(),
+        "_bundlePackageId" to contextWrapper.packageName,
         "_appName" to contextWrapper.getAppName(),
         "_appVersion" to contextWrapper.getAppVersion(),
         "_appBuild" to contextWrapper.getAppBuild().toString(),

--- a/appcues/src/main/java/com/appcues/data/remote/customerapi/CustomerApiRemoteSource.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/customerapi/CustomerApiRemoteSource.kt
@@ -81,7 +81,7 @@ internal class CustomerApiRemoteSource(
             deviceHeight = size.height,
             deviceOrientation = contextWrapper.orientation,
             deviceType = contextWrapper.getString(R.string.appcues_device_type),
-            bundlePackageId = contextWrapper.getPackageName(),
+            bundlePackageId = contextWrapper.packageName,
             sdkVersion = BuildConfig.SDK_VERSION,
             sdkName = "appcues-android",
             osName = "android",

--- a/appcues/src/main/java/com/appcues/util/ContextWrapper.kt
+++ b/appcues/src/main/java/com/appcues/util/ContextWrapper.kt
@@ -8,7 +8,6 @@ import android.content.res.Configuration
 import android.os.Build
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
-import android.util.DisplayMetrics
 import androidx.annotation.StringRes
 import androidx.core.app.NotificationManagerCompat
 import java.util.Locale
@@ -21,10 +20,14 @@ import java.util.Locale
  */
 internal class ContextWrapper(private val context: Context) {
 
-    val displayMetrics: DisplayMetrics
-        get() = context.resources.displayMetrics
     val orientation: String
         get() = if (context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) "landscape" else "portrait"
+
+    val packageManager: PackageManager
+        get() = context.packageManager
+
+    val packageName: String
+        get() = context.packageName
 
     fun getApplication(): Application = context.applicationContext as Application
 
@@ -58,10 +61,6 @@ internal class ContextWrapper(private val context: Context) {
             return Build.MODEL.capitalize()
         }
         return Build.MANUFACTURER.capitalize() + " " + Build.MODEL
-    }
-
-    fun getPackageName(): String = with(context) {
-        packageName
     }
 
     fun getLanguage(): String {

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -34,10 +34,11 @@
     <string name="appcues_debugger_status_check_push_title">Appcues Push</string>
     <string name="appcues_debugger_status_check_push_instruction">Tap to check configuration</string>
     <string name="appcues_debugger_status_check_push_loading_instruction">Tap on the test notification in system tray</string>
-    <string name="appcues_debugger_status_check_push_error_no_token">Error 1: No Push token registered with Appcues</string>
+    <string name="appcues_debugger_status_check_push_manifest_not_set">Error 1: Service not set in AndroidManifest.xml</string>
     <string name="appcues_debugger_status_check_push_error_no_permission">Error 2: Notification permission required. Tap to enable through settings</string>
-    <string name="appcues_debugger_status_check_push_error_ignored">Error 3: Notification dismissed or ignored after 30 seconds</string>
+    <string name="appcues_debugger_status_check_push_error_no_token">Error 3: No Push token registered with Appcues</string>
     <string name="appcues_debugger_status_check_push_unknown_server_error">Error 4: Unknown Server error</string>
+    <string name="appcues_debugger_status_check_push_error_ignored">Error 5: Notification dismissed or ignored after 30 seconds</string>
     <string name="appcues_debugger_status_check_push_server_error">Server Error: %1$s</string>
     <string name="appcues_debugger_status_check_push_error_sever_error">Error 500: Server Error</string>
     <string name="appcues_debugger_status_check_screen_tracking_title">Tracking Screens</string>


### PR DESCRIPTION
Adding extra check that verifies that there is a Service filtered by the firebase messaging Action.

if there is another one not the default FirebaseMessagingService it means they are either using Appcues's or a custom one (which is what we want)

+ Re-ordered existing error messages to match the sequence they are being checked.