### PR TITLE
Support improved testability with injectable CoroutineScope

### DIFF
--- a/appcues/src/debug/java/com/appcues/ExperienceTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/ExperienceTestHelper.kt
@@ -3,7 +3,9 @@ package com.appcues
 import android.content.Context
 import coil.ImageLoader
 import com.appcues.di.Bootstrap
+import com.appcues.di.definition.ScopedDefinition
 import com.appcues.di.scope.get
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * custom instance call that allows for custom imageLoader (used by coil)
@@ -15,11 +17,13 @@ public fun Appcues(
     accountId: String,
     applicationId: String,
     imageLoader: ImageLoader?,
+    coroutineScope: CoroutineScope?,
     config: (AppcuesConfig.() -> Unit)? = null,
 ): Appcues = Bootstrap.createScope(
     context = context,
-    config = AppcuesConfig(accountId, applicationId).apply {
-        config?.invoke(this)
-        this.imageLoader = imageLoader
-    }
-).get()
+    config = AppcuesConfig(accountId, applicationId).apply { config?.invoke(this) }
+).also { scope ->
+    // optional test overrides
+    imageLoader?.let { scope.define(ImageLoader::class, ScopedDefinition { imageLoader }, true) }
+    coroutineScope?.let { scope.define(CoroutineScope::class, ScopedDefinition { coroutineScope}, true) }
+}.get()

--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -25,6 +25,7 @@ import com.appcues.trait.ExperienceTraitLevel
 import com.appcues.trait.TraitRegistry
 import com.appcues.ui.ExperienceRenderer
 import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
@@ -110,7 +111,7 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
     private val activityScreenTracking by scope.inject<ActivityScreenTracking>()
     private val deepLinkHandler by scope.inject<DeepLinkHandler>()
     private val debuggerManager by scope.inject<AppcuesDebuggerManager>()
-    private val appcuesCoroutineScope by scope.inject<AppcuesCoroutineScope>()
+    private val appcuesCoroutineScope by scope.inject<CoroutineScope>()
     private val analyticsPublisher by scope.inject<AnalyticsPublisher>()
     private val pushOpenedProcessor by scope.inject<PushOpenedProcessor>()
 

--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -140,6 +140,7 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
 
         appcuesCoroutineScope.launch {
             analyticsTracker.analyticsFlow.collect {
+                @Suppress("TooGenericExceptionCaught")
                 try {
                     analyticsPublisher.publish(analyticsListener, it)
                 } catch (ex: Exception) {

--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -140,7 +140,12 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
 
         appcuesCoroutineScope.launch {
             analyticsTracker.analyticsFlow.collect {
-                analyticsPublisher.publish(analyticsListener, it)
+                try {
+                    analyticsPublisher.publish(analyticsListener, it)
+                } catch (_: Exception) {
+                    // ignore any exception that occurs in client app code that is observing analytics,
+                    // so we always continue collecting on the analyticsFlow
+                }
             }
         }
 

--- a/appcues/src/main/java/com/appcues/Appcues.kt
+++ b/appcues/src/main/java/com/appcues/Appcues.kt
@@ -142,9 +142,10 @@ public class Appcues internal constructor(internal val scope: AppcuesScope) {
             analyticsTracker.analyticsFlow.collect {
                 try {
                     analyticsPublisher.publish(analyticsListener, it)
-                } catch (_: Exception) {
+                } catch (ex: Exception) {
                     // ignore any exception that occurs in client app code that is observing analytics,
                     // so we always continue collecting on the analyticsFlow
+                    logcues.error(ex)
                 }
             }
         }

--- a/appcues/src/main/java/com/appcues/AppcuesConfig.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesConfig.kt
@@ -1,6 +1,5 @@
 package com.appcues
 
-import coil.ImageLoader
 import com.appcues.LoggingLevel.NONE
 
 /**
@@ -101,7 +100,4 @@ public data class AppcuesConfig internal constructor(
      * a different package than your main app (multi-module apps)
      */
     var packageNames: List<String> = arrayListOf()
-
-    // internally used for ui test on debug variant
-    internal var imageLoader: ImageLoader? = null
 }

--- a/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
@@ -19,6 +19,7 @@ import com.appcues.ui.ExperienceRenderer.PreviewResponse.PreviewDeferred
 import com.appcues.ui.ExperienceRenderer.PreviewResponse.StateMachineError
 import com.appcues.ui.ExperienceRenderer.PreviewResponse.Success
 import com.appcues.util.ContextWrapper
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 internal class DeepLinkHandler(scope: AppcuesScope) {
@@ -35,7 +36,7 @@ internal class DeepLinkHandler(scope: AppcuesScope) {
 
     private val config by scope.inject<AppcuesConfig>()
     private val experienceRenderer by scope.inject<ExperienceRenderer>()
-    private val appcuesCoroutineScope by scope.inject<AppcuesCoroutineScope>()
+    private val appcuesCoroutineScope by scope.inject<CoroutineScope>()
     private val debuggerManager by scope.inject<AppcuesDebuggerManager>()
     private val pushDeeplinkHandler by scope.inject<PushDeeplinkHandler>()
     private val contextWrapper by scope.inject<ContextWrapper>()

--- a/appcues/src/main/java/com/appcues/MainModule.kt
+++ b/appcues/src/main/java/com/appcues/MainModule.kt
@@ -1,5 +1,6 @@
 package com.appcues
 
+import coil.ImageLoader
 import com.appcues.action.ActionProcessor
 import com.appcues.action.ActionRegistry
 import com.appcues.data.AppcuesRepository
@@ -18,6 +19,7 @@ import com.appcues.ui.StateMachineDirectory
 import com.appcues.ui.utils.ImageLoaderWrapper
 import com.appcues.util.AppcuesViewTreeOwner
 import com.appcues.util.LinkOpener
+import kotlinx.coroutines.CoroutineScope
 
 internal object MainModule : AppcuesModule {
 
@@ -27,7 +29,7 @@ internal object MainModule : AppcuesModule {
         scoped { TraitRegistry(get(), get()) }
         scoped { ActionRegistry(get()) }
         scoped { ActionProcessor(get()) }
-        scoped { AppcuesCoroutineScope(logcues = get()) }
+        scoped<CoroutineScope> { AppcuesCoroutineScope(logcues = get()) }
         scoped { Logcues() }
         scoped { LogcatDestination(get(), get<AppcuesConfig>().loggingLevel) }
         scoped { Storage(context = get(), config = get()) }
@@ -53,6 +55,6 @@ internal object MainModule : AppcuesModule {
 
         factory { StateMachine(actionProcessor = get(), lifecycleTracker = get(), onEndedExperience = it.next()) }
 
-        scoped { get<AppcuesConfig>().imageLoader ?: get<ImageLoaderWrapper>().build() }
+        scoped<ImageLoader> { get<ImageLoaderWrapper>().build() }
     }
 }

--- a/appcues/src/main/java/com/appcues/SessionMonitor.kt
+++ b/appcues/src/main/java/com/appcues/SessionMonitor.kt
@@ -10,6 +10,7 @@ import com.appcues.di.component.AppcuesComponent
 import com.appcues.di.component.inject
 import com.appcues.di.scope.AppcuesScope
 import com.appcues.util.ContextWrapper
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.Date
 import java.util.UUID
@@ -23,7 +24,7 @@ internal class SessionMonitor(
     private val analyticsTracker by inject<AnalyticsTracker>()
     private val storage by inject<Storage>()
     private val config by inject<AppcuesConfig>()
-    private val appcuesCoroutineScope by inject<AppcuesCoroutineScope>()
+    private val appcuesCoroutineScope by inject<CoroutineScope>()
     private val contextWrapper by inject<ContextWrapper>()
 
     private var _sessionId: UUID? = null

--- a/appcues/src/main/java/com/appcues/action/ActionProcessor.kt
+++ b/appcues/src/main/java/com/appcues/action/ActionProcessor.kt
@@ -1,7 +1,6 @@
 package com.appcues.action
 
 import com.appcues.Appcues
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.action.appcues.StepInteractionAction
 import com.appcues.action.appcues.StepInteractionAction.StepInteractionData
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
@@ -10,6 +9,7 @@ import com.appcues.di.component.AppcuesComponent
 import com.appcues.di.component.get
 import com.appcues.di.component.inject
 import com.appcues.di.scope.AppcuesScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 
@@ -19,7 +19,7 @@ internal class ActionProcessor(override val scope: AppcuesScope) : AppcuesCompon
 
     // lazy initialization injection to avoid circular dependency
     private val appcues: Appcues by inject()
-    private val appcuesCoroutineScope: AppcuesCoroutineScope by inject()
+    private val appcuesCoroutineScope: CoroutineScope by inject()
 
     private val actionQueue = Channel<ExperienceAction>(Channel.UNLIMITED)
 

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsModule.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsModule.kt
@@ -34,12 +34,7 @@ internal object AnalyticsModule : AppcuesModule {
             )
         }
         scoped {
-            AnalyticsTracker(
-                appcuesCoroutineScope = get(),
-                activityBuilder = get(),
-                sessionMonitor = get(),
-                analyticsQueueProcessor = get(),
-            )
+            AnalyticsTracker(activityBuilder = get(), sessionMonitor = get(), analyticsQueueProcessor = get())
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsQueueProcessor.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsQueueProcessor.kt
@@ -1,11 +1,11 @@
 package com.appcues.analytics
 
 import androidx.annotation.VisibleForTesting
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.data.AppcuesRepository
 import com.appcues.data.remote.appcues.request.ActivityRequest
 import com.appcues.data.remote.appcues.request.EventRequest
 import com.appcues.ui.ExperienceRenderer
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.Date
 import java.util.Timer
@@ -13,7 +13,7 @@ import java.util.TimerTask
 import kotlin.concurrent.schedule
 
 internal class AnalyticsQueueProcessor(
-    private val appcuesCoroutineScope: AppcuesCoroutineScope,
+    private val appcuesCoroutineScope: CoroutineScope,
     private val repository: AppcuesRepository,
     private val experienceRenderer: ExperienceRenderer,
     // this is the background analytics processing queue - 10 sec batch

--- a/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/AnalyticsTracker.kt
@@ -5,22 +5,22 @@ import com.appcues.AnalyticType.EVENT
 import com.appcues.AnalyticType.GROUP
 import com.appcues.AnalyticType.IDENTIFY
 import com.appcues.AnalyticType.SCREEN
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.SessionMonitor
 import com.appcues.data.remote.appcues.request.ActivityRequest
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
 import java.util.UUID
 
 internal class AnalyticsTracker(
-    private val appcuesCoroutineScope: AppcuesCoroutineScope,
     private val activityBuilder: ActivityRequestBuilder,
     private val sessionMonitor: SessionMonitor,
     private val analyticsQueueProcessor: AnalyticsQueueProcessor,
 ) {
 
-    private val _analyticsFlow = MutableSharedFlow<TrackingData>(1)
+    private val _analyticsFlow = MutableSharedFlow<TrackingData>(
+        replay = 1,
+        extraBufferCapacity = Int.MAX_VALUE
+    )
     val analyticsFlow: SharedFlow<TrackingData>
         get() = _analyticsFlow
 
@@ -96,8 +96,6 @@ internal class AnalyticsTracker(
     }
 
     private fun updateAnalyticsFlow(type: AnalyticType, isInternal: Boolean, activity: ActivityRequest) {
-        appcuesCoroutineScope.launch {
-            _analyticsFlow.emit(TrackingData(type, isInternal, activity))
-        }
+        _analyticsFlow.tryEmit(TrackingData(type, isInternal, activity))
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -1,7 +1,6 @@
 package com.appcues.analytics
 
 import com.appcues.AppcuesConfig
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.Storage
 import com.appcues.analytics.ExperienceLifecycleEvent.ExperienceCompleted
 import com.appcues.analytics.ExperienceLifecycleEvent.ExperienceDismissed
@@ -24,8 +23,7 @@ import com.appcues.statemachine.states.BeginningStepState
 import com.appcues.statemachine.states.EndingExperienceState
 import com.appcues.statemachine.states.EndingStepState
 import com.appcues.statemachine.states.RenderingStepState
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.util.Date
@@ -39,18 +37,18 @@ internal class ExperienceLifecycleTracker(
     // AnalyticsTracker -> this <- Analytics Tracker
     private val analyticsTracker: AnalyticsTracker by inject()
     private val storage: Storage by inject()
-    private val appcuesCoroutineScope: AppcuesCoroutineScope by inject()
+    private val appcuesCoroutineScope: CoroutineScope by inject()
     private val config: AppcuesConfig by inject()
 
     private var stateJob: Job? = null
     private var errorJob: Job? = null
 
-    fun start(stateMachine: StateMachine, onEndedExperience: (Experience) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+    fun start(stateMachine: StateMachine, onEndedExperience: (Experience) -> Unit) {
         // ensure any existing observers are stopped before starting new ones
         stop()
 
-        stateJob = appcuesCoroutineScope.launch(dispatcher) { stateMachine.observeState(onEndedExperience) }
-        errorJob = appcuesCoroutineScope.launch(dispatcher) { stateMachine.observeErrors() }
+        stateJob = appcuesCoroutineScope.launch { stateMachine.observeState(onEndedExperience) }
+        errorJob = appcuesCoroutineScope.launch { stateMachine.observeErrors() }
     }
 
     fun stop() {

--- a/appcues/src/main/java/com/appcues/data/remote/NetworkRequest.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/NetworkRequest.kt
@@ -5,6 +5,7 @@ import com.appcues.data.remote.appcues.response.ErrorResponse
 import com.appcues.data.remote.appcues.response.PushErrorResponse
 import com.appcues.util.ResultOf
 import com.squareup.moshi.JsonDataException
+import okio.IOException
 import retrofit2.HttpException
 
 internal object NetworkRequest {
@@ -22,6 +23,8 @@ internal object NetworkRequest {
             exception.response()?.errorBody()?.source()?.let {
                 MoshiConfiguration.moshi.adapter(ErrorResponse::class.java).fromJson(it)
             }
+        } catch (exception: IOException) {
+            null
         } catch (exception: JsonDataException) {
             null
         }
@@ -40,6 +43,8 @@ internal object NetworkRequest {
             exception.response()?.errorBody()?.source()?.let {
                 MoshiConfiguration.moshi.adapter(PushErrorResponse::class.java).fromJson(it)
             }
+        } catch (exception: IOException) {
+            null
         } catch (exception: JsonDataException) {
             null
         }

--- a/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
+++ b/appcues/src/main/java/com/appcues/debugger/DebuggerViewModel.kt
@@ -3,7 +3,6 @@ package com.appcues.debugger
 import androidx.compose.ui.geometry.Offset
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.data.model.RenderContext
 import com.appcues.debugger.DebugMode.Debugger
 import com.appcues.debugger.DebugMode.ScreenCapture
@@ -32,6 +31,7 @@ import com.appcues.logging.LogMessage
 import com.appcues.ui.ExperienceRenderer
 import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -49,7 +49,7 @@ internal class DebuggerViewModel(override val scope: AppcuesScope, debugMode: De
 
     private val getCaptureUseCase by inject<GetCaptureUseCase>()
 
-    private val appcuesCoroutineScope by inject<AppcuesCoroutineScope>()
+    private val appcuesCoroutineScope by inject<CoroutineScope>()
 
     private val experienceRenderer by inject<ExperienceRenderer>()
 

--- a/appcues/src/main/java/com/appcues/di/scope/AppcuesScope.kt
+++ b/appcues/src/main/java/com/appcues/di/scope/AppcuesScope.kt
@@ -12,8 +12,8 @@ internal data class AppcuesScope(
 
     private val definitions = hashMapOf<KClass<*>, Definition<*>>()
 
-    fun <T : Any> define(clazz: KClass<T>, definition: Definition<T>) {
-        if (definitions.contains(clazz)) throw DefinitionException("definition already registered for class $clazz")
+    fun <T : Any> define(clazz: KClass<T>, definition: Definition<T>, override: Boolean = false) {
+        if (!override && definitions.contains(clazz)) throw DefinitionException("definition already registered for class $clazz")
 
         definitions[clazz] = definition
     }

--- a/appcues/src/main/java/com/appcues/push/PushDeeplinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/push/PushDeeplinkHandler.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.AppcuesFirebaseMessagingService.AppcuesMessagingData
 import com.appcues.R
 import com.appcues.SessionMonitor
@@ -19,6 +18,7 @@ import com.appcues.di.scope.AppcuesScope
 import com.appcues.di.scope.inject
 import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -56,7 +56,7 @@ internal class PushDeeplinkHandler(
 
     private val sessionMonitor by inject<SessionMonitor>()
     private val pushOpenedProcessor by inject<PushOpenedProcessor>()
-    private val coroutineScope by scope.inject<AppcuesCoroutineScope>()
+    private val coroutineScope by scope.inject<CoroutineScope>()
     private val storage by inject<Storage>()
     private val pushRepository by scope.inject<PushRepository>()
 

--- a/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
+++ b/appcues/src/main/java/com/appcues/trait/appcues/SkippableTrait.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.R
 import com.appcues.data.model.AppcuesConfigMap
 import com.appcues.data.model.RenderContext
@@ -55,6 +54,7 @@ import com.appcues.ui.extensions.getMargins
 import com.appcues.ui.extensions.xShapePath
 import com.appcues.ui.utils.margin
 import com.appcues.util.ne
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.math.min
 
@@ -62,7 +62,7 @@ internal class SkippableTrait(
     override val config: AppcuesConfigMap,
     private val renderContext: RenderContext,
     private val experienceRenderer: ExperienceRenderer,
-    private val appcuesCoroutineScope: AppcuesCoroutineScope,
+    private val appcuesCoroutineScope: CoroutineScope,
 ) : ContainerDecoratingTrait, BackdropDecoratingTrait {
 
     companion object {

--- a/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
+++ b/appcues/src/main/java/com/appcues/ui/ExperienceRenderer.kt
@@ -35,7 +35,9 @@ import com.appcues.ui.ExperienceRenderer.RenderingResult.StateMachineError
 import com.appcues.ui.ExperienceRenderer.RenderingResult.WontDisplay
 import com.appcues.util.ResultOf.Failure
 import com.appcues.util.ResultOf.Success
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 
 @Suppress("TooManyFunctions")
 internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesComponent {
@@ -131,7 +133,7 @@ internal class ExperienceRenderer(override val scope: AppcuesScope) : AppcuesCom
         return newExperience.priority == NORMAL && state !is IdlingState
     }
 
-    suspend fun show(qualificationResult: QualificationResult) {
+    suspend fun show(qualificationResult: QualificationResult) = withContext(Dispatchers.Main) {
         if (qualificationResult.trigger.reason == "screen_view") {
             // clear list in case this was a screen_view qualification
             potentiallyRenderableExperiences.clear()

--- a/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
+++ b/appcues/src/main/java/com/appcues/ui/ModalStateMachineOwner.kt
@@ -6,7 +6,6 @@ import android.view.ViewTreeObserver
 import android.view.ViewTreeObserver.OnDrawListener
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.view.ViewTreeObserver.OnScrollChangedListener
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.data.model.RenderContext
 import com.appcues.data.model.RenderContext.Modal
 import com.appcues.monitor.AppcuesActivityMonitor
@@ -17,6 +16,7 @@ import com.appcues.statemachine.StateMachine
 import com.appcues.statemachine.states.IdlingState
 import com.appcues.statemachine.states.RenderingStepState
 import com.appcues.ui.utils.getParentView
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 
 internal class ModalStateMachineOwner(
     override val stateMachine: StateMachine,
-    private val coroutineScope: AppcuesCoroutineScope,
+    private val coroutineScope: CoroutineScope,
 ) : StateMachineOwning {
 
     companion object {

--- a/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/CompositionRemembers.kt
@@ -3,6 +3,7 @@ package com.appcues.ui.composables
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,7 +50,9 @@ internal fun LaunchOnHideAnimationCompleted(block: () -> Unit) {
     with(remember { mutableStateOf(isContentVisible) }.value) {
         // if hide animation is completed
         if (isIdle && currentState.not()) {
-            block()
+            SideEffect {
+                block()
+            }
         }
     }
 }

--- a/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
+++ b/appcues/src/main/java/com/appcues/ui/presentation/AppcuesViewModel.kt
@@ -2,7 +2,6 @@ package com.appcues.ui.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.action.ActionProcessor
 import com.appcues.action.ExperienceAction
 import com.appcues.analytics.ExperienceLifecycleEvent.StepInteraction.InteractionType
@@ -18,6 +17,7 @@ import com.appcues.ui.ExperienceRenderer
 import com.appcues.ui.presentation.AppcuesViewModel.UIState.Dismissing
 import com.appcues.ui.presentation.AppcuesViewModel.UIState.Idle
 import com.appcues.ui.presentation.AppcuesViewModel.UIState.Rendering
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,7 +26,7 @@ import kotlinx.coroutines.launch
 
 internal class AppcuesViewModel(
     private val renderContext: RenderContext,
-    private val coroutineScope: AppcuesCoroutineScope,
+    private val coroutineScope: CoroutineScope,
     private val experienceRenderer: ExperienceRenderer,
     private val actionProcessor: ActionProcessor,
     private val onDismiss: () -> Unit,

--- a/appcues/src/test/java/com/appcues/ModulesTests.kt
+++ b/appcues/src/test/java/com/appcues/ModulesTests.kt
@@ -56,6 +56,7 @@ import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import kotlinx.coroutines.CoroutineScope
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -71,7 +72,6 @@ internal class ModulesTests {
         every { applicationContext } returns mockk<Application>(relaxed = true)
     }
 
-    private val customImageLoader = mockk<ImageLoader>()
     private val imageLoader = mockk<ImageLoader>()
     private val imageLoaderWrapper = mockk<ImageLoaderWrapper> {
         every { build() } returns imageLoader
@@ -112,7 +112,7 @@ internal class ModulesTests {
         get<TraitRegistry>()
         get<ActionRegistry>()
         get<ActionProcessor>()
-        get<AppcuesCoroutineScope>()
+        get<CoroutineScope>()
         get<Logcues>()
         get<Storage>()
         get<DeepLinkHandler>()
@@ -125,17 +125,6 @@ internal class ModulesTests {
         get<AnalyticsPublisher>()
         get<StateMachine>(DefinitionParams(listOf(onExperienceEnded)))
         assertThat(get<ImageLoader>()).isEqualTo(imageLoader)
-    }
-
-    @Test
-    fun `check MainModule gets custom ImageLoader`() {
-        val config = AppcuesConfig("account", "app").apply {
-            imageLoader = customImageLoader
-        }
-
-        withScope(config) {
-            assertThat(get<ImageLoader>()).isEqualTo(customImageLoader)
-        }
     }
 
     @Test

--- a/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
+++ b/appcues/src/test/java/com/appcues/action/ActionProcessorTest.kt
@@ -27,6 +27,7 @@ import io.mockk.Called
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -130,7 +131,7 @@ internal class ActionProcessorTest {
                     scoped { mockk<Logcues>(relaxed = true) }
                     scoped { mockk<Appcues>(relaxed = true) }
                     scoped { AppcuesConfig("00000", "123") }
-                    scoped { AppcuesCoroutineScope(get()) }
+                    scoped<CoroutineScope> { AppcuesCoroutineScope(get()) }
                     scoped { mockk<AnalyticsTracker>(relaxed = true) }
                     scoped { ActionProcessor(get()) }
                     scoped { params ->

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerExtTest.kt
@@ -35,7 +35,6 @@ internal class AnalyticsTrackerExtTest {
     @Before
     fun setup() {
         analyticsTracker = AnalyticsTracker(
-            appcuesCoroutineScope = coroutineScope,
             activityBuilder = activityBuilder,
             sessionMonitor = sessionMonitor,
             analyticsQueueProcessor = analyticsQueueProcessor,

--- a/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/AnalyticsTrackerTest.kt
@@ -34,7 +34,6 @@ internal class AnalyticsTrackerTest {
     @Before
     fun setup() {
         analyticsTracker = AnalyticsTracker(
-            appcuesCoroutineScope = coroutineScope,
             activityBuilder = activityBuilder,
             sessionMonitor = sessionMonitor,
             analyticsQueueProcessor = analyticsQueueProcessor,

--- a/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
+++ b/appcues/src/test/java/com/appcues/analytics/ExperienceLifecycleTrackerTest.kt
@@ -40,9 +40,9 @@ import com.google.common.truth.Truth.assertThat
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -262,7 +262,7 @@ internal class ExperienceLifecycleTrackerTest {
     private suspend fun initScope(state: State): AppcuesScope {
         val scope = createScope(state)
         val machine: StateMachine = scope.get()
-        val coroutineScope: AppcuesCoroutineScope = scope.get()
+        val coroutineScope: CoroutineScope = scope.get()
 
         coroutineScope.launch {
             // this collect on the stateFlow simulates the function of the UI
@@ -278,9 +278,7 @@ internal class ExperienceLifecycleTrackerTest {
             }
         }
 
-        coroutineScope.launch {
-            scope.get<ExperienceLifecycleTracker>().start(machine, {}, UnconfinedTestDispatcher())
-        }
+        scope.get<ExperienceLifecycleTracker>().start(machine) {}
 
         return scope
     }
@@ -290,7 +288,7 @@ internal class ExperienceLifecycleTrackerTest {
             modules = arrayListOf(object : AppcuesModule {
                 override fun AppcuesScopeDSL.install() {
                     scoped { AppcuesConfig("00000", "123") }
-                    scoped { AppcuesCoroutineScope(get()) }
+                    scoped<CoroutineScope> { AppcuesCoroutineScope(get()) }
                     scoped { mockk<AnalyticsTracker>(relaxed = true) }
                     scoped { mockk<SessionMonitor>(relaxed = true) }
                     scoped { mockk<Logcues>(relaxed = true) }

--- a/appcues/src/test/java/com/appcues/rules/TestScopeRule.kt
+++ b/appcues/src/test/java/com/appcues/rules/TestScopeRule.kt
@@ -26,6 +26,7 @@ import com.appcues.ui.ExperienceRenderer
 import com.appcues.util.ContextWrapper
 import com.appcues.util.LinkOpener
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
@@ -40,7 +41,7 @@ internal class TestScopeRule : TestWatcher() {
                     override fun AppcuesScopeDSL.install() {
                         scoped { mockk<LogcatDestination>(relaxed = true) }
                         scoped { AppcuesConfig("00000", "123") }
-                        scoped { AppcuesCoroutineScope(get()) }
+                        scoped<CoroutineScope> { AppcuesCoroutineScope(get()) }
                         scoped { mockk<AnalyticsTracker>(relaxed = true) }
                         scoped { mockk<SessionMonitor>(relaxed = true) }
                         scoped { mockk<Logcues>(relaxed = true) }

--- a/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/StateMachineTest.kt
@@ -1,6 +1,5 @@
 package com.appcues.statemachine
 
-import com.appcues.AppcuesCoroutineScope
 import com.appcues.AppcuesScopeTest
 import com.appcues.action.ActionProcessor
 import com.appcues.action.ExperienceAction
@@ -47,6 +46,7 @@ import io.mockk.coVerifyOrder
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
@@ -787,7 +787,7 @@ internal class StateMachineTest : AppcuesScopeTest {
     ): StateMachine {
         val stateFlowCompletion: CompletableDeferred<Boolean> = CompletableDeferred()
         val errorFlowCompletion: CompletableDeferred<Boolean> = CompletableDeferred()
-        val scope: AppcuesCoroutineScope = get()
+        val scope: CoroutineScope = get()
         val machine = StateMachine(get(), get(), state)
         // this collect on the stateFlow simulates the function of the UI
         // that is required to progress the state machine forward on UI present/dismiss

--- a/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/ExperienceRendererTest.kt
@@ -25,6 +25,7 @@ import com.appcues.logging.Logcues
 import com.appcues.mocks.mockEmbedExperience
 import com.appcues.mocks.mockExperience
 import com.appcues.mocks.mockExperienceExperiment
+import com.appcues.rules.MainDispatcherRule
 import com.appcues.statemachine.Action.EndExperience
 import com.appcues.statemachine.Action.StartExperience
 import com.appcues.statemachine.State
@@ -41,11 +42,16 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import java.util.UUID
 
 internal class ExperienceRendererTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
 
     @Test
     fun `dismissCurrentExperience SHOULD NOT mark complete WHEN current state is on last step`() = runTest {
@@ -516,7 +522,7 @@ internal class ExperienceRendererTest {
                     scoped { mockk<AnalyticsTracker>(relaxed = true) }
                     scoped { mockk<ExperienceLifecycleTracker>(relaxed = true) }
                     scoped { StateMachineDirectory() }
-                    scoped { AppcuesCoroutineScope(get()) }
+                    scoped<CoroutineScope> { AppcuesCoroutineScope(get()) }
                     scoped { mockk<Logcues>(relaxed = true) }
                 }
             })

--- a/appcues/src/test/java/com/appcues/ui/presentation/AppcuesViewModelTest.kt
+++ b/appcues/src/test/java/com/appcues/ui/presentation/AppcuesViewModelTest.kt
@@ -33,6 +33,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.mockk.verifySequence
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -56,7 +57,7 @@ internal class AppcuesViewModelTest {
 
     private val renderContext: RenderContext = RenderContext.Modal
 
-    private val coroutineScope: AppcuesCoroutineScope = AppcuesCoroutineScope(Logcues())
+    private val coroutineScope: CoroutineScope = AppcuesCoroutineScope(Logcues())
 
     private val experienceStates = MutableSharedFlow<State>(1)
     private val experienceRenderer: ExperienceRenderer = mockk(relaxed = true) {

--- a/gradle/tools/detekt/detekt-config.yml
+++ b/gradle/tools/detekt/detekt-config.yml
@@ -239,6 +239,7 @@ exceptions:
       - 'NumberFormatException'
       - 'ParseException'
       - 'JsonDataException'
+      - 'IOException'
       - 'TimeoutCancellationException'
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:


### PR DESCRIPTION
These updates came out of some investigation into how to make our automated tests more stable. The key change is allowing the tests to inject a `CoroutineScope` (i.e. `UnconfinedTestDispatcher`) instead of using the `AppcuesCoroutineScope`, to make the execution of our internal coroutines for analytics reporting more reliable during test runs. ([ref](https://developer.android.com/kotlin/coroutines/test?authuser=1#creating-your-own-testscope))

There were some other details found along the way that also tripped up tests, and I'll note those inline.

There is a corresponding change in the spec repo to use this new feature in the tests.

Posting this for visibility and to test in CI, but we can also wait for Andre on this one I think. Would be good to get his opinions on changes here.