### PR TITLE
Add _timezoneOffset auto property

### DIFF
--- a/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AutoPropertyDecorator.kt
@@ -14,6 +14,7 @@ import com.appcues.data.remote.appcues.request.EventRequest
 import com.appcues.monitor.AppcuesActivityMonitor
 import com.appcues.util.ContextWrapper
 import java.util.Date
+import java.util.TimeZone
 
 internal class AutoPropertyDecorator(
     private val config: AppcuesConfig,
@@ -53,6 +54,7 @@ internal class AutoPropertyDecorator(
         "_osVersion" to "${VERSION.SDK_INT}",
         "_deviceType" to contextWrapper.getString(R.string.appcues_device_type),
         "_deviceModel" to contextWrapper.getDeviceName(),
+        "_timezoneOffset" to TimeZone.getDefault().offsetMinutes()
     )
 
     private val pushProperties: Map<String, Any?>
@@ -155,3 +157,7 @@ internal class AutoPropertyDecorator(
         )
     }
 }
+
+private const val MILLISECONDS_PER_MINUTE = 60_000
+
+private fun TimeZone.offsetMinutes() = getOffset(System.currentTimeMillis()) / MILLISECONDS_PER_MINUTE

--- a/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AutoPropertyDecoratorTest.kt
@@ -53,7 +53,7 @@ internal class AutoPropertyDecoratorTest {
 
     @Test
     fun `autoProperties SHOULD contain proper amount of elements`() {
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(22)
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(23)
         with(autoPropertyDecorator.autoProperties) {
             // App
             assertThat(containsKey("_appId")).isTrue()
@@ -94,7 +94,7 @@ internal class AutoPropertyDecoratorTest {
             )
         )
         // then
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(23)
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(24)
     }
 
     @Test
@@ -117,7 +117,7 @@ internal class AutoPropertyDecoratorTest {
             )
         )
         // then
-        assertThat(autoPropertyDecorator.autoProperties).hasSize(24)
+        assertThat(autoPropertyDecorator.autoProperties).hasSize(25)
     }
 
     @Test
@@ -277,7 +277,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(22)
+            assertThat(profileUpdate).hasSize(23)
         }
     }
 
@@ -294,7 +294,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(23)
+            assertThat(profileUpdate).hasSize(24)
         }
         // then when
         with(autoPropertyDecorator.decorateTrack(EventRequest(name = SessionStarted.eventName))) {
@@ -315,7 +315,7 @@ internal class AutoPropertyDecoratorTest {
         // when
         with(autoPropertyDecorator.decorateIdentify(activityRequest)) {
             // then
-            assertThat(profileUpdate).hasSize(23)
+            assertThat(profileUpdate).hasSize(24)
             assertThat(profileUpdate!!["_test"]).isEqualTo("Test")
         }
     }


### PR DESCRIPTION
Will help support options in the future to only send push notifications within certain time windows in the device's timezone. This property is set at the user level (last known value) and each device level.

![Screenshot 2024-10-04 at 3 53 51 PM](https://github.com/user-attachments/assets/3a3e10f5-e9b3-48a8-b913-d05539e8223c)
