### PR TITLE
Capture push intended user id from push payload, not local storage

### DIFF
--- a/appcues/src/main/java/com/appcues/push/PushDeeplinkHandler.kt
+++ b/appcues/src/main/java/com/appcues/push/PushDeeplinkHandler.kt
@@ -35,6 +35,7 @@ internal class PushDeeplinkHandler(
         private const val NOTIFICATION_WORKFLOW_TASK_ID_PARAM = "workflow_task_id"
         private const val NOTIFICATION_WORKFLOW_VERSION_PARAM = "workflow_version"
         private const val NOTIFICATION_FORWARD_DEEPLINK_PARAM = "forward_deeplink"
+        private const val NOTIFICATION_USER_ID_PARAM = "user_id"
 
         private const val NETWORK_ERROR_NOT_FOUND = 404
 
@@ -48,6 +49,7 @@ internal class PushDeeplinkHandler(
                 .appendPath("notification")
                 .appendPath(appcuesData.notificationId)
                 .apply {
+                    appendQueryParameter(NOTIFICATION_USER_ID_PARAM, appcuesData.userId)
                     if (appcuesData.test) { appendQueryParameter(NOTIFICATION_TEST_PARAM, "true") }
                     appcuesData.notificationVersion?.let { appendQueryParameter(NOTIFICATION_VERSION_PARAM, it.toString()) }
                     appcuesData.workflowId?.let { appendQueryParameter(NOTIFICATION_WORKFLOW_ID_PARAM, it) }
@@ -99,8 +101,9 @@ internal class PushDeeplinkHandler(
 
         val deeplink = query[NOTIFICATION_FORWARD_DEEPLINK_PARAM]
         val experienceId = query[NOTIFICATION_SHOW_CONTENT_PARAM]
+        val userId = query[NOTIFICATION_USER_ID_PARAM]
 
-        val action = PushOpenedAction(pushNotificationId, storage.userId, properties, deeplink, experienceId, isTest)
+        val action = PushOpenedAction(pushNotificationId, userId, properties, deeplink, experienceId, isTest)
 
         if (sessionMonitor.hasSession()) {
             coroutineScope.launch { pushOpenedProcessor.process(action) }

--- a/appcues/src/main/java/com/appcues/push/PushOpenedAction.kt
+++ b/appcues/src/main/java/com/appcues/push/PushOpenedAction.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 
 internal data class PushOpenedAction(
     val pushNotificationId: UUID,
-    val userId: String,
+    val userId: String?,
     val eventProperties: Map<String, Any>?,
     val deeplink: String?,
     val experienceId: String?,


### PR DESCRIPTION
Fixing an issue customer ran into when executing deferred push notifications, taps on a notification when the current user was not in an identified state. This was a flaw in the previous logic, where we should be using the `user_id` from the push data, not storage.

The purpose of this `user_id` reference is to ensure that upon the next user identify, a pending push action processes only if the new user matches the intended target of the previous push. This avoids a hopefully rare edge case where the push that was tapped was intended for another user than the next authenticated user, and the deeplink/flow is no longer valid and should not execute.