### PR TITLE
Add compose activity to sample app

### DIFF
--- a/samples/kotlin-android-app/build.gradle
+++ b/samples/kotlin-android-app/build.gradle
@@ -51,6 +51,11 @@ android {
     buildFeatures {
         buildConfig true
         viewBinding true
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.4.8"
     }
 }
 
@@ -68,6 +73,14 @@ dependencies {
     implementation("androidx.media3:media3-exoplayer:1.4.1")
     implementation("androidx.media3:media3-exoplayer-hls:1.4.1")
     implementation("androidx.media3:media3-ui:1.4.1")
+
+    // Jetpack Compose BOM
+    // https://developer.android.com/develop/ui/compose/bom/bom-mapping
+    implementation platform('androidx.compose:compose-bom:2025.09.00') // Compose 1.9.1
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.activity:activity-compose:1.10.1'
 }
 
 tasks.register('versionTxt') {

--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -76,6 +76,10 @@
                     android:scheme="appcues-example" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".compose.ComposeActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Appcues" />
 
         <service
             android:name="com.appcues.AppcuesFirebaseMessagingService"

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/compose/ComposeActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/compose/ComposeActivity.kt
@@ -1,0 +1,26 @@
+package com.appcues.samples.kotlin.compose
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import com.appcues.samples.kotlin.compose.ui.theme.AppcuesComposeTheme
+
+class ComposeActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppcuesComposeTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    ComposeFragment()
+                }
+            }
+        }
+    }
+}

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/compose/ComposeFragment.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/compose/ComposeFragment.kt
@@ -1,0 +1,63 @@
+package com.appcues.samples.kotlin.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.appcues.samples.kotlin.ExampleApplication
+
+@Composable
+fun ComposeFragment() {
+    val appcues = ExampleApplication.appcues
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Welcome to Compose!",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            fontSize = 24.sp
+        )
+        
+        Text(
+            text = "This is a Jetpack Compose fragment",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(top = 16.dp)
+        )
+
+        Button(
+            onClick = {
+                appcues.track("event1")
+            },
+            modifier = Modifier.padding(top = 32.dp)
+        ) {
+            Text("Trigger Event 1")
+        }
+
+        Button(
+            onClick = {
+                // Finish the activity to go back to the main activity
+                (context as? androidx.activity.ComponentActivity)?.finish()
+            },
+            modifier = Modifier.padding(top = 16.dp)
+        ) {
+            Text("Back to Main")
+        }
+    }
+}

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/compose/ui/theme/Theme.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/compose/ui/theme/Theme.kt
@@ -1,0 +1,40 @@
+package com.appcues.samples.kotlin.compose.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+@Suppress("MagicNumber")
+private val DarkColorScheme = darkColorScheme(
+    primary = Color(0xFF5C5CFF),
+    secondary = Color(0xFF2CB4FF),
+    tertiary = Color(0xFFFF5290)
+)
+
+@Suppress("MagicNumber")
+private val LightColorScheme = lightColorScheme(
+    primary = Color(0xFF5C5CFF),
+    secondary = Color(0xFF2CB4FF),
+    tertiary = Color(0xFFFF5290)
+)
+
+@Composable
+fun AppcuesComposeTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (darkTheme) {
+        DarkColorScheme
+    } else {
+        LightColorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = MaterialTheme.typography,
+        content = content
+    )
+}

--- a/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/EventsFragment.kt
+++ b/samples/kotlin-android-app/src/main/java/com/appcues/samples/kotlin/main/EventsFragment.kt
@@ -1,5 +1,6 @@
 package com.appcues.samples.kotlin.main
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -16,6 +17,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import com.appcues.samples.kotlin.ExampleApplication
 import com.appcues.samples.kotlin.R
+import com.appcues.samples.kotlin.compose.ComposeActivity
 import com.appcues.samples.kotlin.databinding.FragmentEventsBinding
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -53,6 +55,11 @@ class EventsFragment : Fragment() {
             requireActivity()
                 .findNavController(R.id.nav_host_fragment_activity_example)
                 .navigate(R.id.action_from_events_to_recycler_view)
+        }
+
+        binding.composeButton.setOnClickListener {
+            val intent = Intent(requireContext(), ComposeActivity::class.java)
+            startActivity(intent)
         }
 
         return binding.root

--- a/samples/kotlin-android-app/src/main/res/layout/fragment_events.xml
+++ b/samples/kotlin-android-app/src/main/res/layout/fragment_events.xml
@@ -63,4 +63,18 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonEvent3" />
 
+    <Button
+        android:id="@+id/composeButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="24dp"
+        android:contentDescription="@string/content_description_show_compose"
+        android:tag="btnCompose"
+        android:text="@string/show_compose_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/recyclerViewButton" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/samples/kotlin-android-app/src/main/res/values/strings.xml
+++ b/samples/kotlin-android-app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="trigger_event_2_button">Trigger Event 2</string>
     <string name="trigger_event_3_button">Trigger Event 3</string>
     <string name="show_recycler_view_button">Show RecyclerView</string>
+    <string name="show_compose_button">Show Compose</string>
     <string name="launch_modal_button">Launch Modal</string>
     <string name="given_name_label">Given Name</string>
     <string name="family_name_label">Family Name</string>
@@ -31,6 +32,7 @@
     <string name="content_description_event_2">Trigger Event 2</string>
     <string name="content_description_event_3">Trigger Event 3</string>
     <string name="content_description_show_recycler_view">Show RecyclerView</string>
+    <string name="content_description_show_compose">Show Compose</string>
     <string name="content_description_save_profile">Save Profile</string>
     <string name="content_description_save_group">Save Group</string>
     <string name="content_description_tab_events">Events Tab</string>


### PR DESCRIPTION
Creates a very basic compose view in the sample app to make testing compose version compatibility easier.

<img width="270" height="606" alt="Screenshot_20250916_150713" src="https://github.com/user-attachments/assets/8e729d5a-5fcd-4360-9462-b8e9c66790dc" />
