### PR TITLE
Disambiguate function for navigating debugger pages

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerPanel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerPanel.kt
@@ -98,7 +98,7 @@ internal sealed class DebuggerPages(val path: String, val parent: DebuggerPages?
     object ExpandedLogDetailsPage : DebuggerPages("log_details", LogListPage, listOf())
 }
 
-internal fun NavHostController.navigate(page: DebuggerPages) {
+internal fun NavHostController.navigateDebugger(page: DebuggerPages) {
     navigate(page.path)
 }
 
@@ -125,10 +125,10 @@ private fun DebuggerPanelPages(viewModel: DebuggerViewModel) {
                 debuggerViewModel = viewModel,
                 onEventClick = {
                     selectedEvent.value = it
-                    navController.navigate(EventDetailsPage)
+                    navController.navigateDebugger(EventDetailsPage)
                 },
-                onFontsClick = { navController.navigate(FontListPage) },
-                onDetailedLogClick = { navController.navigate(LogListPage) }
+                onFontsClick = { navController.navigateDebugger(FontListPage) },
+                onDetailedLogClick = { navController.navigateDebugger(LogListPage) }
             )
         }
 
@@ -145,7 +145,7 @@ private fun DebuggerPanelPages(viewModel: DebuggerViewModel) {
         registerPage(LogListPage) {
             DebuggerLogList(viewModel, navController) {
                 selectedLogMessage.value = it
-                navController.navigate(ExpandedLogDetailsPage)
+                navController.navigateDebugger(ExpandedLogDetailsPage)
             }
         }
 
@@ -159,7 +159,7 @@ private fun DebuggerPanelPages(viewModel: DebuggerViewModel) {
     val deeplink = viewModel.deeplink.collectAsState()
     LaunchedEffect(deeplink.value) {
         deeplink.value.toPage()?.let {
-            navController.navigate(it)
+            navController.navigateDebugger(it)
             viewModel.consumeDeeplink()
         }
     }


### PR DESCRIPTION
There is a crash when tapping a row in the debugger event history, to view event details - or to navigate to any sub page of the debugger, for that matter.

The issue is that the recent update to navigation-compose 2.8.1 introduced a conflict with our own implementation of `NavController.navigate(DebuggerPage)` and the [newly added](https://developer.android.com/reference/androidx/navigation/NavController#navigate(kotlin.Any,kotlin.Function1)) `NavController.navigate(any)` from version 2.8.1. This is part of a [type safe navigation project in Compose](https://medium.com/androiddevelopers/navigation-compose-meet-type-safety-e081fb3cf2f8), but not actually something we are using yet, or intend to at this point due to the implication of using newer versions of Kotlin that it requires.

Simply disambiguating our function name from the internal function will resolve the current issue and allow our dependencies to remain unchanged.