### PR TITLE
Update test date precision

### DIFF
--- a/appcues/src/main/java/com/appcues/debugger/model/DebuggerConstants.kt
+++ b/appcues/src/main/java/com/appcues/debugger/model/DebuggerConstants.kt
@@ -8,6 +8,6 @@ internal object DebuggerConstants {
     @SuppressWarnings("MagicNumber")
     // used in multiple places for ui testing purposes
     val testDate: Date = Calendar.getInstance().apply {
-        set(2024, Calendar.SEPTEMBER, 19, 0, 23, 0)
+        timeInMillis = 1726719780000L
     }.time
 }


### PR DESCRIPTION
Use exact millisecond precision on the test data so the snapshot tests don't have small differences on [this screen](https://github.com/appcues/appcues-mobile-experience-spec/blob/main/verification-suites/android/snapshots/DebuggerTests/testDebuggerPanel.3.png)
