### PR TITLE
simplify primitive deserialization

### DIFF
--- a/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
+++ b/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt
@@ -80,16 +80,16 @@ internal object MoshiConfiguration {
 
     private fun getPrimitiveFactory(): Factory {
         return PolymorphicJsonAdapterFactory.of(PrimitiveResponse::class.java, "type")
-            .withSubtype(BoxPrimitiveResponse::class.java, PrimitiveResponse.Type.BOX.jsonName)
-            .withSubtype(CustomComponentPrimitiveResponse::class.java, PrimitiveResponse.Type.CUSTOM_COMPONENT.jsonName)
-            .withSubtype(ButtonPrimitiveResponse::class.java, PrimitiveResponse.Type.BUTTON.jsonName)
-            .withSubtype(EmbedPrimitiveResponse::class.java, PrimitiveResponse.Type.EMBED.jsonName)
-            .withSubtype(ImagePrimitiveResponse::class.java, PrimitiveResponse.Type.IMAGE.jsonName)
-            .withSubtype(OptionSelectPrimitiveResponse::class.java, PrimitiveResponse.Type.OPTION_SELECT.jsonName)
-            .withSubtype(StackPrimitiveResponse::class.java, PrimitiveResponse.Type.STACK.jsonName)
-            .withSubtype(TextInputPrimitiveResponse::class.java, PrimitiveResponse.Type.TEXT_INPUT.jsonName)
-            .withSubtype(TextPrimitiveResponse::class.java, PrimitiveResponse.Type.TEXT.jsonName)
-            .withSubtype(BlockPrimitiveResponse::class.java, PrimitiveResponse.Type.BLOCK.jsonName)
-            .withSubtype(SpacerPrimitiveResponse::class.java, PrimitiveResponse.Type.SPACER.jsonName)
+            .withSubtype(BoxPrimitiveResponse::class.java, "box")
+            .withSubtype(CustomComponentPrimitiveResponse::class.java, "customComponent")
+            .withSubtype(ButtonPrimitiveResponse::class.java, "button")
+            .withSubtype(EmbedPrimitiveResponse::class.java, "embed")
+            .withSubtype(ImagePrimitiveResponse::class.java, "image")
+            .withSubtype(OptionSelectPrimitiveResponse::class.java, "optionSelect")
+            .withSubtype(StackPrimitiveResponse::class.java, "stack")
+            .withSubtype(TextInputPrimitiveResponse::class.java, "textInput")
+            .withSubtype(TextPrimitiveResponse::class.java, "text")
+            .withSubtype(BlockPrimitiveResponse::class.java, "block")
+            .withSubtype(SpacerPrimitiveResponse::class.java, "spacer")
     }
 }

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/response/step/primitive/PrimitiveResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/response/step/primitive/PrimitiveResponse.kt
@@ -1,57 +1,29 @@
 package com.appcues.data.remote.appcues.response.step.primitive
 
 import com.appcues.data.model.AppcuesConfigMap
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.BLOCK
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.BOX
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.BUTTON
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.CUSTOM_COMPONENT
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.EMBED
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.IMAGE
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.OPTION_SELECT
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.SPACER
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.STACK
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.TEXT
-import com.appcues.data.remote.appcues.response.step.primitive.PrimitiveResponse.Type.TEXT_INPUT
 import com.appcues.data.remote.appcues.response.styling.StyleColorResponse
 import com.appcues.data.remote.appcues.response.styling.StyleResponse
 import com.appcues.data.remote.appcues.response.styling.StyleSizeResponse
 import java.util.UUID
 
-internal sealed class PrimitiveResponse(
-    val type: Type,
-) {
-
-    enum class Type(val jsonName: String) {
-        STACK("stack"),
-        BOX("box"),
-        CUSTOM_COMPONENT("customComponent"),
-        BUTTON("button"),
-        TEXT("text"),
-        IMAGE("image"),
-        EMBED("embed"),
-        SPACER("spacer"),
-        TEXT_INPUT("textInput"),
-        OPTION_SELECT("optionSelect"),
-        BLOCK("block"),
-    }
-
+internal sealed class PrimitiveResponse {
     internal data class BlockPrimitiveResponse(
         val id: UUID,
         val content: PrimitiveResponse,
-    ) : PrimitiveResponse(BLOCK)
+    ) : PrimitiveResponse()
 
     internal data class BoxPrimitiveResponse(
         val id: UUID,
         val style: StyleResponse? = null,
         val items: List<PrimitiveResponse>,
-    ) : PrimitiveResponse(BOX)
+    ) : PrimitiveResponse()
 
     internal data class CustomComponentPrimitiveResponse(
         val id: UUID,
         val style: StyleResponse? = null,
         val identifier: String,
         val config: AppcuesConfigMap,
-    ) : PrimitiveResponse(CUSTOM_COMPONENT)
+    ) : PrimitiveResponse()
 
     internal data class StackPrimitiveResponse(
         val id: UUID,
@@ -61,14 +33,14 @@ internal sealed class PrimitiveResponse(
         val distribution: String? = null,
         val spacing: Double = 0.0,
         val sticky: String? = null,
-    ) : PrimitiveResponse(STACK)
+    ) : PrimitiveResponse()
 
     internal data class TextPrimitiveResponse(
         val id: UUID,
         val style: StyleResponse? = null,
         val text: String? = null,
         val spans: List<TextSpanResponse>? = null,
-    ) : PrimitiveResponse(TEXT)
+    ) : PrimitiveResponse()
 
     internal data class TextSpanResponse(
         val text: String,
@@ -79,7 +51,7 @@ internal sealed class PrimitiveResponse(
         val id: UUID,
         val style: StyleResponse? = null,
         val content: PrimitiveResponse,
-    ) : PrimitiveResponse(BUTTON)
+    ) : PrimitiveResponse()
 
     internal data class ImagePrimitiveResponse(
         val id: UUID,
@@ -89,19 +61,19 @@ internal sealed class PrimitiveResponse(
         val blurHash: String? = null,
         val intrinsicSize: StyleSizeResponse? = null,
         val accessibilityLabel: String? = null,
-    ) : PrimitiveResponse(IMAGE)
+    ) : PrimitiveResponse()
 
     internal data class EmbedPrimitiveResponse(
         val id: UUID,
         val style: StyleResponse? = null,
         val embed: String,
         val intrinsicSize: StyleSizeResponse? = null,
-    ) : PrimitiveResponse(EMBED)
+    ) : PrimitiveResponse()
 
     internal data class SpacerPrimitiveResponse(
         val id: UUID,
         val spacing: Double = 0.0,
-    ) : PrimitiveResponse(SPACER)
+    ) : PrimitiveResponse()
 
     internal data class OptionSelectPrimitiveResponse(
         val id: UUID,
@@ -122,7 +94,7 @@ internal sealed class PrimitiveResponse(
         val accentColor: StyleColorResponse?,
         val attributeName: String?,
         val leadingFill: Boolean?
-    ) : PrimitiveResponse(OPTION_SELECT) {
+    ) : PrimitiveResponse() {
 
         data class OptionItem(
             val value: String,
@@ -145,5 +117,5 @@ internal sealed class PrimitiveResponse(
         val textFieldStyle: StyleResponse?,
         val cursorColor: StyleColorResponse?,
         val attributeName: String?,
-    ) : PrimitiveResponse(TEXT_INPUT)
+    ) : PrimitiveResponse()
 }


### PR DESCRIPTION
This change resolves an issue that a customer observed where minified builds (Proguard) would fail to render an experience. The issue resulted in a JSON deserialization error, from Moshi, the JSON library we use.

```
com.squareup.moshi.JsonDataException: Expected one of [STACK, BOX, CUSTOM_COMPONENT, BUTTON, TEXT, IMAGE, EMBED, SPACER, TEXT_INPUT, OPTION_SELECT, BLOCK] but was text at path $.steps[0].children[0].content.items[0].items[0].content.errorLabel.type
```

Tracing through the problem and the customer provided build configuration. I was able to reproduce by using the `-dontshrink` option in a sample app proguard-rules.pro file, and building against a matching Kotlin version `2.1.0` (our core sdk still builds against the older `1.8.22`) - using a release config build with `isMinifyEnabled = true`.

Here is what appears to be happening
* We use a `PolymorphicJsonAdapterFactory` from Moshi [here](https://github.com/appcues/appcues-android-sdk/blob/main/appcues/src/main/java/com/appcues/data/MoshiConfiguration.kt#L82-L93), to deserialize the correct primitive type, based on the `"type"` property in the JSON coming in
* The `PrimitiveResponse` base class has a [type](https://github.com/appcues/appcues-android-sdk/blob/main/appcues/src/main/java/com/appcues/data/remote/appcues/response/step/primitive/PrimitiveResponse.kt#L21) field that references this [Type enum](https://github.com/appcues/appcues-android-sdk/blob/main/appcues/src/main/java/com/appcues/data/remote/appcues/response/step/primitive/PrimitiveResponse.kt#L24-L36) in the same file
* That `PrimitiveResponse.Type` has a `jsonName` field that is the text representation in the JSON model that maps to each enum value - ex: `"text"` maps to enum value `TEXT`.
* As we deserialize, most of the base `PrimitiveResponse` values work ok still, but eventually we get to a nested `TextPrimitiveResponse` -- see the path in the error `$.steps[0].children[0].content.items[0].items[0].content.errorLabel` - this corresponds to an `OptionSelectPrimitiveResponse.errorLabel` [here](https://github.com/appcues/appcues-android-sdk/blob/main/appcues/src/main/java/com/appcues/data/remote/appcues/response/step/primitive/PrimitiveResponse.kt#L110) - which is a nested `TextPrimitiveResponse` -- a specific derived type, not the base class `PrimitiveResponse` that the Moshi adapter is configured for
* When it tries to deserialize this type (I believe using a default adapter for that type, not the custom adapter for the base type), for some reason it is unable to map `"text"` the the `type` property (the enum) on the base class -- and this only happens in the minified build with the `-dontshrink` option. Something about how Proguard is optimizing/renaming/moving things is breaking this

The fix: we don't actually need this `type` property on the base class at all, it is never used anywhere else in the code. We can simplify our `PolymorphicJsonAdapterFactory` to just pick the correct primitive type based on the string value, and remove this `Type` enum entirely. This solves the problem.

Why did this work before? I don't know. It seems to work in our test app with an earlier version of Kotlin, even when that proguard rule is applied. So something changed, and it is unclear if the prior behavior was simply due to luck at this point. But, I think this implementation is simpler and does not rely on any unclear deserialization side effects - resolves the issue.