### PR TITLE
Force compose foundation lib version to match other compose dependencies

### DIFF
--- a/appcues/build.gradle
+++ b/appcues/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     implementation "androidx.startup:startup-runtime:1.2.0"
     implementation "androidx.navigation:navigation-compose:2.7.3"
     implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"


### PR DESCRIPTION
There was an unexpected dependency version still lingering in the recent update to Compose 1.8.2 in #677 

This PR should resolve it, the full details/explanation are noted in https://github.com/appcues/appcues-flutter-plugin/issues/109#issuecomment-2962583455

This should resolve #676 and related Flutter update will resolve https://github.com/appcues/appcues-flutter-plugin/issues/109