### PR TITLE
✨ Adding delay action

### DIFF
--- a/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionRegistry.kt
@@ -2,6 +2,7 @@ package com.appcues.action
 
 import com.appcues.action.appcues.CloseAction
 import com.appcues.action.appcues.ContinueAction
+import com.appcues.action.appcues.DelayAction
 import com.appcues.action.appcues.LaunchExperienceAction
 import com.appcues.action.appcues.LinkAction
 import com.appcues.action.appcues.RequestReviewAction
@@ -34,6 +35,7 @@ internal class ActionRegistry(override val scope: AppcuesScope) : AppcuesCompone
         register(TrackEventAction.TYPE) { config, _ -> TrackEventAction(config, get()) }
         register(UpdateProfileAction.TYPE) { config, _ -> UpdateProfileAction(config, get(), get()) }
         register(RequestReviewAction.TYPE) { config, _ -> RequestReviewAction(config, get(), get()) }
+        register(DelayAction.TYPE) { config, _ -> DelayAction(config) }
     }
 
     operator fun get(key: String): ActionFactoryBlock? {

--- a/appcues/src/main/java/com/appcues/action/appcues/DelayAction.kt
+++ b/appcues/src/main/java/com/appcues/action/appcues/DelayAction.kt
@@ -1,0 +1,22 @@
+package com.appcues.action.appcues
+
+import com.appcues.action.ExperienceAction
+import com.appcues.data.model.AppcuesConfigMap
+import com.appcues.data.model.getConfigOrDefault
+import kotlinx.coroutines.delay
+
+internal class DelayAction(
+    override val config: AppcuesConfigMap,
+) : ExperienceAction {
+
+    companion object {
+
+        const val TYPE = "@appcues/delay"
+    }
+
+    private val duration = config.getConfigOrDefault("duration", 0)
+
+    override suspend fun execute() {
+        delay(duration.toLong())
+    }
+}

--- a/appcues/src/test/java/com/appcues/action/appcues/DelayActionTest.kt
+++ b/appcues/src/test/java/com/appcues/action/appcues/DelayActionTest.kt
@@ -1,0 +1,52 @@
+package com.appcues.action.appcues
+
+import com.appcues.AppcuesScopeTest
+import com.appcues.rules.TestScopeRule
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTime
+
+@ExperimentalTime
+internal class DelayActionTest : AppcuesScopeTest {
+
+    @get:Rule
+    override val scopeRule = TestScopeRule()
+
+    @Test
+    fun `close SHOULD have expected type name`() {
+        assertThat(DelayAction.TYPE).isEqualTo("@appcues/delay")
+    }
+
+    @Test
+    fun `delay SHOULD call delay with given value of 300ms `() = runTest {
+        // GIVEN
+        val action = DelayAction(mapOf("duration" to 300))
+
+        launch {
+            val workDuration = testScheduler.timeSource.measureTime {
+                // WHEN
+                action.execute()
+            }
+            assertThat(workDuration).isEqualTo(300.milliseconds)
+        }
+    }
+
+    @Test
+    fun `delay SHOULD call delay with given value of 1000ms `() = runTest {
+        // GIVEN
+        val action = DelayAction(mapOf("duration" to 1000))
+
+        launch {
+            val workDuration = testScheduler.timeSource.measureTime {
+                // WHEN
+                action.execute()
+            }
+            assertThat(workDuration).isEqualTo(1000.milliseconds)
+        }
+    }
+}


### PR DESCRIPTION
Adding support for the new @appcues/delay action:

```json
{
  "on": "navigate",
  "type": "@appcues/delay",
  "config": {
    "duration": 3000
  }
}
```
