### PR TITLE
:arrow_up: Update compose to use bom, side effects include updating k…

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
     id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
 }
 
 apply from: 'artifacts-android.gradle'
@@ -11,10 +12,13 @@ apply from: 'copy-dependencies.gradle'
 apply from: 'dokka.gradle'
 
 ext.room_version = '2.5.2'
-ext.compose_version = '1.6.2'
-ext.compose_compiler_version = '1.4.8'
+ext.compose_compiler_version = '1.5.14'
 ext.coil_version = '2.4.0'
 ext.moshi_version = '1.15.0'
+
+ksp {
+    arg('room.schemaLocation', "$projectDir/schemas")
+}
 
 android {
     compileSdk 34
@@ -29,12 +33,6 @@ android {
         testApplicationId = "com.appcues.test"
 
         consumerProguardFiles "consumer-rules.pro"
-
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
-            }
-        }
     }
 
     resourcePrefix 'appcues_'
@@ -83,16 +81,17 @@ dependencies {
     implementation "androidx.browser:browser:1.6.0"
     implementation "androidx.startup:startup-runtime:1.1.1"
     implementation "androidx.navigation:navigation-compose:2.7.3"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    implementation platform('androidx.compose:compose-bom:2024.06.00')
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-test-manifest"
     implementation "com.google.android.material:material:1.11.0"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
     implementation "androidx.savedstate:savedstate:1.2.1"
     // Image Loader
     implementation "io.coil-kt:coil-compose:$coil_version"
@@ -106,7 +105,7 @@ dependencies {
     implementation "com.squareup.moshi:moshi:$moshi_version"
     implementation "com.squareup.moshi:moshi-adapters:$moshi_version"
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
+    ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
     // Play In-App Review
     implementation 'com.google.android.play:review:2.0.1'
     implementation 'com.google.android.play:review-ktx:2.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24"
         classpath "org.jetbrains.dokka:kotlin-as-java-plugin:1.8.20"
     }
 }
@@ -13,6 +13,7 @@ buildscript {
 plugins {
     id "io.gitlab.arturbosch.detekt" version "1.21.0"
     id "org.jetbrains.dokka" version "1.8.20"
+    id "com.google.devtools.ksp" version "1.9.24-1.0.20" apply false
 }
 
 allprojects {


### PR DESCRIPTION
Update Compose to 1.6.8 and use bill of materials to handle versioning. In order to do this, Kotlin also need to be updated to 1.9.24. In order to update Kotlin, ksp needed to be used for Room instead of kapt 😄. I also updated Moshi to use ksp since kapt is deprecated.