### PR TITLE
Fix the safe area padding used in modal layout calculations

### DIFF
--- a/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
+++ b/appcues/src/debug/java/com/appcues/CompositionTestHelper.kt
@@ -282,7 +282,8 @@ internal fun testWindowInfo(): AppcuesWindowInfo {
 
     // For tests, use the LocalConfiguration.current to derive the available content size and insets.
     // This supports a snapshot testing environment where there is not a container/overlay view in use.
-    val insetsDp = WindowInsets.safeDrawing.asPaddingValues()
+    val safeInsets = WindowInsets.safeDrawing
+    val insetsDp = safeInsets.asPaddingValues()
 
     val size = Size(
         width = configuration.screenWidthDp.toFloat(),
@@ -330,6 +331,7 @@ internal fun testWindowInfo(): AppcuesWindowInfo {
         screenWidthType = screenWidthType,
         screenHeightType = screenHeightType,
         safeRect = safeRect,
+        safeInsets = safeInsets,
         orientation = orientation,
         deviceType = deviceType,
     )

--- a/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
+++ b/appcues/src/main/java/com/appcues/ui/composables/AppcuesComposition.kt
@@ -5,6 +5,7 @@ import android.webkit.WebChromeClient
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -16,6 +17,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -210,6 +212,14 @@ internal fun getWindowInfo(): AppcuesWindowInfo {
             width = view.width.toDp().toFloat(),
             height = view.height.toDp().toFloat()
         )
+
+        val safeInsets = WindowInsets(
+            left = insetsDp.left.dp,
+            top = insetsDp.top.dp,
+            right = insetsDp.right.dp,
+            bottom = insetsDp.bottom.dp
+        )
+
         val safeRect = Rect(
             left = insetsDp.left.toFloat(),
             top = insetsDp.top.toFloat(),
@@ -251,6 +261,7 @@ internal fun getWindowInfo(): AppcuesWindowInfo {
             screenWidthType = screenWidthType,
             screenHeightType = screenHeightType,
             safeRect = safeRect,
+            safeInsets = safeInsets,
             orientation = orientation,
             deviceType = deviceType,
         )

--- a/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/BottomSheetModal.kt
@@ -9,7 +9,6 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -17,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -63,7 +61,8 @@ internal fun BottomSheetModal(
         val enterAnimation = enterTransitionDerivedOf(appcuesWindowInfo)
         val exitAnimation = exitTransitionDerivedOf(appcuesWindowInfo)
         val isDark = isSystemInDarkTheme()
-        val safeAreaInsets = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal.plus(WindowInsetsSides.Bottom)).asPaddingValues()
+        val safeAreaInsets = appcuesWindowInfo.safeInsets
+            .only(WindowInsetsSides.Horizontal.plus(WindowInsetsSides.Bottom)).asPaddingValues()
 
         Box(
             modifier = Modifier

--- a/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/DialogModal.kt
@@ -13,14 +13,12 @@ import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
@@ -100,7 +98,7 @@ internal fun DialogModal(
     val density = LocalDensity.current
     val dismissalDelegate = LocalAppcuesDismissalDelegate.current
     val contentCanDismiss = dismissalDelegate.canDismiss
-    val safeAreaInsets = WindowInsets.systemBars.asPaddingValues()
+    val safeAreaInsets = windowInfo.safeInsets.asPaddingValues()
 
     val maxWidth = maxWidthDerivedOf(windowInfo)
     val maxHeight = maxHeightDerivedOf(windowInfo)

--- a/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/ExpandedBottomSheetModal.kt
@@ -9,7 +9,6 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -17,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -62,8 +60,8 @@ internal fun ExpandedBottomSheetModal(
         val enterAnimation = enterTransitionDerivedOf(windowInfo)
         val exitAnimation = exitTransitionDerivedOf(windowInfo)
         val isDark = isSystemInDarkTheme()
-        val topSafeAreaInsets = WindowInsets.systemBars.only(WindowInsetsSides.Top).asPaddingValues()
-        val safeAreaInsets = WindowInsets.systemBars
+        val topSafeAreaInsets = windowInfo.safeInsets.only(WindowInsetsSides.Top).asPaddingValues()
+        val safeAreaInsets = windowInfo.safeInsets
             .only(WindowInsetsSides.Horizontal.plus(WindowInsetsSides.Bottom))
             .asPaddingValues()
 

--- a/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
+++ b/appcues/src/main/java/com/appcues/ui/modal/FullScreenModal.kt
@@ -13,12 +13,10 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -62,7 +60,7 @@ internal fun FullScreenModal(
         val enterAnimation = enterTransitionDerivedOf(windowInfo)
         val exitAnimation = exitTransitionDerivedOf(windowInfo)
         val isDark = isSystemInDarkTheme()
-        val safeAreaInsets = WindowInsets.systemBars.asPaddingValues()
+        val safeAreaInsets = windowInfo.safeInsets.asPaddingValues()
 
         Box(
             modifier = Modifier.fillMaxSize(),

--- a/appcues/src/main/java/com/appcues/ui/utils/AppcuesWindowInfo.kt
+++ b/appcues/src/main/java/com/appcues/ui/utils/AppcuesWindowInfo.kt
@@ -1,11 +1,13 @@
 package com.appcues.ui.utils
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.ui.geometry.Rect
 
 internal data class AppcuesWindowInfo(
     val screenWidthType: ScreenType,
     val screenHeightType: ScreenType,
     val safeRect: Rect,
+    val safeInsets: WindowInsets,
     val orientation: Orientation,
     val deviceType: DeviceType,
 ) {


### PR DESCRIPTION
The update here is to use the insets calculated from the root view in `AppcuesWindowInfo` for the safe area insets, rather than use the `WindowInsets.systemBars` inside compositions. This is because that inset value does not always include the actual system bar values on apps not configured for edge-to-edge on older API versions. I believe this will make all the recent changes fully back compat.