### PR TITLE
Add randomize option for select surveys

### DIFF
--- a/appcues/src/main/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapper.kt
+++ b/appcues/src/main/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapper.kt
@@ -40,7 +40,8 @@ internal fun OptionSelectPrimitiveResponse.mapOptionSelectPrimitive(): OptionSel
         unselectedColor = unselectedColor?.mapComponentColor(),
         accentColor = accentColor?.mapComponentColor(),
         attributeName = attributeName,
-        leadingFill = leadingFill ?: false
+        leadingFill = leadingFill ?: false,
+        randomizeOptionOrder = randomizeOptionOrder ?: false
     )
 }
 

--- a/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
+++ b/appcues/src/main/java/com/appcues/data/model/ExperiencePrimitive.kt
@@ -160,6 +160,7 @@ internal sealed class ExperiencePrimitive(
         val accentColor: ComponentColor? = null,
         val attributeName: String? = null,
         val leadingFill: Boolean = false,
+        val randomizeOptionOrder: Boolean = false,
     ) : ExperiencePrimitive(id, style) {
 
         data class OptionItem(

--- a/appcues/src/main/java/com/appcues/data/remote/appcues/response/step/primitive/PrimitiveResponse.kt
+++ b/appcues/src/main/java/com/appcues/data/remote/appcues/response/step/primitive/PrimitiveResponse.kt
@@ -93,7 +93,8 @@ internal sealed class PrimitiveResponse {
         val unselectedColor: StyleColorResponse?,
         val accentColor: StyleColorResponse?,
         val attributeName: String?,
-        val leadingFill: Boolean?
+        val leadingFill: Boolean?,
+        val randomizeOptionOrder: Boolean?
     ) : PrimitiveResponse() {
 
         data class OptionItem(

--- a/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
+++ b/appcues/src/main/java/com/appcues/ui/primitive/OptionSelectPrimitive.kt
@@ -94,10 +94,11 @@ private fun OptionSelectPrimitive.ComposeOptions(
     showError: Boolean,
 ) {
     val errorTint = if (showError) errorLabel?.style?.foregroundColor?.getColor(isSystemInDarkTheme()) else null
+    val displayOptions = formState.getOptions(this@ComposeOptions)
 
     when {
         selectMode == SINGLE && displayFormat == PICKER -> {
-            options.ComposePicker(
+            displayOptions.ComposePicker(
                 selectedValues = formState.getValue(this@ComposeOptions),
                 modifier = Modifier.styleBorder(pickerStyle ?: ComponentStyle(), isSystemInDarkTheme()),
                 placeholder = placeholder,
@@ -107,7 +108,7 @@ private fun OptionSelectPrimitive.ComposeOptions(
             }
         }
         selectMode == SINGLE && displayFormat == NPS -> {
-            options.ComposeNPS(
+            displayOptions.ComposeNPS(
                 selectedValues = formState.getValue(this@ComposeOptions)
             ) {
                 formState.setValue(this@ComposeOptions, it)
@@ -115,7 +116,7 @@ private fun OptionSelectPrimitive.ComposeOptions(
         }
         displayFormat == HORIZONTAL_LIST -> {
             Row(verticalAlignment = controlPosition.getVerticalAlignment() ?: Alignment.CenterVertically) {
-                options.ComposeSelections(
+                displayOptions.ComposeSelections(
                     selectedValues = formState.getValue(this@ComposeOptions),
                     selectMode = selectMode,
                     controlPosition = controlPosition,
@@ -129,7 +130,7 @@ private fun OptionSelectPrimitive.ComposeOptions(
         }
         else -> { // VERTICAL_LIST case or a fallback (i.e. a PICKER but with multi-select, invalid)
             Column(horizontalAlignment = controlPosition.getHorizontalAlignment() ?: Alignment.CenterHorizontally) {
-                options.ComposeSelections(
+                displayOptions.ComposeSelections(
                     selectedValues = formState.getValue(this@ComposeOptions),
                     selectMode = selectMode,
                     controlPosition = controlPosition,

--- a/appcues/src/test/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapperTest.kt
+++ b/appcues/src/test/java/com/appcues/data/mapper/step/primitives/OptionSelectPrimitiveMapperTest.kt
@@ -35,6 +35,7 @@ internal class OptionSelectPrimitiveMapperTest {
             accentColor = null,
             attributeName = null,
             leadingFill = null,
+            randomizeOptionOrder = null,
         )
 
         // WHEN
@@ -71,6 +72,7 @@ internal class OptionSelectPrimitiveMapperTest {
             accentColor = null,
             attributeName = null,
             leadingFill = null,
+            randomizeOptionOrder = null,
         )
 
         // WHEN


### PR DESCRIPTION
Randomize survey options if `randomizeOptionOrder == true`. We store the randomized order in the `ExperienceStepFormState` because 1) we want the order to remain the same even if you navigate from one step group to another and back, and 2) we want to access the order to include in analytics.