### PR TITLE
Allow tap interactions in tooltip highlight area to optionally pass through to underlying views

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import coil.ImageLoader
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
@@ -27,10 +28,12 @@ import com.appcues.di.scope.get
 import com.appcues.logging.Logcues
 import com.appcues.ui.composables.AppcuesActionsDelegate
 import com.appcues.ui.composables.AppcuesDismissalDelegate
+import com.appcues.ui.composables.AppcuesTapForwardingDelegate
 import com.appcues.ui.composables.ComposeContainer
 import com.appcues.ui.composables.ExperienceCompositionState
 import com.appcues.ui.composables.LocalAppcuesActionDelegate
 import com.appcues.ui.composables.LocalAppcuesDismissalDelegate
+import com.appcues.ui.composables.LocalAppcuesTapForwardingDelegate
 import com.appcues.ui.composables.LocalExperienceCompositionState
 import com.appcues.ui.composables.LocalExperienceStepFormStateDelegate
 import com.appcues.ui.composables.LocalImageLoader
@@ -119,6 +122,7 @@ public fun ComposeContainer(context: Context, stepContentJson: List<String>?, tr
                 isBackdropVisible = MutableTransitionState(true)
             ),
             LocalAppcuesDismissalDelegate provides FakeAppcuesDismissalDelegate(),
+            LocalAppcuesTapForwardingDelegate provides FakeAppcuesTapForwardingDelegate(),
         ) {
             // render the step container on the desired step
             Box(
@@ -182,6 +186,7 @@ public fun ComposeContainer(
                 isBackdropVisible = MutableTransitionState(!animated)
             ),
             LocalAppcuesDismissalDelegate provides FakeAppcuesDismissalDelegate(),
+            LocalAppcuesTapForwardingDelegate provides FakeAppcuesTapForwardingDelegate(),
         ) {
             // render the step container on the desired step
             Box(
@@ -239,4 +244,8 @@ private class FakeAppcuesActionDelegate : AppcuesActionsDelegate {
 private class FakeAppcuesDismissalDelegate : AppcuesDismissalDelegate {
     override val canDismiss = false
     override fun requestDismissal() { }
+}
+
+private class FakeAppcuesTapForwardingDelegate: AppcuesTapForwardingDelegate {
+    override fun onTap(offset: Offset) { }
 }

--- a/appcues/src/main/java/com/appcues/trait/appcues/TargetInteractionTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/TargetInteractionTrait.kt
@@ -1,9 +1,7 @@
 package com.appcues.trait.appcues
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.offset
@@ -11,10 +9,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.unit.dp
 import com.appcues.action.ActionProcessor
 import com.appcues.action.ActionRegistry
@@ -25,6 +29,7 @@ import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.Interactio
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.getConfigActions
+import com.appcues.data.model.getConfigOrDefault
 import com.appcues.trait.BackdropDecoratingTrait
 import com.appcues.trait.appcues.BackdropKeyholeTrait.ConfigShape.CIRCLE
 import com.appcues.trait.appcues.BackdropKeyholeTrait.ConfigShape.RECTANGLE
@@ -36,6 +41,7 @@ import com.appcues.trait.extensions.rememberTargetRectangleInfo
 import com.appcues.ui.composables.AppcuesActionsDelegate
 import com.appcues.ui.composables.AppcuesStepMetadata
 import com.appcues.ui.composables.LocalAppcuesStepMetadata
+import com.appcues.ui.composables.LocalAppcuesTapForwardingDelegate
 import com.appcues.ui.extensions.toLongPressMotionOrNull
 import com.appcues.ui.extensions.toTapMotionOrEmpty
 import com.appcues.ui.utils.rememberAppcuesWindowInfo
@@ -57,6 +63,7 @@ internal class TargetInteractionTrait(
     override val isBlocking = false
 
     private val actions = config.getConfigActions("actions", renderContext, actionRegistry)
+    private val enablePassThrough = config.getConfigOrDefault("enablePassThrough", false)
 
     private val actionDelegate = object : AppcuesActionsDelegate {
         override fun onActions(actions: List<ExperienceAction>, interactionType: InteractionType, viewDescription: String?) {
@@ -76,6 +83,8 @@ internal class TargetInteractionTrait(
         // in an invisible section of the app capturing and taking action on touch in an unexpected way.
         if (!isBlocking) return
 
+        val tapForwardingDelegate = LocalAppcuesTapForwardingDelegate.current
+
         val targetRectInfo = rememberTargetRectangleInfo(LocalAppcuesStepMetadata.current)
         val keyholeSettings = rememberKeyholeSettings(LocalAppcuesStepMetadata.current)
         // only draws when target rectangle info exists
@@ -89,24 +98,38 @@ internal class TargetInteractionTrait(
             val offsetY = if (keyholeSettings.shape == RECTANGLE) rect.top else rect.top - ((encompassesDiameter - rect.height) / 2)
             val clipShape = if (keyholeSettings.shape == RECTANGLE) RoundedCornerShape(keyholeSettings.cornerRadius.dp) else CircleShape
 
+            var globalOffset by remember { mutableStateOf(Offset.Zero) }
+
             Box(
                 modifier = Modifier
                     .size(width = width.dp, height = height.dp)
                     .offset(x = offsetX.dp, y = offsetY.dp)
                     .clip(clipShape)
-                    // add click listener but without any ripple effect.
-                    .then(
-                        if (actions.isNotEmpty()) {
-                            Modifier.combinedClickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null,
-                                onLongClick = actions.toLongPressMotionOrNull(actionDelegate, TARGET_LONG_PRESSED, VIEW_DESCRIPTION),
-                                onClick = actions.toTapMotionOrEmpty(actionDelegate, TARGET_TAPPED, VIEW_DESCRIPTION),
-                            )
-                        }
-                        // when no actions are listed, the default behavior is to
-                        else Modifier.pointerInput(Unit) { detectTapGestures { } }
-                    )
+                    .onGloballyPositioned { coordinates ->
+                        globalOffset = coordinates.positionInWindow()
+                    }
+                    .pointerInput(Unit) {
+                        detectTapGestures(
+                            onTap = { offset ->
+                                if (enablePassThrough) {
+                                    // If a target is allowed to pass touches through to the host application,
+                                    // we find the global offset of the tap and pass it back through to the
+                                    // View that is hosting our experience, using this tapForwardingDelegate.
+                                    // This will end up passing MotionEvents back through to the underlying views
+                                    // as if the tap was not captured at all by our Composable here.
+                                    val globalTapOffset = Offset(
+                                        x = offset.x + globalOffset.x,
+                                        y = offset.y + globalOffset.y
+                                    )
+                                    tapForwardingDelegate.onTap(globalTapOffset)
+                                }
+                                actions.toTapMotionOrEmpty(actionDelegate, TARGET_TAPPED, VIEW_DESCRIPTION).invoke()
+                            },
+                            onLongPress = {
+                                actions.toLongPressMotionOrNull(actionDelegate, TARGET_LONG_PRESSED, VIEW_DESCRIPTION)?.invoke()
+                            }
+                        )
+                    }
             )
         }
     }

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -45,6 +45,7 @@ internal fun AppcuesComposition(
             LocalAppcuesPaginationDelegate provides AppcuesPagination { viewModel.onPageChanged(it) },
             LocalExperienceCompositionState provides ExperienceCompositionState(),
             LocalAppcuesDismissalDelegate provides DefaultAppcuesDismissalDelegate(viewModel),
+            LocalAppcuesTapForwardingDelegate provides DefaultAppcuesTapForwardingDelegate(viewModel),
         ) {
             MainSurface()
         }

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionLocals.kt
@@ -4,6 +4,7 @@ import android.webkit.WebChromeClient
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.geometry.Offset
 import coil.ImageLoader
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
@@ -51,6 +52,19 @@ internal class DefaultAppcuesDismissalDelegate(private val viewModel: AppcuesVie
     override val canDismiss: Boolean
         get() = viewModel.canDismiss()
     override fun requestDismissal() = viewModel.requestDismissal()
+}
+
+// Tap forwarding delegate used to support tooltip tap pass through, abstraction layer for testing
+internal val LocalAppcuesTapForwardingDelegate = staticCompositionLocalOf<AppcuesTapForwardingDelegate> {
+    noLocalProvidedFor("LocalAppcuesTapForwardingDelegate")
+}
+
+internal interface AppcuesTapForwardingDelegate {
+    fun onTap(offset: Offset)
+}
+
+internal class DefaultAppcuesTapForwardingDelegate(private val viewModel: AppcuesViewModel) : AppcuesTapForwardingDelegate {
+    override fun onTap(offset: Offset) = viewModel.tapPassThroughHandler(offset)
 }
 
 /**

--- a/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
@@ -1,5 +1,6 @@
 package com.appcues.ui.presentation
 
+import androidx.compose.ui.geometry.Offset
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.appcues.action.ActionProcessor
@@ -30,6 +31,7 @@ internal class AppcuesViewModel(
     private val experienceRenderer: ExperienceRenderer,
     private val actionProcessor: ActionProcessor,
     private val onDismiss: () -> Unit,
+    val tapPassThroughHandler: (Offset) -> Unit,
 ) : ViewModel() {
 
     sealed class UIState {

--- a/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt
@@ -3,10 +3,12 @@ package com.appcues.ui.presentation
 import android.app.Activity
 import android.os.Handler
 import android.os.Looper
+import android.view.MotionEvent
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.findViewTreeOnBackPressedDispatcherOwner
 import androidx.compose.runtime.key
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -103,7 +105,8 @@ internal abstract class ViewPresenter(
                 coroutineScope = coroutineScope,
                 experienceRenderer = experienceRenderer,
                 actionProcessor = actionProcessor,
-                onDismiss = ::remove
+                onDismiss = ::remove,
+                tapPassThroughHandler = ::tapPassThrough,
             ).also {
                 composeView.setContent {
                     // [currentExperience?.instanceId]: when the instanceId changes it means it could be a "newer" version
@@ -141,6 +144,21 @@ internal abstract class ViewPresenter(
             gestureListener = null
             viewModel = null
             parentView = WeakReference(null)
+        }
+    }
+
+    private fun tapPassThrough(offset: Offset) {
+        parentView.get()?.let { view ->
+            val now = System.currentTimeMillis()
+            val downEvent = MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, offset.x, offset.y, 0)
+            val upEvent = MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, offset.x, offset.y, 0)
+
+            // Dispatch both ACTION_DOWN and ACTION_UP events to simulate a click
+            view.dispatchTouchEvent(downEvent)
+            view.dispatchTouchEvent(upEvent)
+
+            downEvent.recycle()
+            upEvent.recycle()
         }
     }
 

--- a/appcues/src/test/java/com/appcues/ui/presentation/AppcuesViewModelTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/presentation/AppcuesViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.appcues.ui.presentation
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.compose.ui.geometry.Offset
 import androidx.lifecycle.viewModelScope
 import com.appcues.AppcuesCoroutineScope
 import com.appcues.action.ActionProcessor
@@ -68,6 +69,8 @@ internal class AppcuesViewModelTest {
 
     private val onDismiss: () -> Unit = mockk(relaxed = true)
 
+    private val tapPassThroughHandler: (Offset) -> Unit = mockk(relaxed = true)
+
     private lateinit var viewModel: AppcuesViewModel
 
     private val uiStates = arrayListOf<UIState>()
@@ -78,7 +81,14 @@ internal class AppcuesViewModelTest {
     fun setup() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
 
-        viewModel = AppcuesViewModel(renderContext, coroutineScope, experienceRenderer, actionProcessor, onDismiss).apply {
+        viewModel = AppcuesViewModel(
+            renderContext = renderContext,
+            coroutineScope = coroutineScope,
+            experienceRenderer = experienceRenderer,
+            actionProcessor = actionProcessor,
+            onDismiss = onDismiss,
+            tapPassThroughHandler = tapPassThroughHandler
+        ).apply {
             stateJob = viewModelScope.launch { uiState.collect { uiStates.add(it) } }
         }
 
@@ -106,7 +116,7 @@ internal class AppcuesViewModelTest {
             coEvery { getStateFlow(renderContext) } returns null
         }
         // WHEN
-        viewModel = AppcuesViewModel(renderContext, coroutineScope, experienceRenderer, actionProcessor, onDismiss)
+        viewModel = AppcuesViewModel(renderContext, coroutineScope, experienceRenderer, actionProcessor, onDismiss, tapPassThroughHandler)
         // WHEN
         verifySequence { onDismiss.invoke() }
     }


### PR DESCRIPTION
The changes here in the `TargetInteractionTrait` are the key updates. We'll now detect tap gestures, and conditionally forward them back to the underlying Android View that is hosting our experience, if the trait `enablePassThrough` is `true`. This is done by creating synthetic `MotionEvent`s for down + up and sending them to the View. The trait also continues to run any actions declared for tap (or longPress), so these can be combined.

The abstraction to a `LocalAppcuesTapForwardingDelegate` that gets passed through the composition is simply to avoid referencing `LocalViewModel` directly, for snapshot test purposes -- similar to what is done in a couple other spots now.

This example shows a tooltip highlight that allows pass though - note the `event2` that gets fired on the tap, but also defines an `@appcues/continue` action on that tap - causing the experience to progress (and end in this case).

https://github.com/user-attachments/assets/b095ab9b-f422-4106-b8bf-311386d33368