### PR TITLE
Update maven publish plugin to 0.32

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
     id 'kotlin-kapt'
-    id "com.vanniktech.maven.publish" version "0.31.0"
+    id "com.vanniktech.maven.publish" version "0.32.0"
 }
 
 apply from: 'artifacts-android.gradle'


### PR DESCRIPTION
minor update, but wanted to include [this improvement](https://github.com/vanniktech/gradle-maven-publish-plugin/pull/935) for package names during publish to Maven Central that was released
https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.32.0

it will give a more readable name for each artifact to distinguish this SDK from the Segment plugin, rather than just a UUID value.