### PR TITLE
🔧 Update circle config to use static android version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ orbs:
 # -------------------------
 executors:
   android_compatible:
-    machine: 
-      image: android:default
+    machine:
+      image: android:2024.01.1
     resource_class: large
     working_directory: ~/code
 
@@ -68,12 +68,12 @@ commands:
           command: ./checksum.sh /tmp/checksum.txt
       - restore_cache:
           name: Restore Gradle cache
-          key: gradle-{{ checksum "/tmp/checksum.txt" }}
+          key: 1-gradle-{{ checksum "/tmp/checksum.txt" }}
   save_gradle_cache:
     description: 'Save Gradle cache'
     steps:
       - save_cache:
-          key: gradle-{{ checksum "/tmp/checksum.txt" }}
+          key: 1-gradle-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle/caches
             - ~/.gradle/wrapper


### PR DESCRIPTION
matching the change from SDK4 branch [here](https://github.com/appcues/appcues-android-sdk/pull/613/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R30), circleci will use static android version for now (avoid weird errors when there is a new version)