### PR TITLE
Fix logic for allowing back press to skip experience

### DIFF
--- a/appcues/src/main/java/com/appcues/data/model/Experience.kt
+++ b/appcues/src/main/java/com/appcues/data/model/Experience.kt
@@ -86,7 +86,7 @@ internal data class Experience(
     }
 
     fun isSkippable(flatStepIndex: Int): Boolean {
-        return getStepOrThrow(flatStepIndex).backdropDecoratingTraits.any { it is SkippableTrait }
+        return getStepOrThrow(flatStepIndex).backdropDecoratingTraits.any { it is SkippableTrait && it.skipOnBackPressed }
     }
 
     private fun getStepOrThrow(flatStepIndex: Int): Step {

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -108,6 +108,9 @@ internal class SkippableTrait(
         else -> ButtonAppearance.DEFAULT
     }
 
+    val skipOnBackPressed: Boolean
+        get() = !ignoreBackdropTap
+
     // computed style props
 
     private val buttonWidth by lazy { buttonStyle?.width ?: buttonStyle?.height ?: BUTTON_DEFAULT_SIZE }


### PR DESCRIPTION
When a modal 'close x` is toggled off in the builder, it does not actually remove the `@appcues/skippable` trait, but rather, sets the config properties

```json
{
    "config": {
        "buttonAppearance": "hidden",
        "ignoreBackdropTap": true
    },
    "type": "@appcues/skippable"
}
```

We had previously used the existence or not of this trait to determine if an experience was skippable, for the purposes of back button/gesture handling. Instead, we now only allow skippable behavior if the trait exists (same as before) AND if the `ignoreBackdropTap` is `false` -- truly set to skippable in the builder.