### PR TITLE
Allow interaction with underlying app when backdrop is disabled

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/step/StepMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/StepMapper.kt
@@ -44,7 +44,7 @@ internal class StepMapper(
             id = from.id,
             content = responseContent.mapPrimitive(),
             presentingTrait = presentingTrait,
-            stepDecoratingTraits = mappedTraits.filterIsInstance(StepDecoratingTrait::class.java),
+            stepDecoratingTraits = mappedTraits.filterIsInstance<StepDecoratingTrait>(),
             backdropDecoratingTraits = mappedTraits.filterIsInstance<BackdropDecoratingTrait>(),
             containerDecoratingTraits = mappedTraits.filterIsInstance<ContainerDecoratingTrait>(),
             metadataSettingTraits = mappedTraits.filterIsInstance<MetadataSettingTrait>(),

--- a/appcues/src/main/java/com/appcues/trait/BackdropDecoratingTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/BackdropDecoratingTrait.kt
@@ -9,14 +9,22 @@ import androidx.compose.runtime.Composable
 internal interface BackdropDecoratingTrait : ExperienceTrait {
 
     /**
+     * Indicates whether or not this trait will block interactions from passing through the backdrop
+     * to application content behind the experience.
+     */
+    val isBlocking: Boolean
+
+    /**
      * Decorates the backdrop of the experience
      *
      * Example usage:
      * @sample com.appcues.trait.appcues.BackdropTrait
      *
+     * @param isBlocking Specifies whether the current content has any blocking BackdropDecoratingTraits being applied.
+     *                   This can be used by any other decorating traits to decide how to apply behaviors.
      * @param content BackdropDecoratingTraits are chained together as one composition.
      *                Its important to call [content] if you want to apply every decoration on stack
      */
     @Composable
-    fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit)
+    fun BoxScope.BackdropDecorate(isBlocking: Boolean, content: @Composable BoxScope.() -> Unit)
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropKeyholeTrait.kt
@@ -44,6 +44,8 @@ internal class BackdropKeyholeTrait(
         const val METADATA_KEYHOLE_SETTINGS = "keyholeSettings"
     }
 
+    override val isBlocking = false
+
     enum class ConfigShape {
         RECTANGLE, CIRCLE
     }
@@ -75,7 +77,13 @@ internal class BackdropKeyholeTrait(
     }
 
     @Composable
-    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
+    override fun BoxScope.BackdropDecorate(isBlocking: Boolean, content: @Composable BoxScope.() -> Unit) {
+        // if there is no blocking backdrop (backdrop trait) then we do not decorate any keyhole sections
+        if (!isBlocking) {
+            content()
+            return
+        }
+
         val density = LocalDensity.current
         val metadata = LocalAppcuesStepMetadata.current
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/BackdropTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/BackdropTrait.kt
@@ -18,8 +18,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInteropFilter
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.getConfigColor
 import com.appcues.data.model.styling.ComponentColor
@@ -42,12 +44,15 @@ internal class BackdropTrait(
         const val METADATA_BACKGROUND_COLOR = "backgroundColor"
     }
 
+    override val isBlocking = true
+
     override fun produceMetadata(): Map<String, Any?> {
         return hashMapOf(METADATA_BACKGROUND_COLOR to config.getConfigColor("backgroundColor"))
     }
 
+    @OptIn(ExperimentalComposeUiApi::class)
     @Composable
-    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
+    override fun BoxScope.BackdropDecorate(isBlocking: Boolean, content: @Composable BoxScope.() -> Unit) {
         val metadata = LocalAppcuesStepMetadata.current
         val animation = rememberColorStepAnimation(metadata)
         val color = rememberBackgroundColor(metadata = metadata, animationSpec = animation)
@@ -64,6 +69,8 @@ internal class BackdropTrait(
                     .fillMaxSize()
                     // set background color
                     .backdrop(color.value)
+                    // this makes the content behind the experience non-interactive, capture all touches inside of our overlay
+                    .pointerInteropFilter { false }
             )
         }
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/EffectsTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/EffectsTrait.kt
@@ -27,6 +27,8 @@ internal class EffectsTrait(
         CONFETTI
     }
 
+    override val isBlocking = false
+
     private val presentationStyle = config.getConfig<String?>("presentationStyle").toPresentationStyle()
 
     private val duration = config.getConfigInt("duration") ?: DEFAULT_DURATION
@@ -36,7 +38,7 @@ internal class EffectsTrait(
     private val style = config.getConfigStyle("style")
 
     @Composable
-    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
+    override fun BoxScope.BackdropDecorate(isBlocking: Boolean, content: @Composable BoxScope.() -> Unit) {
         // other backdrop decorate traits renders first (putting this one on top)
         content()
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -95,6 +95,8 @@ internal class SkippableTrait(
         DEFAULT, MINIMAL, HIDDEN
     }
 
+    override val isBlocking = false
+
     override val containerComposeOrder = ContainerDecoratingType.OVERLAY
 
     // config properties
@@ -150,8 +152,8 @@ internal class SkippableTrait(
     }
 
     @Composable
-    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
-        if (ignoreBackdropTap.not()) {
+    override fun BoxScope.BackdropDecorate(isBlocking: Boolean, content: @Composable BoxScope.() -> Unit) {
+        if (ignoreBackdropTap.not() && isBlocking) {
             Spacer(
                 modifier = Modifier
                     .matchParentSize()

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetInteractionTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetInteractionTrait.kt
@@ -54,6 +54,8 @@ internal class TargetInteractionTrait(
         private const val VIEW_DESCRIPTION = "Target Rectangle"
     }
 
+    override val isBlocking = false
+
     private val actions = config.getConfigActions("actions", renderContext, actionRegistry)
 
     private val actionDelegate = object : AppcuesActionsDelegate {
@@ -64,10 +66,15 @@ internal class TargetInteractionTrait(
 
     @OptIn(ExperimentalFoundationApi::class)
     @Composable
-    override fun BoxScope.BackdropDecorate(content: @Composable BoxScope.() -> Unit) {
+    override fun BoxScope.BackdropDecorate(isBlocking: Boolean, content: @Composable BoxScope.() -> Unit) {
         // calling content before our composable makes so we are on top of all other backdrop traits
         // wrapping content call
         content()
+
+        // if there is no blocking backdrop (no backdrop trait) - then interactions on the backdrop simply
+        // flow through to the underlying application. We do not apply a target interaction since it would result
+        // in an invisible section of the app capturing and taking action on touch in an unexpected way.
+        if (!isBlocking) return
 
         val targetRectInfo = rememberTargetRectangleInfo(LocalAppcuesStepMetadata.current)
         val keyholeSettings = rememberKeyholeSettings(LocalAppcuesStepMetadata.current)


### PR DESCRIPTION
stacks on #642 

Similar change to iOS update in https://github.com/appcues/appcues-ios-sdk/pull/567 - if there is no `@appcues/backdrop` trait, then interactions with the app beneath our content are not blocked.

implications:
* Skippable trait will no longer cover the screen with a tap to dismiss handler, if no backdrop exists
* Target interaction will no longer capture input, if no backdrop exists
* Backdrop keyhole will not attempt to render, if no backdrop exists
* Effects trait will continue to operate as-is, so you could have confetti showing while also allowing interaction with the app behind that confetti

The above updates are accomplished by adding a new `isBlocking` property on any `BackdropDecoratingTrait`, to allow it to declare that it blocks input -- currently only true for `@appcues/backdrop`. When the step is rendering, we first check if any of the `BackdropDecoratingTraits` are blocking, and pass that information through to each trait being applied to the backdrop, so it can decide whether or not to enable certain functionality, as noted above.