### PR TITLE
Protect against missing intent extras

### DIFF
--- a/appcues/src/main/java/com/appcues/ui/InAppReviewActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/InAppReviewActivity.kt
@@ -86,10 +86,11 @@ internal class InAppReviewActivity : AppCompatActivity() {
                     requestCompletion.await()
                 }
             } catch (e: TimeoutCancellationException) {
-                val scope = Bootstrap.get(intent.getStringExtra(EXTRA_SCOPE_ID)!!)
-
-                scope?.get<Logcues>()?.run {
-                    info("In-App Review not available for this application")
+                val scopeId = intent.getStringExtra(EXTRA_SCOPE_ID)
+                if (scopeId != null) {
+                    Bootstrap.get(scopeId)?.get<Logcues>()?.run {
+                        info("In-App Review not available for this application")
+                    }
                 }
 
                 finish()

--- a/appcues/src/main/java/com/appcues/ui/RequestPermissionActivity.kt
+++ b/appcues/src/main/java/com/appcues/ui/RequestPermissionActivity.kt
@@ -38,7 +38,15 @@ internal class RequestPermissionActivity : AppCompatActivity() {
             }
     }
 
-    private val permissionKey by lazy { intent.getStringExtra(EXTRA_PERMISSION_KEY)!! }
+    private val permissionKey by lazy {
+        intent.getStringExtra(EXTRA_PERMISSION_KEY) ?: run {
+            // If we don't have a permission key, complete with false and finish
+            // This could happen if the Activity was terminated and recreated for some reason
+            completion?.complete(false)
+            finish()
+            ""
+        }
+    }
 
     private val permissionLauncher = registerForActivityResult(RequestPermission()) {
         completion?.complete(it)


### PR DESCRIPTION
I believe this should improve the issue noted in #664 -  by removing the `!!` not-null assertion and safely checking the extra values.

These values could be null in some edge cases when a device has killed a process and then an Activity tries to re-create, potentially. I think this could lead to the observed intermittent crash issue related to these Activities for requesting a permission or app review. Now they will gracefully close in this scenario and can be retried at a later time.