### PR TITLE
Ensure content is rendered in the correct Activity view hierarchy

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt
+++ b/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt
@@ -22,7 +22,7 @@ internal fun Activity.getParentView(): ViewGroup {
         // in case of multiple views, get the one that is hosting android.R.id.content
         // we get the last one because sometimes stacking activities might be listed in this method,
         // and we always want the one that is on top
-        WindowInspector.getGlobalWindowViews().findTopMost() ?: window.decorView
+        WindowInspector.getGlobalWindowViews().findTopMost(this) ?: window.decorView
     } else {
         @Suppress("SwallowedException", "TooGenericExceptionCaught")
         try {
@@ -33,15 +33,17 @@ internal fun Activity.getParentView(): ViewGroup {
             val getRootView: Method = windowManagerClass.getMethod("getRootView", String::class.java)
             val rootViewNames = getViewRootNames.invoke(windowManager) as Array<Any?>
             val rootViews = rootViewNames.map { getRootView(windowManager, it) as View }
-            rootViews.findTopMost() ?: window.decorView
+            rootViews.findTopMost(this) ?: window.decorView
         } catch (ex: Exception) {
             Log.e("Appcues", "error getting decorView, ${ex.message}")
             // if all else fails, use the decorView on the window, which is typically the only one
             window.decorView
         }
     }
-
+    
     return decorView.rootView as ViewGroup
 }
 
-private fun List<View>.findTopMost() = lastOrNull { it.findViewById<View?>(android.R.id.content) != null }
+private fun List<View>.findTopMost(activity: Activity) = lastOrNull {
+    it.context == activity && it.findViewById<View?>(android.R.id.content) != null
+}


### PR DESCRIPTION
Discovered during investigation of a customer issue. When one Activity is navigating back to another Activity, there is a brief moment in time where `WindowInspector.getGlobalWindowViews()` will return multiple global views - one for both the exiting and entering Activities. We were not properly filtering to find our target view to inject content. We should always find the view that is within the target Activity we are rendering content within (already known from our `AppcuesActivityMonitor`).

## More details
To reproduce, I qualified for content in a Fragment onResume, right as one Activity was exiting to return to the previous Activity and returning back to the screen to qualify. This correctly results in the "current" Activity we track updating [here](https://github.com/appcues/appcues-android-sdk/blob/4.3.5/appcues/src/main/java/com/appcues/monitor/AppcuesActivityMonitor.kt#L51). 

In the `ViewPresenter` that is handling the rendering of the new content, we get the correct Activity reference, [here](https://github.com/appcues/appcues-android-sdk/blob/4.3.5/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt#L85). 

The problem lies within the call to getParentView [here](https://github.com/appcues/appcues-android-sdk/blob/4.3.5/appcues/src/main/java/com/appcues/ui/presentation/ViewPresenter.kt#L92). While the prior code was an extension on `Activity`, it actually was not using the target `Activity`, at all [here](https://github.com/appcues/appcues-android-sdk/blob/4.3.5/appcues/src/main/java/com/appcues/ui/utils/ActivityExt.kt#L15). This allowed the observed flaw where the global Window View from the exiting activity was being selected for injecting the new Appcues content, rather than the target/new Activity.

[sc-77236]