### PR TITLE
🐛 fix state machine when another activity is started on top

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/states/EndingStepState.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/states/EndingStepState.kt
@@ -15,7 +15,7 @@ import com.appcues.statemachine.effects.PresentationEffect
 // send to the state machine once it's done dismissing the current container
 // the presence of a non-null value is what tells the UI to dismiss the current container,
 // and it should be set to null if a dismiss is not requested (i.e. moving to next step in same container)
-// also when awaitDismissEffect is not null it means that when we take StartStep we want to present a new container
+// also when awaitDismissEffect is not null it means that ui/view presenter will remove the container from parentView
 internal data class EndingStepState(
     val experience: Experience,
     val flatStepIndex: Int,

--- a/appcues/src/main/java/com/appcues/statemachine/states/RenderingStepState.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/states/RenderingStepState.kt
@@ -90,18 +90,20 @@ internal data class RenderingStepState(
     }
 
     private fun toEndingExperience(action: EndExperience): Transition {
+        // passing in the effect on EndingStepState to ensure the UI will dismiss
+        // even though we might not be waiting for the completion before moving to
+        // the next step.
+        val awaitDismissEffect = AwaitDismissEffect(action)
         return if (action.destroyed) {
             // this means the activity hosting the experience was destroyed externally (i.e. deep link) and we should
             // immediately transition to EndingExperience - not rely on the UI to do it for us (it's gone)
-            next(EndingStepState(experience, flatStepIndex, action.markComplete, null), ContinuationEffect(action))
+            next(EndingStepState(experience, flatStepIndex, action.markComplete, awaitDismissEffect), ContinuationEffect(action))
         } else {
             // otherwise, its a natural end of experience from an in-experience action / dismiss
             // and should be communicated to the UI layer to dismiss itself.
             //
             // instead of using sideEffect we pass EndExperience on EndingStep
             // then AppcuesViewModel will continue to EndExperience when appropriate
-            val awaitDismissEffect = AwaitDismissEffect(action)
-
             next(EndingStepState(experience, flatStepIndex, action.markComplete, awaitDismissEffect), awaitDismissEffect)
         }
     }

--- a/appcues/src/test/java/com/appcues/statemachine/states/RenderingStepStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/RenderingStepStateTest.kt
@@ -58,7 +58,8 @@ internal class RenderingStepStateTest {
         // WHEN
         val transition = state.take(action)
         // THEN
-        transition.assertState(EndingStepState(experience, flatStepIndex, markComplete, null))
+        val awaitDismissEffect = AwaitDismissEffect(action)
+        transition.assertState(EndingStepState(experience, flatStepIndex, markComplete, awaitDismissEffect))
         transition.assertEffect(ContinuationEffect(action))
     }
 


### PR DESCRIPTION
Reported by a customer in [#mobile-support ](https://appcues.slack.com/archives/C03JYPH1NJZ/p1724931068889339) it looks like an oversight on our part for some of the possible outcomes from creating an overlay activity on top of an existing activity that was presenting an experience.

changes: 

* When transitioning from [RenderingStep to EndingExperience](https://github.com/appcues/appcues-android-sdk/compare/fix/overlay_view_experience?expand=1#diff-9a2951280d6c94900b1fb1c73e24089e62d7f593ef819d695183f858be5a74cdR92) we will always pass in the AwaitDismissEffect to ensure that it will always fire up a new ui state in AppcuesViewModel.

*  Since the reported issue was this error message `java.lang.IllegalStateException: Method removeObserver must be called on the main thread` when [removing](https://github.com/appcues/appcues-android-sdk/compare/fix/overlay_view_experience?expand=1#diff-eed3d6c94ac3b8e438725716643f71dd0a8e01f23818b047709860a6be149b15R131) the view we will ensure to do all the processing from the main thread

* In some scenarios when there is another activity on top the view was not properly getting removed, this is because when we call "getParentView" we are looking for the topMost decorView available, when multiple activities are in display we can get a different decorView from the first one we got when its time to do cleanup, to avoid this we are storing the view that was used to show the experience.
