### PR TITLE
Do not execute pre-step navigation actions again when a step is attempting to recover from error

### DIFF
--- a/appcues/src/main/java/com/appcues/statemachine/effects/PresentationEffect.kt
+++ b/appcues/src/main/java/com/appcues/statemachine/effects/PresentationEffect.kt
@@ -20,7 +20,7 @@ internal data class PresentationEffect(
 ) : SideEffect {
 
     override suspend fun launch(processor: ActionProcessor): Action {
-        if (stepContainerIndex != 0 || experience.trigger !is Qualification) {
+        if (!isRecovering && (stepContainerIndex != 0 || experience.trigger !is Qualification)) {
             // for pre-step navigation actions - only allow these to execute if this experience is being launched for some
             // other reason than qualification (i.e. deep links, preview, manual show). For any qualified experience, the initial
             // starting state of the experience is determined solely by flow settings determining the trigger


### PR DESCRIPTION
Turned out to be a simple one-liner, as we already have a reference in this presentation logic to tell us if we are in recovery mode.