### PR TITLE
Trim any leading hyphen on form response generated property names

### DIFF
--- a/appcues/src/main/java/com/appcues/util/StringExt.kt
+++ b/appcues/src/main/java/com/appcues/util/StringExt.kt
@@ -6,9 +6,11 @@ internal fun String.toSlug() = lowercase(Locale.getDefault())
     .replace("\n", " ")
     .replace("[^a-z\\d\\s]".toRegex(), " ")
     .split(" ")
+    .filter { it.isNotEmpty() }
     .joinToString("-")
     .replace("-+".toRegex(), "-")
     .trimEnd('-')
+    .trimStart('-')
 
 @Suppress("TooGenericExceptionCaught", "SwallowedException")
 internal fun String.beautify(indentationMultiplier: Int): String {

--- a/appcues/src/test/java/com/appcues/data/model/ExperienceStepFormStateTest.kt
+++ b/appcues/src/test/java/com/appcues/data/model/ExperienceStepFormStateTest.kt
@@ -363,6 +363,35 @@ internal class ExperienceStepFormStateTest {
         assertThat(formState.isFormComplete).isFalse()
     }
 
+    @Test
+    fun `form state SHOULD NOT include leading or trailing hyphens WHEN formatted to profile update`() {
+        // GIVEN
+        val formState = ExperienceStepFormState()
+        val options = optionItems(5)
+        val label = TextPrimitive(
+            id = UUID.randomUUID(),
+            spans = listOf(TextSpanPrimitive("*Personalized Onboarding Multi-Select Response-"))
+        )
+        val optionSelect = OptionSelectPrimitive(
+            id = UUID.randomUUID(),
+            label = label,
+            minSelections = 1u,
+            selectMode = MULTIPLE,
+            options = options,
+        )
+        val textInput = TextInputPrimitive(id = UUID.randomUUID(), label = label, required = true)
+        formState.register(textInput)
+        formState.register(optionSelect)
+        formState.setValue(optionSelect, options[0].value)
+
+        // WHEN
+        val profileUpdate = formState.formattedAsProfileUpdate()
+
+        // THEN
+        assertThat(profileUpdate.size).isEqualTo(1)
+        assertThat(profileUpdate.keys.first()).isEqualTo("_appcuesForm_personalized-onboarding-multi-select-response")
+    }
+
     private fun optionItems(count: Int) = (0..count).map {
         OptionItem("$it", TextPrimitive(UUID.randomUUID(), spans = listOf(TextSpanPrimitive("$it"))))
     }


### PR DESCRIPTION
The hyphen in the scenario described in the ticket was due to replacing of special char `*` with empty space ` `, then splitting on empty space, but not filtering out empty strings, then joining with a `-`. In this case, joining an empty string to the front with a hypen.

Fix here is to (A) filter out empty strings in the join, and (B) trim any leading hyphen for good measure.

| before | after | 
| --- | --- |
|  ![before](https://github.com/user-attachments/assets/74248537-09df-4c0a-841d-60b1ebd1c610) |  ![after](https://github.com/user-attachments/assets/226edf0c-f87e-491a-8385-9cb8c5418ffd) |
