### PR TITLE
Fix embed background color not applying

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/EmbedTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/EmbedTrait.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.getConfigOrDefault
@@ -84,6 +85,7 @@ internal class EmbedTrait(
                         .fillMaxWidth()
                         // Embeds works well using the modifier set for modal (presentationStyle = dialog) for now.
                         .modalStyle(style, isDark) { Modifier.dialogModifier(it, isDark) },
+                    color = Color.Transparent,
                     content = {
                         content(
                             Modifier,


### PR DESCRIPTION
Discovered that we were not handling background color on embeds correctly.

It looks like the Compose 1.5 -> 1.6 update a while back required a change in the code for this, and most of those were handled in this PR like https://github.com/appcues/appcues-android-sdk/pull/562/files#diff-afc24a72ab4ac5516ef5e46774a4ca3ea80

Full screen modal got missed, and fixed in https://github.com/appcues/appcues-android-sdk/pull/591

This should be the final related fix.