### PR TITLE
Update Compose and some other dependencies

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -10,11 +10,11 @@ apply from: 'publish-maven.gradle'
 apply from: 'copy-dependencies.gradle'
 apply from: 'dokka.gradle'
 
-ext.room_version = '2.5.2'
-ext.compose_version = '1.6.2'
+ext.room_version = '2.6.1'
+ext.compose_version = '1.7.2'
 ext.compose_compiler_version = '1.4.8'
-ext.coil_version = '2.4.0'
-ext.moshi_version = '1.15.0'
+ext.coil_version = '2.7.0'
+ext.moshi_version = '1.15.1'
 
 android {
     compileSdk 34
@@ -78,18 +78,20 @@ android {
 
 dependencies {
     // Androidx
-    implementation "androidx.core:core-ktx:1.12.0"
-    implementation 'androidx.activity:activity-compose:1.7.2'
-    implementation "androidx.browser:browser:1.6.0"
-    implementation "androidx.startup:startup-runtime:1.1.1"
-    implementation "androidx.navigation:navigation-compose:2.7.3"
+    implementation "androidx.core:core-ktx:1.13.1"
+    implementation 'androidx.activity:activity-compose:1.9.2'
+    implementation "androidx.browser:browser:1.8.0"
+    implementation "androidx.startup:startup-runtime:1.2.0"
+    implementation "androidx.navigation:navigation-compose:2.8.1"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
-    implementation "com.google.android.material:material:1.11.0"
+    implementation "com.google.android.material:material:1.12.0"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.8.6'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
@@ -111,7 +113,7 @@ dependencies {
     implementation 'com.google.android.play:review:2.0.1'
     implementation 'com.google.android.play:review-ktx:2.0.1'
     // Messaging
-    implementation "com.google.firebase:firebase-messaging-ktx:23.4.1"
+    implementation "com.google.firebase:firebase-messaging-ktx:24.0.1"
     // Animation
     implementation 'nl.dionsegijn:konfetti-compose:2.0.4'
 
@@ -119,7 +121,7 @@ dependencies {
     testImplementation "io.mockk:mockk:1.13.5"
     testImplementation "com.google.truth:truth:1.1.5"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
     testImplementation 'app.cash.turbine:turbine:1.0.0'
 }

--- a/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/CaptureConfirmDialog.kt
@@ -19,14 +19,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.derivedStateOf
@@ -45,14 +44,15 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -104,7 +104,7 @@ private fun Header(debuggerViewModel: DebuggerViewModel) {
                     onClick = { debuggerViewModel.closeExpandedView() },
                     role = Role.Button,
                     interactionSource = remember { MutableInteractionSource() },
-                    indication = rememberRipple(bounded = false, 24.dp),
+                    indication = ripple(bounded = false, 24.dp),
                     onClickLabel = stringResource(id = string.appcues_screen_capture_dismiss)
                 )
                 .drawBehind {
@@ -225,22 +225,22 @@ private fun CaptureContents(debuggerViewModel: DebuggerViewModel, capture: Captu
 
 @Composable
 private fun TextWebLink(text: String, @Suppress("SameParameterValue") url: String) {
-    val uriHandler = LocalUriHandler.current
-    ClickableText(
+    Text(
         modifier = Modifier.fillMaxWidth(),
         text = buildAnnotatedString {
-            append(text)
-            addStyle(
-                style = SpanStyle(
-                    color = LocalAppcuesTheme.current.link,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Medium,
-                ),
-                start = 0,
-                end = text.length
-            )
-        },
-        onClick = { uriHandler.openUri(url) }
+            withLink(LinkAnnotation.Url(url = url)) {
+                append(text)
+                addStyle(
+                    style = SpanStyle(
+                        color = LocalAppcuesTheme.current.link,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                    ),
+                    start = 0,
+                    end = text.length
+                )
+            }
+        }
     )
 }
 

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerComposition.kt
@@ -15,12 +15,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.Event
 import androidx.lifecycle.Lifecycle.Event.ON_ANY
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.appcues.debugger.DebugMode.Debugger
 import com.appcues.debugger.DebugMode.ScreenCapture
 import com.appcues.debugger.DebuggerViewModel

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionButton.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionButton.kt
@@ -18,7 +18,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -157,7 +157,7 @@ private fun Modifier.clickableAndDraggable(
         Modifier
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
-                indication = rememberRipple(),
+                indication = ripple(),
                 onClickLabel = onClickLabel,
                 role = Role.Button,
                 onClick = onClick

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionEvents.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerFloatingActionEvents.kt
@@ -122,7 +122,7 @@ private fun LazyItemScope.Item(event: DebuggerEventItem, isAnchoredStart: Boolea
                 .clip(RoundedCornerShape(6.dp))
                 .background(theme.background)
                 .padding(2.dp)
-                .animateItemPlacement(),
+                .animateItem(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {

--- a/appcues/src/main/java/com/appcues/trait/appcues/CarouselTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/CarouselTrait.kt
@@ -1,6 +1,5 @@
 package com.appcues.trait.appcues
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.pager.HorizontalPager
@@ -31,7 +30,6 @@ internal class CarouselTrait(
         const val TYPE = "@appcues/carousel"
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
     @Composable
     override fun BoxScope.CreateContentHolder(containerPages: ContainerPages) {
         val pagerState = rememberPagerState(
@@ -117,8 +115,7 @@ internal class CarouselTrait(
         }
     }
 
-    @ExperimentalFoundationApi
-    private class HorizontalPagerSize constructor(private val pagerState: PagerState) {
+    private class HorizontalPagerSize(private val pagerState: PagerState) {
 
         val heightMap = mutableStateMapOf<Int, Int>()
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -301,7 +301,7 @@ internal class SkippableTrait(
                     },
                     role = Role.Button,
                     interactionSource = remember { MutableInteractionSource() },
-                    indication = rememberRipple(bounded = false, radius = rippleRadius.dp),
+                    indication = ripple(bounded = false, radius = rippleRadius.dp),
                     onClickLabel = stringResource(id = R.string.appcues_skippable_trait_dismiss)
                 )
             }

--- a/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/extensions/StyleComponentExt.kt
@@ -29,11 +29,12 @@ import com.appcues.data.model.styling.ComponentStyle.ComponentHorizontalAlignmen
 import com.appcues.data.model.styling.ComponentStyle.ComponentVerticalAlignment
 import com.appcues.ui.composables.LocalLogcues
 import com.appcues.ui.composables.LocalPackageNames
+import com.appcues.ui.utils.MarginValues
 import java.io.File
 
 internal fun ComponentStyle?.getMargins(defaultValue: Dp = 0.dp): PaddingValues {
-    return if (this == null) PaddingValues(defaultValue) else
-        PaddingValues(
+    return if (this == null) MarginValues(defaultValue) else
+        MarginValues(
             start = marginLeading?.dp ?: defaultValue,
             top = marginTop?.dp ?: defaultValue,
             bottom = marginBottom?.dp ?: defaultValue,

--- a/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/ExperiencePrimitive.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -49,7 +49,7 @@ internal fun ExperiencePrimitive.Compose(matchParentBox: BoxScope? = null, modif
                     actionsDelegate = LocalAppcuesActionDelegate.current,
                     actions = LocalAppcuesActions.current,
                     interactionSource = remember { MutableInteractionSource() },
-                    indication = rememberRipple(),
+                    indication = ripple(),
                     enabled = remember { true },
                     role = getRole()
                 ),

--- a/appcues/src/main/java/com/appcues/ui/utils/AppcuesMargins.kt
+++ b/appcues/src/main/java/com/appcues/ui/utils/AppcuesMargins.kt
@@ -11,8 +11,11 @@ import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.InspectorValueInfo
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.offset
 
 @Stable
@@ -59,4 +62,54 @@ private class MarginValuesModifier(
         val otherModifier = other as? MarginValuesModifier ?: return false
         return paddingValues == otherModifier.paddingValues
     }
+}
+
+// This is a copy/paste of the standard PaddingValuesImpl from compose foundation, but without
+// the restriction against negative values, as we allow negative margins and handle that above
+// in our MarginValuesModifier. Prior to Compose 1.7 we still used the standard PaddingValuesImpl,
+// but in Compose 1.7 they added checks that throw exceptions if negative values are used, so
+// we need our own.
+//
+// This implementation still implements the same PaddingValues interface, so there is minimal impact to
+// existing call sites.
+//
+// the change to check negative values was in this update:
+// https://android-review.googlesource.com/c/platform/frameworks/support/+/3021136/3/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/Padding.kt
+@Stable
+@Suppress("FunctionNaming") // matching Compose naming for PaddingValues here
+internal fun MarginValues(all: Dp): PaddingValues = MarginValues(all, all, all, all)
+
+internal class MarginValues(
+    @Stable
+    val start: Dp = 0.dp,
+    @Stable
+    val top: Dp = 0.dp,
+    @Stable
+    val end: Dp = 0.dp,
+    @Stable
+    val bottom: Dp = 0.dp
+) : PaddingValues {
+
+    override fun calculateLeftPadding(layoutDirection: LayoutDirection) =
+        if (layoutDirection == LayoutDirection.Ltr) start else end
+
+    override fun calculateTopPadding() = top
+
+    override fun calculateRightPadding(layoutDirection: LayoutDirection) =
+        if (layoutDirection == LayoutDirection.Ltr) end else start
+
+    override fun calculateBottomPadding() = bottom
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is MarginValues) return false
+        return start == other.start &&
+            top == other.top &&
+            end == other.end &&
+            bottom == other.bottom
+    }
+
+    override fun hashCode() =
+        ((start.hashCode() * 31 + top.hashCode()) * 31 + end.hashCode()) * 31 + bottom.hashCode()
+
+    override fun toString() = "MarginValues(start=$start, top=$top, end=$end, bottom=$bottom)"
 }

--- a/appcues/src/test/java/com/appcues/data/model/ExperienceTest.kt
+++ b/appcues/src/test/java/com/appcues/data/model/ExperienceTest.kt
@@ -82,7 +82,6 @@ internal class ExperienceTest {
     @Test
     fun `areStepsFromDifferentGroup SHOULD return true WHEN step 0 and step 1 are from different group`() {
         // GIVEN
-        val id = UUID.randomUUID()
         val stepContainer1 = getStepContainer(steps = arrayListOf(getStep()))
         val stepContainer2 = getStepContainer(steps = arrayListOf(getStep()))
         val experience = getExperience(listOf(stepContainer1, stepContainer2))
@@ -95,7 +94,6 @@ internal class ExperienceTest {
     @Test
     fun `areStepsFromDifferentGroup SHOULD return false WHEN step 0 and step 1 are from the same group`() {
         // GIVEN
-        val id = UUID.randomUUID()
         val stepContainer1 = getStepContainer(steps = arrayListOf(getStep(), getStep()))
         val stepContainer2 = getStepContainer(steps = arrayListOf())
         val experience = getExperience(listOf(stepContainer1, stepContainer2))

--- a/appcues/src/test/java/com/appcues/statemachine/effects/PresentationEffectTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/effects/PresentationEffectTest.kt
@@ -19,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -181,6 +182,7 @@ internal class PresentationEffectTest {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `launch SHOULD retry produceMetadata 3 times after 4 seconds WHEN shouldPresent AND produceMetadata throws`() = runTest {
         // GIVEN

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -57,12 +57,12 @@ android {
 dependencies {
     implementation project(":appcues")
 
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.3'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.7.3'
-    implementation 'com.google.firebase:firebase-messaging-ktx:23.4.1'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.8.1'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.8.1'
+    implementation 'com.google.firebase:firebase-messaging-ktx:24.0.1'
 }
 
 tasks.register('versionTxt') {

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/MainActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onNewIntent(intent: Intent?) {
+    override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleLinkIntent(intent)
     }


### PR DESCRIPTION
These are the updates I think are needed for Compose 1.7+ to work, plus misc other version updates to bring up to latest. This appears to have no cascading effects on the Kotlin version (due to staying on same Compose Compiler version 1.4.8) or on anything like Android targetSdk - so, I think rather safe for rolling out across our platforms, but that is what I'll be testing next.

Without this update, any app that begins using Compose 1.7 will hit a crash at runtime with an error like:
```
java.lang.NoSuchMethodError: No static method HorizontalPager-xYaah8o(Landroidx/compose/foundation/pager/PagerState;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/pager/PageSize;IFLandroidx/compose/ui/Alignment$Vertical;Landroidx/compose/foundation/gestures/snapping/SnapFlingBehavior;ZZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/input/nestedscroll/NestedScrollConnection;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;III)V in class Landroidx/compose/foundation/pager/PagerKt; or its super classes (declaration of 'androidx.compose.foundation.pager.PagerKt' appears in /data/app/~~klOqzmhdPE9hWF1ejvR47g==/com.appcues.samples.kotlin-N61GjtIaKqkxVkXcboelvw==/base.apk)
```

This appears to be due to the change in 1.7.0 noted [here](https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.7.0-alpha02), where `HorizontalPager` was promoted to stable. Thus, something in how this loads at runtime was changed (I'm not sure exactly what) due to [these](https://android-review.googlesource.com/c/platform/frameworks/support/+/2888286/5/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt) changes, even though the actual API itself appears unchanged. 

There are some other deprecations, some of which were errors that also needed code changes to make the Compose upgrade, and those are included here.
