### PR TITLE
Update to Compose 1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ The SDK is a Kotlin library for sending user properties and events to the Appcue
 
 ### Prerequisites
 
-Your application's `build.gradle` must have a `compileSdkVersion` of 34+ and `minSdkVersion` of 21+, and use Android Gradle Plugin (AGP) 8+.
+Your application's `build.gradle` must have a `compileSdk` of 35+ and `minSdk` of 21+, and use Android Gradle Plugin (AGP) 8+.
 
 ```
 android {
-    compileSdkVersion 34
+    compileSdk 35
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk 21
     }
 }
 ```

--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -14,7 +14,7 @@ apply from: 'dokka.gradle'
 apply from: 'appcues-properties.gradle'
 
 ext.room_version = '2.6.1'
-ext.compose_version = '1.7.3'
+ext.compose_version = '1.8.2'
 ext.compose_compiler_version = '1.4.8'
 ext.coil_version = '2.4.0'
 ext.moshi_version = '1.15.0'

--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     namespace "com.appcues.samples.kotlin"
 


### PR DESCRIPTION
Address #676 

* Updates Jetpack Compose `1.7.3` -> `1.8.2`
* Updates required `compileSdk: 34` -> `compileSdk: 35`

There were changes in Compose 1.8.0-alpha06 to how AnchoredDraggableState confirmValueChange` works [ref](https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.8.0-alpha06) ([code](https://android-review.googlesource.com/c/platform/frameworks/support/+/3260759/5/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/AnchoredDraggable.kt))

> instead of vetoing state changes, disallowed anchors should not be in the active anchor set, and an OverscrollEffect should be used to indicate the unavailability of the requested action.

We use the veto state changes behavior [here](https://github.com/appcues/appcues-android-sdk/blob/4.3.8/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt#L324) for a snapback effect on slideout swipe when dismiss is not allowed, purely a UI thing, but now flagging this function as deprecated.

Simply updating to 1.8+ fixes things, allows our SDK to be used in apps using 1.8+, and continues to work with the deprecated functions. We also need to revise the deprecated code of course at some point, but still works.

So why the crash if the app uses 1.8 but the sdk uses 1.7? The related constructor was moved.

in 1.7
commonMain/androidx/compose/foundation/gestures/AnchoredDraggable.kt
```kotlin
@Stable
@ExperimentalFoundationApi
class AnchoredDraggableState<T>(
    initialValue: T,
    internal val positionalThreshold: (totalDistance: Float) -> Float,
    internal val velocityThreshold: () -> Float,
    val snapAnimationSpec: AnimationSpec<Float>,
    val decayAnimationSpec: DecayAnimationSpec<Float>,
    internal val confirmValueChange: (newValue: T) -> Boolean = { true }
)
```

in 1.8
commonMain/androidx/compose/foundation/gestures/AnchoredDraggable.kt
```kotlin
@Deprecated(ConfigurationMovedToModifier, level = DeprecationLevel.WARNING)
@Suppress("DEPRECATION") // confirmValueChange is deprecated
fun <T> AnchoredDraggableState(
    initialValue: T,
    positionalThreshold: (totalDistance: Float) -> Float,
    velocityThreshold: () -> Float,
    snapAnimationSpec: AnimationSpec<Float>,
    decayAnimationSpec: DecayAnimationSpec<Float>,
    confirmValueChange: (newValue: T) -> Boolean = { true }
)
```
 
what was once the class constructor was moved to a top level "constructor function" instead. This confuses the runtime and you get the cryptic error
```
E/AndroidRuntime(PID): java.lang.NoSuchMethodError: No direct method
(Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/animation/core/AnimationSpec;Landroidx/compose/animation/core/D
ecayAnimationSpec;Lkotlin/jvm/functions/Function1;)V in class Landroidx.compose/foundation/gestures/AnchoredDraggableState; or its super classes
```

I believe [this](https://android-review.googlesource.com/c/platform/frameworks/support/+/3012013/37/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/AnchoredDraggable.kt) is the actual change where it happened, but regardless, it breaks now. So we have to provide the option to use the new 1.8 version to any app that is on compose 1.8 itself (or via other dependencies). 

**Important note:** Using compose 1.8+ does bring along the implication that the app update to `compileSdk: 35`.