### PR TITLE
Check for push enabled status changes while app is not active

### DIFF
--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -311,7 +311,7 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
         if (token != storage.pushToken) {
             storage.pushToken = token
 
-            analyticsTracker.track(AnalyticsEvent.DeviceUpdated.eventName, properties = null, interactive = false, isInternal = true)
+            analyticsTracker.track(AnalyticsEvent.DeviceUpdated.eventName, properties = null, interactive = true, isInternal = true)
         }
     }
 
@@ -379,7 +379,7 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
             // session but this is a way to force an update of any device props that may have changed outside of the SDK
             // i.e. push permission.
             // this is interactive=true so it gets batched together with the identify in a single request
-            analyticsTracker.track(AnalyticsEvent.DeviceUpdated.eventName, isInternal = true)
+            analyticsTracker.track(AnalyticsEvent.DeviceUpdated.eventName, properties = null, interactive = true, isInternal = true)
         }
 
         // whenever user identifies we check to see if there is a pending push open action matching the userId,

--- a/appcues/src/main/java/com/appcues/action/appcues/RequestPushAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/RequestPushAction.kt
@@ -29,6 +29,6 @@ internal class RequestPushAction(
 
         completion.await()
 
-        analyticsTracker.track(AnalyticsEvent.DeviceUpdated.eventName, properties = null, interactive = false, isInternal = true)
+        analyticsTracker.track(AnalyticsEvent.DeviceUpdated.eventName, properties = null, interactive = true, isInternal = true)
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -61,7 +61,7 @@ internal class AutoPropertyDecorator(
             "_language" to contextWrapper.getLanguage(),
             "_pushToken" to storage.pushToken,
             "_pushEnabledBackground" to (storage.pushToken != null),
-            "_pushEnabled" to contextWrapper.isNotificationEnabled()
+            "_pushEnabled" to (contextWrapper.isNotificationEnabled() && !storage.pushToken.isNullOrEmpty())
             // token information on comes later on future task
             // "_pushSubscriptionStatus" to “subscribed”, “opted-in”, “unsubscribed”
         )


### PR DESCRIPTION
I put this in `SessionMonitor`, piggybacking on some lifecycle observation already there, as a simple add-on. This could also be moved into its own class if you feel like it shouldn't mix in with the SessionMonitor like this. I thought it was simple enough to put here, but also take no issue if preference is to not do that.