### PR TITLE
Add an option to control embed cache behavior and retained content

### DIFF
--- a/appcues/src/main/java/com/appcues/AppcuesFrameView.kt
+++ b/appcues/src/main/java/com/appcues/AppcuesFrameView.kt
@@ -18,7 +18,17 @@ public class AppcuesFrameView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
-    internal val composeView = ComposeView(context)
+    internal var composeView = ComposeView(context)
+
+    /**
+     * When retainContent is `true` (default), the embed frame content is cached and re-rendered through any
+     * re-register of this frame until the next screen_view qualification occurs. This default behavior enables
+     * common cell-reuse type of use cases, such as embeds in recycler views.
+     *
+     * Set this value `false` to require each new register of the same frame ID to qualify for new content
+     * independently of any previous usage of the frame view.
+     */
+    public var retainContent: Boolean = true
 
     init {
         // frame view will start GONE and the view presenter
@@ -28,6 +38,18 @@ public class AppcuesFrameView @JvmOverloads constructor(
     }
 
     internal fun reset() {
-        composeView.setContent { }
+        // just clearing the compose view like
+        //
+        //   composeView.setContent { }
+        //
+        // appears to be problematic, and can live the view in a state where new content
+        // is not rendered correctly upon next usage.
+        //
+        // thus, below we remove the view entirely and create a new one. This ensures
+        // that a cell re-use type of scenario can re-render content as needed.
+
+        removeView(composeView)
+        composeView = ComposeView(context)
+        addView(composeView)
     }
 }

--- a/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
+++ b/appcues/src/main/java/com/appcues/analytics/ExperienceLifecycleTracker.kt
@@ -108,15 +108,13 @@ internal class ExperienceLifecycleTracker(
                 }
             }
             is EndingExperienceState -> {
-                if (trackAnalytics) {
-                    if (markComplete) {
-                        // if ending on the last step OR an action requested it be considered complete explicitly,
-                        // track the experience_completed event
-                        trackLifecycleEvent(ExperienceCompleted(experience))
-                    } else {
-                        // otherwise its considered experience_dismissed (not completed)
-                        trackLifecycleEvent(ExperienceDismissed(experience, flatStepIndex))
-                    }
+                if (markComplete) {
+                    // if ending on the last step OR an action requested it be considered complete explicitly,
+                    // track the experience_completed event
+                    trackLifecycleEvent(ExperienceCompleted(experience))
+                } else {
+                    // otherwise its considered experience_dismissed (not completed)
+                    trackLifecycleEvent(ExperienceDismissed(experience, flatStepIndex))
                 }
             }
             else -> Unit

--- a/appcues/src/main/java/com/appcues/statemachine/Action.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/Action.kt
@@ -11,7 +11,6 @@ internal sealed class Action {
     data class EndExperience(
         val markComplete: Boolean,
         val destroyed: Boolean,
-        val trackAnalytics: Boolean = true,
     ) : Action()
 
     object Reset : Action()

--- a/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/StateMachine.kt
@@ -84,6 +84,8 @@ internal class StateMachine(
     }
 
     suspend fun stop(dismiss: Boolean) {
+        // on a forced stop (reset) - we stop any lifecycle tracking (analytics callbacks)
+        stopLifecycleTracking()
         handleAction(
             EndExperience(
                 markComplete = false,
@@ -91,8 +93,6 @@ internal class StateMachine(
                 // for this use case - when !destroyed, the state machine will wait on the UI to dismiss and
                 // signal to move to next step
                 destroyed = !dismiss,
-                // special case - no complete/dismiss analytics tracked on a force stop
-                trackAnalytics = false
             )
         )
     }

--- a/appcues/src/main/java/com/appcues/statemachine/states/EndingExperienceState.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/states/EndingExperienceState.kt
@@ -12,7 +12,6 @@ internal data class EndingExperienceState(
     val experience: Experience,
     val flatStepIndex: Int,
     val markComplete: Boolean,
-    val trackAnalytics: Boolean,
 ) : State {
 
     override val currentExperience: Experience

--- a/appcues/src/main/java/com/appcues/statemachine/states/EndingStepState.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/states/EndingStepState.kt
@@ -38,7 +38,7 @@ internal data class EndingStepState(
 
     private fun toEndingExperience(action: EndExperience): Transition {
         return next(
-            state = EndingExperienceState(experience, flatStepIndex, action.markComplete, action.trackAnalytics),
+            state = EndingExperienceState(experience, flatStepIndex, action.markComplete),
             sideEffect = ContinuationEffect(Reset)
         )
     }

--- a/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
+++ b/appcues/src/main/java/com/appcues/ui/StateMachineDirectory.kt
@@ -36,6 +36,9 @@ internal class AppcuesFrameStateMachineOwner(
         _frame.clear()
     }
 
+    // this is called on scenarios like cell re-use in a recycler, when a frame view
+    // gets recycled into a different frame ID, or in any scenario where a frame ID is
+    // set to a different frame - this frame is no longer valid
     override suspend fun reset() {
         frame?.reset()
         // do not need to dismiss here, as the frame UI is already removed for embed
@@ -62,6 +65,10 @@ internal class StateMachineDirectory {
 
     fun setOwner(owner: StateMachineOwning) {
         stateMachines[owner.renderContext] = owner
+    }
+
+    fun remove(context: RenderContext) {
+        stateMachines.remove(context)
     }
 
     suspend fun resetAll() {

--- a/appcues/src/test/java/com/appcues/statemachine/states/EndingExperienceStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/EndingExperienceStateTest.kt
@@ -16,7 +16,7 @@ internal class EndingExperienceStateTest {
     fun `EndingExperienceState SHOULD be instance of STATE`() {
         // GIVEN
         val experience = mockk<Experience>()
-        val state = EndingExperienceState(experience, 0, markComplete = true, trackAnalytics = true)
+        val state = EndingExperienceState(experience, 0, markComplete = true)
         // THEN
         assertThat(state).isInstanceOf(State::class.java)
         assertThat(state.currentExperience).isEqualTo(experience)
@@ -27,7 +27,7 @@ internal class EndingExperienceStateTest {
     fun `take SHOULD ignore listed actions`() {
         // GIVEN
         val experience = mockk<Experience>()
-        val state = EndingExperienceState(experience, 0, markComplete = true, trackAnalytics = true)
+        val state = EndingExperienceState(experience, 0, markComplete = true)
         // THEN
         state.assertIgnoredActions(
             listOf(
@@ -46,7 +46,7 @@ internal class EndingExperienceStateTest {
     fun `take Reset SHOULD transition to IdlingState AND no sideEffects WHEN markedComplete is false`() {
         // GIVEN
         val experience = mockk<Experience>()
-        val state = EndingExperienceState(experience, 0, markComplete = false, trackAnalytics = true)
+        val state = EndingExperienceState(experience, 0, markComplete = false)
         // WHEN
         val transition = state.take(Reset)
         // THEN
@@ -61,7 +61,7 @@ internal class EndingExperienceStateTest {
         val experience = mockk<Experience> {
             every { completionActions } returns actions
         }
-        val state = EndingExperienceState(experience, 0, markComplete = true, trackAnalytics = true)
+        val state = EndingExperienceState(experience, 0, markComplete = true)
         // WHEN
         val transition = state.take(Reset)
         // THEN

--- a/appcues/src/test/java/com/appcues/statemachine/states/EndingStepStateTest.kt
+++ b/appcues/src/test/java/com/appcues/statemachine/states/EndingStepStateTest.kt
@@ -50,11 +50,11 @@ internal class EndingStepStateTest {
         val experience = mockk<Experience>()
         val currentStep = 2
         val state = EndingStepState(experience, currentStep, true, null)
-        val action = EndExperience(markComplete = true, destroyed = false, trackAnalytics = false)
+        val action = EndExperience(markComplete = true, destroyed = false)
         // WHEN
         val transition = state.take(action)
         // THEN
-        transition.assertState(EndingExperienceState(experience, currentStep, action.markComplete, action.trackAnalytics))
+        transition.assertState(EndingExperienceState(experience, currentStep, action.markComplete))
         transition.assertEffect(ContinuationEffect(Reset))
     }
 

--- a/docs/AppcuesFrameViewConfiguring.md
+++ b/docs/AppcuesFrameViewConfiguring.md
@@ -41,8 +41,9 @@ Column {
 
 ## Other Considerations
 
-* The `frameId` registered with Appcues for each frame should ideally be globally unique in the application, but at least must be unique on the screen where experience content may be targeted. 
-* Some `AppcuesFrameView` instances may not be visible on the screen when it first loads, if they are lower down on a scrolling page, for instance. However, when they scroll into view, any qualified content on that screen will then render into that position.
-* Using `AppcuesFrameView` in views with element re-use (ex. `RecyclerView`) is supported, but may require re-registering with a new `frameId` when elements are re-used, depending on your use case.
-* When configuring settings for triggering embedded experience content, make sure that the experience is triggered on the same screen where the target `frameId` exists.
-* To preview embedded content from the mobile builder inside your application, you may need to initiate the preview and then navigate to the screen where the target `frameId` exists.
+- The `frameId` registered with Appcues for each frame should ideally be globally unique in the application, but at least must be unique on the screen where experience content may be targeted.
+- Some `AppcuesFrameView` instances may not be visible on the screen when it first loads, if they are lower down on a scrolling page, for instance. However, when they scroll into view, any qualified content on that screen will then render into that position.
+- Using `AppcuesFrameView` in views with element re-use (ex. `RecyclerView`) is supported, but may require re-registering with a new `frameId` when elements are re-used, depending on your use case.
+- If you are re-registering a frame in a non cell re-use situation where you don't need the content to re-render, setting the `retainContent` property to `false` on the `AppcuesFrameView` instance prevents having the same content re-render.
+- When configuring settings for triggering embedded experience content, make sure that the experience is triggered on the same screen where the target `frameId` exists.
+- To preview embedded content from the mobile builder inside your application, you may need to initiate the preview and then navigate to the screen where the target `frameId` exists.


### PR DESCRIPTION
The idea here is to add a `retainContent` (default true) option on `AppcuesFrameView`, to give control over how the embed cache operates. 

By default, a frame with embed content can render over and over as the same frameId is re-registered in a situation like a recycler view. However, in some use cases this is undesired, and a subsequent render of the embed on a new view load would actually show content that was not supposed to be qualified. If a fragment is launching, for instance, and sometimes should qualify, but sometimes not - each new render of the view should only show current qualified experiences - nothing from cache. This can now be accomplished by setting `retainContent = false` on that particular frame view.

Note: we also had a bug here where the desired recyclerView behavior was not working - this is because the frame reset was triggering an `onExperienceEnded` callback and clearing the cache. The existing unit test did not catch this, as that dependency was mocked (its a chain of callbacks through the ExperienceLifecycleListener). I've reworked this to make the default behavior work as expected, and match iOS. Will comment inline in a couple spots on this detail. 

## Usage
This feature would require opting-in to set the new property, something like this, when registering the frame.
```kotlin
    override fun onCreateView(
        inflater: LayoutInflater,
        container: ViewGroup?,
        savedInstanceState: Bundle?
    ): View {
        _binding = FragmentRecyclerviewBinding.inflate(inflater, container, false)
        
        appcues.registerEmbed("embedRecyclerFrame", binding.embedRecyclerFrame.apply { retainContent = false })  // <-- Here!

        return binding.root
    }
```

and we'll need to provide similar options in cross-platform wrappers that may want to use this. One alternative would be the change the registration API (`registerEmbed` function) to add another optional parameter. I don't feel too strongly either way, but this approach as a view property was my first instinct to support the option.