### PR TITLE
Don't apply carousel gesture handling if only a single page

### DIFF
--- a/appcues/src/main/java/com/appcues/trait/appcues/CarouselTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/CarouselTrait.kt
@@ -32,6 +32,14 @@ internal class CarouselTrait(
 
     @Composable
     override fun BoxScope.CreateContentHolder(containerPages: ContainerPages) {
+        if (containerPages.pageCount < 2) {
+            // If we do not have multiple pages, skip all carousel logic
+            // to avoid the creation of a pager or horizontal scroll gesture handling.
+            // This ends up working exactly the same as the DefaultContentHolderTrait
+            containerPages.composePage(containerPages.currentPage)
+            return
+        }
+
         val pagerState = rememberPagerState(
             initialPage = containerPages.currentPage,
             pageCount = { containerPages.pageCount }


### PR DESCRIPTION
If a carousel trait is applied but only a single page, we should ignore it - otherwise, it will capture any horizontal scroll gestures and prevent our swipe to dismiss capability.