### PR TITLE
Revert dependency versions to avoid kotlin version requirement change

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The SDK is a Kotlin library for sending user properties and events to the Appcue
 
 ### Prerequisites
 
-Your application's `build.gradle` must have a `compileSdkVersion` of 34+ and `minSdkVersion` of 21+
+Your application's `build.gradle` must have a `compileSdkVersion` of 34+ and `minSdkVersion` of 21+, and use Android Gradle Plugin (AGP) 8+.
 
 ```
 android {

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -14,7 +14,7 @@ ext.room_version = '2.6.1'
 ext.compose_version = '1.7.2'
 ext.compose_compiler_version = '1.4.8'
 ext.coil_version = '2.4.0'
-ext.moshi_version = '1.15.1'
+ext.moshi_version = '1.15.0'
 
 android {
     compileSdk 34
@@ -82,7 +82,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.9.2'
     implementation "androidx.browser:browser:1.8.0"
     implementation "androidx.startup:startup-runtime:1.2.0"
-    implementation "androidx.navigation:navigation-compose:2.8.1"
+    implementation "androidx.navigation:navigation-compose:2.7.3"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -13,7 +13,7 @@ apply from: 'dokka.gradle'
 ext.room_version = '2.6.1'
 ext.compose_version = '1.7.2'
 ext.compose_compiler_version = '1.4.8'
-ext.coil_version = '2.7.0'
+ext.coil_version = '2.4.0'
 ext.moshi_version = '1.15.1'
 
 android {


### PR DESCRIPTION
After analyzing our dependency usage a bit more, I discovered that reverting coil (image loading), moshi (json) and navigation-compose (debugger nav) components back to previous versions before #635  allows us to update to Compose 1.7.2 without imposing a new requirement of Kotlin 1.9. I don't see any compelling reason to force this upgrade, so I propose we keep those as-is. This lessens the burden of integration on some cross platform frameworks as well. Our minimum Kotlin version is 1.8.22 [as determined by the Compose compiler](https://developer.android.com/jetpack/androidx/releases/compose-kotlin) currently.

There does not appear to be any way to avoid the AGP 8+ requirement at this point, as it seems Compose 1.7 requires that. Hopefully this is acceptable, as that version has been out for a while, but it may require some additional integration work for some apps.