### PR TITLE
Improve push open handling

### DIFF
--- a/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/DeepLinkHandler.kt
@@ -3,7 +3,6 @@ package com.appcues
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
-import android.os.Bundle
 import android.widget.Toast
 import com.appcues.data.model.ExperienceTrigger.DeepLink
 import com.appcues.debugger.AppcuesDebuggerManager
@@ -45,7 +44,6 @@ internal class DeepLinkHandler(scope: AppcuesScope) {
         if (intent == null) return false
         val linkAction: String? = intent.action
         val linkData: Uri? = intent.data
-        val extras = intent.extras
 
         if (linkData != null) {
             val scheme = contextWrapper.getString(R.string.appcues_custom_scheme).ifEmpty { "appcues-${config.applicationId}" }
@@ -53,7 +51,7 @@ internal class DeepLinkHandler(scope: AppcuesScope) {
             val validHost = linkData.host == "sdk"
 
             if (linkAction == Intent.ACTION_VIEW && validScheme && validHost) {
-                return processLink(linkData, activity, extras)
+                return processLink(linkData, activity)
             }
         }
 
@@ -72,7 +70,7 @@ internal class DeepLinkHandler(scope: AppcuesScope) {
     }
 
     // return true if handled
-    private fun processLink(linkData: Uri, activity: Activity, extras: Bundle?): Boolean {
+    private fun processLink(linkData: Uri, activity: Activity): Boolean {
         val segments = linkData.pathSegments
         val query = linkData.getQueryMap()
 
@@ -106,7 +104,7 @@ internal class DeepLinkHandler(scope: AppcuesScope) {
                 }
             }
 
-            pushDeeplinkHandler.processLink(activity, segments, extras, query) -> true
+            pushDeeplinkHandler.processLink(activity, segments, query) -> true
 
             else -> false
         }

--- a/appcues/src/main/java/com/appcues/debugger/model/DebuggerConstants.kt
+++ b/appcues/src/main/java/com/appcues/debugger/model/DebuggerConstants.kt
@@ -8,6 +8,6 @@ internal object DebuggerConstants {
     @SuppressWarnings("MagicNumber")
     // used in multiple places for ui testing purposes
     val testDate: Date = Calendar.getInstance().apply {
-        set(2024, Calendar.SEPTEMBER, 19, 0, 23, 0)
+        timeInMillis = 1726719780000L
     }.time
 }

--- a/appcues/src/main/java/com/appcues/debugger/ui/DebuggerExt.kt
+++ b/appcues/src/main/java/com/appcues/debugger/ui/DebuggerExt.kt
@@ -67,5 +67,6 @@ internal fun String.toEventTitle(): Int? = when (this) {
     AnalyticsEvent.ExperienceDismissed.eventName -> R.string.appcues_debugger_event_type_experience_dismissed_title
     AnalyticsEvent.ExperienceError.eventName -> R.string.appcues_debugger_event_type_experience_error_title
     AnalyticsEvent.ExperienceRecovery.eventName -> R.string.appcues_debugger_event_type_experience_recover_title
+    AnalyticsEvent.PushOpened.eventName -> R.string.appcues_debugger_event_type_push_opened_title
     else -> null
 }

--- a/appcues/src/main/res/values/strings.xml
+++ b/appcues/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="appcues_debugger_event_type_experience_dismissed_title">Experience Dismissed</string>
     <string name="appcues_debugger_event_type_experience_error_title">Experience Error</string>
     <string name="appcues_debugger_event_type_experience_recover_title">Experience Recovered</string>
+    <string name="appcues_debugger_event_type_push_opened_title">Push Opened</string>
 
     <string name="appcues_debugger_back_description">Back</string>
     <string name="appcues_debugger_event_details_title">Event details</string>


### PR DESCRIPTION
It was discovered that on cross platform frameworks, the push open tracking was not working as expected. The reason for this is the usage of Intent `extras` to pass the push details. 

The simplest approach I could think of to improve this was to just move to a URL query parameter approach to pass the extras, which accomplishes the same result but is cross-platform friendly with things like React Native linking - where the URL is already passed back to the JS side of the app and processed through normal deep link handling (passing into our SDK). This seems to work fine and allow us to avoid any other changes on the x-plat sides.

Here is the end result in React Native using an updated local library for the native dependency - Push opens, tracks analytics, and launches a linked flow:


https://github.com/user-attachments/assets/cde4b4f7-e680-46cd-950e-c6c8846492eb

Also did some touch up on the debugger recent events view here, to (A) give a friendly name for the `Push Opened` event and (B) fix up some details around how the floating events appear and fade out, to make this behave more smoothly.

Before this change, the visibility changes were not quite right, and things would hang until a new event came through. Also, all items were hidden at once, when the final item expired, not on a per item basis - video below shows the before:

https://github.com/user-attachments/assets/4e777df3-dc10-4a63-858f-cf1adfc6fb8a

After this change, the items start to fade correctly after 1 sec, with a smooth fade, then disappear after 1 more second - on a per item basis. Video below shows the after:

https://github.com/user-attachments/assets/0db28456-9dd0-47b7-a2a6-c5197bd79958